### PR TITLE
[feat] 공통 컴포넌트 1차 구현 및 프리뷰 페이지 추가

### DIFF
--- a/src/components/common/BaseButton.vue
+++ b/src/components/common/BaseButton.vue
@@ -1,11 +1,58 @@
 <script setup>
+import { computed } from 'vue'
 
+const props = defineProps({
+  variant: {
+    type: String,
+    default: 'primary',
+  },
+  size: {
+    type: String,
+    default: 'md',
+  },
+  type: {
+    type: String,
+    default: 'button',
+  },
+  disabled: {
+    type: Boolean,
+    default: false,
+  },
+  block: {
+    type: Boolean,
+    default: false,
+  },
+})
+
+const variantClasses = {
+  primary: 'border-brand bg-brand text-white hover:bg-teal-700 focus-visible:ring-brand/30',
+  secondary: 'border-slate-200 bg-white text-slate-700 hover:bg-slate-50 focus-visible:ring-slate-300',
+  ghost: 'border-transparent bg-slate-100/70 text-slate-700 hover:bg-slate-200/80 focus-visible:ring-slate-300',
+  danger: 'border-red-200 bg-red-50 text-red-700 hover:bg-red-100 focus-visible:ring-red-200',
+}
+
+const sizeClasses = {
+  sm: 'h-9 px-3 text-sm',
+  md: 'h-11 px-4 text-sm',
+  lg: 'h-12 px-5 text-base',
+}
+
+const buttonClasses = computed(() => [
+  'inline-flex items-center justify-center gap-2 rounded-2xl border font-medium transition duration-200 focus-visible:outline-none focus-visible:ring-4 disabled:cursor-not-allowed disabled:border-slate-200 disabled:bg-slate-100 disabled:text-slate-400',
+  variantClasses[props.variant] || variantClasses.primary,
+  sizeClasses[props.size] || sizeClasses.md,
+  props.block ? 'w-full' : '',
+].join(' '))
 </script>
 
 <template>
-
+  <button
+    :type="type"
+    :disabled="disabled"
+    :class="buttonClasses"
+  >
+    <slot name="leading" />
+    <slot />
+    <slot name="trailing" />
+  </button>
 </template>
-
-<style scoped>
-
-</style>

--- a/src/components/common/BaseModal.vue
+++ b/src/components/common/BaseModal.vue
@@ -1,11 +1,80 @@
 <script setup>
+const props = defineProps({
+  open: {
+    type: Boolean,
+    default: false,
+  },
+  title: {
+    type: String,
+    default: '',
+  },
+  description: {
+    type: String,
+    default: '',
+  },
+  width: {
+    type: String,
+    default: 'max-w-2xl',
+  },
+  closeOnBackdrop: {
+    type: Boolean,
+    default: true,
+  },
+})
 
+const emit = defineEmits(['close'])
+
+function closeModal() {
+  emit('close')
+}
+
+function handleBackdropClick() {
+  if (props.closeOnBackdrop) {
+    closeModal()
+  }
+}
 </script>
 
 <template>
+  <teleport to="body">
+    <div
+      v-if="open"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/50 px-4 py-8 backdrop-blur-sm"
+      @click.self="handleBackdropClick"
+    >
+      <div
+        class="w-full rounded-[28px] border border-white/70 bg-white p-6 shadow-panel"
+        :class="width"
+      >
+        <div class="flex items-start justify-between gap-4">
+          <div>
+            <h2 class="text-xl font-semibold text-ink">{{ title }}</h2>
+            <p v-if="description" class="mt-1 text-sm text-slate-500">{{ description }}</p>
+          </div>
+          <button
+            type="button"
+            class="rounded-full p-2 text-slate-400 transition hover:bg-slate-100 hover:text-slate-600"
+            @click="closeModal"
+          >
+            <span class="sr-only">닫기</span>
+            <svg class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+              <path
+                fill-rule="evenodd"
+                d="M4.47 4.47a.75.75 0 0 1 1.06 0L10 8.94l4.47-4.47a.75.75 0 1 1 1.06 1.06L11.06 10l4.47 4.47a.75.75 0 0 1-1.06 1.06L10 11.06l-4.47 4.47a.75.75 0 1 1-1.06-1.06L8.94 10 4.47 5.53a.75.75 0 0 1 0-1.06Z"
+                clip-rule="evenodd"
+              />
+            </svg>
+          </button>
+        </div>
 
+        <div class="mt-6">
+          <slot />
+        </div>
+
+        <div v-if="$slots.footer" class="mt-6 flex justify-end gap-3">
+          <slot name="footer" />
+        </div>
+      </div>
+    </div>
+  </teleport>
 </template>
-
-<style scoped>
-
-</style>

--- a/src/components/common/BaseSelect.vue
+++ b/src/components/common/BaseSelect.vue
@@ -1,11 +1,81 @@
 <script setup>
+import { computed } from 'vue'
 
+const props = defineProps({
+  modelValue: {
+    type: [String, Number],
+    default: '',
+  },
+  options: {
+    type: Array,
+    default: () => [],
+  },
+  placeholder: {
+    type: String,
+    default: '선택하세요',
+  },
+  disabled: {
+    type: Boolean,
+    default: false,
+  },
+  name: {
+    type: String,
+    default: '',
+  },
+  id: {
+    type: String,
+    default: '',
+  },
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+const fieldValue = computed({
+  get: () => props.modelValue,
+  set: (value) => emit('update:modelValue', value),
+})
+
+function normalizeOption(option) {
+  if (typeof option === 'object' && option !== null) {
+    return {
+      label: option.label ?? option.name ?? String(option.value ?? ''),
+      value: option.value ?? '',
+    }
+  }
+
+  return {
+    label: String(option),
+    value: option,
+  }
+}
 </script>
 
 <template>
-
+  <div class="relative">
+    <select
+      :id="id"
+      v-model="fieldValue"
+      :name="name"
+      :disabled="disabled"
+      class="h-11 w-full appearance-none rounded-2xl border border-white/70 bg-white/90 px-4 pr-10 text-sm text-ink shadow-sm transition duration-200 focus:border-brand focus:outline-none focus:ring-4 focus:ring-brand/15 disabled:cursor-not-allowed disabled:bg-slate-100 disabled:text-slate-400"
+    >
+      <option value="" disabled>{{ placeholder }}</option>
+      <option
+        v-for="option in options"
+        :key="normalizeOption(option).value"
+        :value="normalizeOption(option).value"
+      >
+        {{ normalizeOption(option).label }}
+      </option>
+    </select>
+    <span class="pointer-events-none absolute inset-y-0 right-4 flex items-center text-slate-400">
+      <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+        <path
+          fill-rule="evenodd"
+          d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.168l3.71-3.938a.75.75 0 1 1 1.08 1.04l-4.25 4.5a.75.75 0 0 1-1.08 0l-4.25-4.5a.75.75 0 0 1 .02-1.06Z"
+          clip-rule="evenodd"
+        />
+      </svg>
+    </span>
+  </div>
 </template>
-
-<style scoped>
-
-</style>

--- a/src/components/common/BaseTable.vue
+++ b/src/components/common/BaseTable.vue
@@ -1,11 +1,92 @@
 <script setup>
+defineProps({
+  columns: {
+    type: Array,
+    default: () => [],
+  },
+  rows: {
+    type: Array,
+    default: () => [],
+  },
+  rowKey: {
+    type: String,
+    default: 'id',
+  },
+  emptyText: {
+    type: String,
+    default: '데이터가 없습니다.',
+  },
+})
 
+function normalizeColumn(column) {
+  if (typeof column === 'string') {
+    return {
+      key: column,
+      label: column,
+      align: 'left',
+    }
+  }
+
+  return {
+    key: column.key,
+    label: column.label ?? column.key,
+    align: column.align ?? 'left',
+    width: column.width ?? '',
+  }
+}
+
+function getCellValue(row, key) {
+  return row?.[key]
+}
 </script>
 
 <template>
-
+  <div class="overflow-hidden rounded-3xl border border-white/70 bg-white/85 shadow-panel backdrop-blur">
+    <div class="overflow-x-auto">
+      <table class="min-w-full divide-y divide-slate-100">
+        <thead class="bg-slate-50/80">
+          <tr>
+            <th
+              v-for="column in columns"
+              :key="normalizeColumn(column).key"
+              scope="col"
+              class="px-5 py-4 text-sm font-semibold text-slate-600"
+              :class="normalizeColumn(column).align === 'right' ? 'text-right' : 'text-left'"
+              :style="{ width: normalizeColumn(column).width }"
+            >
+              {{ normalizeColumn(column).label }}
+            </th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-slate-100 bg-white">
+          <tr v-if="rows.length === 0">
+            <td :colspan="columns.length || 1" class="px-5 py-10 text-center text-sm text-slate-400">
+              {{ emptyText }}
+            </td>
+          </tr>
+          <tr
+            v-for="row in rows"
+            v-else
+            :key="row?.[rowKey] ?? JSON.stringify(row)"
+            class="transition hover:bg-slate-50/70"
+          >
+            <td
+              v-for="column in columns"
+              :key="normalizeColumn(column).key"
+              class="px-5 py-4 text-sm text-slate-700"
+              :class="normalizeColumn(column).align === 'right' ? 'text-right' : 'text-left'"
+            >
+              <slot
+                :name="`cell-${normalizeColumn(column).key}`"
+                :row="row"
+                :value="getCellValue(row, normalizeColumn(column).key)"
+              >
+                {{ getCellValue(row, normalizeColumn(column).key) ?? '-' }}
+              </slot>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
 </template>
-
-<style scoped>
-
-</style>

--- a/src/components/common/BaseTextField.vue
+++ b/src/components/common/BaseTextField.vue
@@ -1,11 +1,59 @@
 <script setup>
+import { computed } from 'vue'
 
+const props = defineProps({
+  modelValue: {
+    type: [String, Number],
+    default: '',
+  },
+  type: {
+    type: String,
+    default: 'text',
+  },
+  placeholder: {
+    type: String,
+    default: '',
+  },
+  disabled: {
+    type: Boolean,
+    default: false,
+  },
+  readonly: {
+    type: Boolean,
+    default: false,
+  },
+  name: {
+    type: String,
+    default: '',
+  },
+  id: {
+    type: String,
+    default: '',
+  },
+  autocomplete: {
+    type: String,
+    default: 'off',
+  },
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+const fieldValue = computed({
+  get: () => props.modelValue,
+  set: (value) => emit('update:modelValue', value),
+})
 </script>
 
 <template>
-
+  <input
+    :id="id"
+    v-model="fieldValue"
+    :name="name"
+    :type="type"
+    :placeholder="placeholder"
+    :disabled="disabled"
+    :readonly="readonly"
+    :autocomplete="autocomplete"
+    class="h-11 w-full rounded-2xl border border-white/70 bg-white/90 px-4 text-sm text-ink shadow-sm transition duration-200 placeholder:text-slate-400 focus:border-brand focus:outline-none focus:ring-4 focus:ring-brand/15 disabled:cursor-not-allowed disabled:bg-slate-100 disabled:text-slate-400"
+  />
 </template>
-
-<style scoped>
-
-</style>

--- a/src/components/common/BaseTextarea.vue
+++ b/src/components/common/BaseTextarea.vue
@@ -1,11 +1,57 @@
 <script setup>
+import { computed } from 'vue'
 
+const props = defineProps({
+  modelValue: {
+    type: String,
+    default: '',
+  },
+  placeholder: {
+    type: String,
+    default: '',
+  },
+  rows: {
+    type: Number,
+    default: 5,
+  },
+  disabled: {
+    type: Boolean,
+    default: false,
+  },
+  readonly: {
+    type: Boolean,
+    default: false,
+  },
+  resize: {
+    type: String,
+    default: 'vertical',
+  },
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+const fieldValue = computed({
+  get: () => props.modelValue,
+  set: (value) => emit('update:modelValue', value),
+})
+
+const resizeClassMap = {
+  none: 'resize-none',
+  vertical: 'resize-y',
+  both: 'resize',
+}
 </script>
 
 <template>
-
+  <textarea
+    v-model="fieldValue"
+    :rows="rows"
+    :placeholder="placeholder"
+    :disabled="disabled"
+    :readonly="readonly"
+    :class="[
+      'w-full rounded-2xl border border-white/70 bg-white/90 px-4 py-3 text-sm text-ink shadow-sm transition duration-200 placeholder:text-slate-400 focus:border-brand focus:outline-none focus:ring-4 focus:ring-brand/15 disabled:cursor-not-allowed disabled:bg-slate-100 disabled:text-slate-400',
+      resizeClassMap[resize] || resizeClassMap.vertical,
+    ]"
+  />
 </template>
-
-<style scoped>
-
-</style>

--- a/src/components/common/InfoField.vue
+++ b/src/components/common/InfoField.vue
@@ -1,11 +1,31 @@
 <script setup>
-
+defineProps({
+  label: {
+    type: String,
+    required: true,
+  },
+  value: {
+    type: [String, Number],
+    default: '',
+  },
+  stacked: {
+    type: Boolean,
+    default: false,
+  },
+  emptyText: {
+    type: String,
+    default: '-',
+  },
+})
 </script>
 
 <template>
-
+  <div :class="stacked ? 'space-y-1.5' : 'flex items-start justify-between gap-4'">
+    <p class="shrink-0 text-sm font-medium text-slate-500">{{ label }}</p>
+    <div class="min-w-0 text-sm text-ink" :class="stacked ? '' : 'text-right'">
+      <slot>
+        {{ value || emptyText }}
+      </slot>
+    </div>
+  </div>
 </template>
-
-<style scoped>
-
-</style>

--- a/src/components/common/SearchInput.vue
+++ b/src/components/common/SearchInput.vue
@@ -1,11 +1,73 @@
 <script setup>
+import { computed } from 'vue'
 
+const props = defineProps({
+  modelValue: {
+    type: String,
+    default: '',
+  },
+  placeholder: {
+    type: String,
+    default: '검색어를 입력하세요',
+  },
+  disabled: {
+    type: Boolean,
+    default: false,
+  },
+  clearable: {
+    type: Boolean,
+    default: true,
+  },
+})
+
+const emit = defineEmits(['update:modelValue', 'search'])
+
+const fieldValue = computed({
+  get: () => props.modelValue,
+  set: (value) => emit('update:modelValue', value),
+})
+
+function handleSearch() {
+  emit('search', fieldValue.value)
+}
+
+function clearInput() {
+  emit('update:modelValue', '')
+  emit('search', '')
+}
 </script>
 
 <template>
-
+  <div class="flex items-center gap-2 rounded-2xl border border-white/70 bg-white/90 px-4 shadow-sm transition duration-200 focus-within:border-brand focus-within:ring-4 focus-within:ring-brand/15">
+    <svg class="h-4 w-4 shrink-0 text-slate-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+      <path
+        fill-rule="evenodd"
+        d="M9 3.5a5.5 5.5 0 1 0 3.473 9.766l3.63 3.63a.75.75 0 1 0 1.06-1.06l-3.63-3.63A5.5 5.5 0 0 0 9 3.5ZM5 9a4 4 0 1 1 8 0 4 4 0 0 1-8 0Z"
+        clip-rule="evenodd"
+      />
+    </svg>
+    <input
+      v-model="fieldValue"
+      :placeholder="placeholder"
+      :disabled="disabled"
+      class="h-11 min-w-0 flex-1 bg-transparent text-sm text-ink placeholder:text-slate-400 focus:outline-none disabled:cursor-not-allowed disabled:text-slate-400"
+      @keydown.enter.prevent="handleSearch"
+    />
+    <button
+      v-if="clearable && fieldValue"
+      type="button"
+      class="text-xs font-medium text-slate-400 transition hover:text-slate-600"
+      @click="clearInput"
+    >
+      초기화
+    </button>
+    <button
+      type="button"
+      class="rounded-xl bg-brand px-3 py-2 text-xs font-semibold text-white transition hover:bg-teal-700 disabled:cursor-not-allowed disabled:bg-slate-300"
+      :disabled="disabled"
+      @click="handleSearch"
+    >
+      검색
+    </button>
+  </div>
 </template>
-
-<style scoped>
-
-</style>

--- a/src/components/common/StatusBadge.vue
+++ b/src/components/common/StatusBadge.vue
@@ -1,11 +1,55 @@
 <script setup>
+import { computed } from 'vue'
 
+const props = defineProps({
+  value: {
+    type: String,
+    default: '',
+  },
+  variant: {
+    type: String,
+    default: '',
+  },
+})
+
+const statusMap = {
+  active: 'border-emerald-200 bg-emerald-50 text-emerald-700',
+  활성: 'border-emerald-200 bg-emerald-50 text-emerald-700',
+  confirmed: 'border-teal-200 bg-teal-50 text-teal-700',
+  확정: 'border-teal-200 bg-teal-50 text-teal-700',
+  sent: 'border-sky-200 bg-sky-50 text-sky-700',
+  발송: 'border-sky-200 bg-sky-50 text-sky-700',
+  draft: 'border-slate-200 bg-slate-100 text-slate-700',
+  초안: 'border-slate-200 bg-slate-100 text-slate-700',
+  inactive: 'border-slate-200 bg-slate-100 text-slate-500',
+  비활성: 'border-slate-200 bg-slate-100 text-slate-500',
+  ready: 'border-amber-200 bg-amber-50 text-amber-700',
+  준비중: 'border-amber-200 bg-amber-50 text-amber-700',
+  준비완료: 'border-amber-200 bg-amber-50 text-amber-700',
+  in_progress: 'border-violet-200 bg-violet-50 text-violet-700',
+  생산중: 'border-violet-200 bg-violet-50 text-violet-700',
+  partial: 'border-orange-200 bg-orange-50 text-orange-700',
+  부분수금: 'border-orange-200 bg-orange-50 text-orange-700',
+  unpaid: 'border-rose-200 bg-rose-50 text-rose-700',
+  미수금: 'border-rose-200 bg-rose-50 text-rose-700',
+  paid: 'border-emerald-200 bg-emerald-50 text-emerald-700',
+  완납: 'border-emerald-200 bg-emerald-50 text-emerald-700',
+  completed: 'border-brand/20 bg-brand/10 text-brand',
+  완료: 'border-brand/20 bg-brand/10 text-brand',
+  출하완료: 'border-brand/20 bg-brand/10 text-brand',
+}
+
+const badgeClasses = computed(() => {
+  const key = props.variant || String(props.value).trim().toLowerCase()
+  return statusMap[key] || 'border-slate-200 bg-slate-100 text-slate-700'
+})
 </script>
 
 <template>
-
+  <span
+    class="inline-flex min-h-7 items-center rounded-full border px-2.5 py-1 text-xs font-semibold tracking-[0.02em]"
+    :class="badgeClasses"
+  >
+    <slot>{{ value }}</slot>
+  </span>
 </template>
-
-<style scoped>
-
-</style>

--- a/src/components/layout/PageTitleBar.vue
+++ b/src/components/layout/PageTitleBar.vue
@@ -1,11 +1,25 @@
 <script setup>
-
+defineProps({
+  title: {
+    type: String,
+    required: true,
+  },
+  description: {
+    type: String,
+    default: '',
+  },
+})
 </script>
 
 <template>
+  <div class="flex flex-col gap-4 rounded-[28px] border border-white/70 bg-white/85 p-5 shadow-panel backdrop-blur md:flex-row md:items-center md:justify-between">
+    <div>
+      <h1 class="text-2xl font-semibold tracking-tight text-ink">{{ title }}</h1>
+      <p v-if="description" class="mt-1 text-sm text-slate-500">{{ description }}</p>
+    </div>
 
+    <div v-if="$slots.actions" class="flex flex-wrap items-center gap-3">
+      <slot name="actions" />
+    </div>
+  </div>
 </template>
-
-<style scoped>
-
-</style>

--- a/src/data/navigation.js
+++ b/src/data/navigation.js
@@ -1,5 +1,6 @@
 export const navigationItems = [
   { label: 'Dashboard', path: '/', caption: '공통' },
+  { label: 'Common Preview', path: '/common-preview', caption: '공통 UI 테스트' },
   { label: 'Auth', path: '/auth', caption: '인증/권한' },
   { label: 'Master', path: '/master', caption: '기준정보' },
   { label: 'Order', path: '/order', caption: '주문/출고' },

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import AppLayout from '@/layouts/AppLayout.vue'
+import CommonComponentsPage from '@/views/CommonComponentsPage.vue'
 import DashboardPage from '@/views/DashboardPage.vue'
 import ServicePage from '@/views/ServicePage.vue'
 
@@ -15,6 +16,16 @@ const routes = [
         meta: {
           title: 'Dashboard',
           serviceName: '공통 대시보드',
+        },
+      },
+      {
+        path: 'common-preview',
+        name: 'common-preview',
+        component: CommonComponentsPage,
+        meta: {
+          title: 'Common Preview',
+          serviceName: '공통 컴포넌트 프리뷰',
+          description: '1차 구현한 공통 컴포넌트의 동작 검증용 화면',
         },
       },
       {

--- a/src/views/CommonComponentsPage.vue
+++ b/src/views/CommonComponentsPage.vue
@@ -1,0 +1,171 @@
+<script setup>
+import { reactive, ref } from 'vue'
+import BaseButton from '@/components/common/BaseButton.vue'
+import BaseCard from '@/components/common/BaseCard.vue'
+import BaseModal from '@/components/common/BaseModal.vue'
+import BaseSelect from '@/components/common/BaseSelect.vue'
+import BaseTable from '@/components/common/BaseTable.vue'
+import BaseTextField from '@/components/common/BaseTextField.vue'
+import BaseTextarea from '@/components/common/BaseTextarea.vue'
+import InfoField from '@/components/common/InfoField.vue'
+import SearchInput from '@/components/common/SearchInput.vue'
+import StatusBadge from '@/components/common/StatusBadge.vue'
+import PageTitleBar from '@/components/layout/PageTitleBar.vue'
+
+const form = reactive({
+  name: '김영업',
+  email: 'kim@salesboost.com',
+  department: 'sales',
+  note: '초도 거래처 미팅 이후 후속 견적 전달 예정',
+  search: '',
+})
+
+const isModalOpen = ref(false)
+
+const departmentOptions = [
+  { label: '영업1팀', value: 'sales' },
+  { label: '생산팀', value: 'production' },
+  { label: '출하팀', value: 'shipping' },
+  { label: '경영지원', value: 'support' },
+]
+
+const tableColumns = [
+  { key: 'name', label: '화면' },
+  { key: 'owner', label: '담당' },
+  { key: 'status', label: '상태' },
+  { key: 'action', label: '작업', align: 'right' },
+]
+
+const tableRows = [
+  { id: 1, name: '거래처 목록', owner: '영업', status: '활성' },
+  { id: 2, name: 'PI 상세', owner: '문서', status: '확정' },
+  { id: 3, name: '사용자 관리', owner: '관리', status: '비활성' },
+]
+
+function handleSearch(value) {
+  form.search = value
+}
+</script>
+
+<template>
+  <div class="space-y-6">
+    <PageTitleBar
+      title="공통 컴포넌트 프리뷰"
+      description="1차 구현한 공통 컴포넌트의 기본 동작과 화면 톤을 한 번에 확인하는 테스트 페이지"
+    >
+      <template #actions>
+        <BaseButton variant="ghost">문서 보기</BaseButton>
+        <BaseButton @click="isModalOpen = true">모달 열기</BaseButton>
+      </template>
+    </PageTitleBar>
+
+    <section class="grid gap-6 xl:grid-cols-2">
+      <BaseCard title="Button" subtitle="variant, size, disabled, block 조합 확인">
+        <div class="space-y-4">
+          <div class="flex flex-wrap gap-3">
+            <BaseButton>저장</BaseButton>
+            <BaseButton variant="secondary">취소</BaseButton>
+            <BaseButton variant="ghost">인쇄</BaseButton>
+            <BaseButton variant="danger">삭제</BaseButton>
+            <BaseButton disabled>비활성</BaseButton>
+          </div>
+          <div class="flex flex-wrap gap-3">
+            <BaseButton size="sm">작은 버튼</BaseButton>
+            <BaseButton size="lg" variant="secondary">큰 버튼</BaseButton>
+          </div>
+          <BaseButton block>전체 너비 버튼</BaseButton>
+        </div>
+      </BaseCard>
+
+      <BaseCard title="StatusBadge" subtitle="상태값별 색상 매핑 확인">
+        <div class="flex flex-wrap gap-3">
+          <StatusBadge value="활성" />
+          <StatusBadge value="비활성" />
+          <StatusBadge value="확정" />
+          <StatusBadge value="발송" />
+          <StatusBadge value="생산중" />
+          <StatusBadge value="부분수금" />
+          <StatusBadge value="완료" />
+        </div>
+      </BaseCard>
+    </section>
+
+    <section class="grid gap-6 xl:grid-cols-2">
+      <BaseCard title="Input" subtitle="텍스트, 셀렉트, 텍스트에어리어, 검색 입력 테스트">
+        <div class="space-y-4">
+          <div class="space-y-2">
+            <p class="text-sm font-medium text-slate-600">이름</p>
+            <BaseTextField v-model="form.name" placeholder="이름을 입력하세요" />
+          </div>
+          <div class="space-y-2">
+            <p class="text-sm font-medium text-slate-600">이메일</p>
+            <BaseTextField v-model="form.email" type="email" placeholder="이메일을 입력하세요" />
+          </div>
+          <div class="space-y-2">
+            <p class="text-sm font-medium text-slate-600">부서</p>
+            <BaseSelect v-model="form.department" :options="departmentOptions" placeholder="부서를 선택하세요" />
+          </div>
+          <div class="space-y-2">
+            <p class="text-sm font-medium text-slate-600">비고</p>
+            <BaseTextarea v-model="form.note" placeholder="비고를 입력하세요" />
+          </div>
+          <div class="space-y-2">
+            <p class="text-sm font-medium text-slate-600">검색</p>
+            <SearchInput
+              v-model="form.search"
+              placeholder="검색어를 입력하세요"
+              @search="handleSearch"
+            />
+          </div>
+        </div>
+      </BaseCard>
+
+      <BaseCard title="InfoField" subtitle="상세 페이지에서 쓰는 라벨 + 값 표시 형식">
+        <div class="space-y-4">
+          <InfoField label="거래처" value="COOLSAY SDN BHD" />
+          <InfoField label="통화" value="USD" />
+          <InfoField label="담당자" value="김영업" />
+          <InfoField label="상태">
+            <StatusBadge value="확정" />
+          </InfoField>
+          <InfoField label="비고" stacked>
+            <p class="leading-6 text-slate-600">
+              초도 미팅 이후 바이어 요청 사항을 정리해 다음 견적에 반영합니다.
+            </p>
+          </InfoField>
+        </div>
+      </BaseCard>
+    </section>
+
+    <BaseCard title="Table" subtitle="컬럼, 데이터, 슬롯 셀 렌더링 확인">
+      <BaseTable :columns="tableColumns" :rows="tableRows" row-key="id">
+        <template #cell-status="{ value }">
+          <StatusBadge :value="value" />
+        </template>
+        <template #cell-action>
+          <div class="flex justify-end gap-2">
+            <BaseButton size="sm" variant="ghost">보기</BaseButton>
+            <BaseButton size="sm" variant="secondary">수정</BaseButton>
+          </div>
+        </template>
+      </BaseTable>
+    </BaseCard>
+
+    <BaseModal
+      :open="isModalOpen"
+      title="BaseModal 동작 확인"
+      description="열기, 닫기, footer slot, backdrop 닫힘 동작을 테스트할 수 있습니다."
+      @close="isModalOpen = false"
+    >
+      <div class="space-y-3 text-sm text-slate-600">
+        <p>현재 구현한 BaseModal의 기본 구조를 확인하는 테스트용 내용입니다.</p>
+        <p>우상단 닫기 버튼 또는 배경 클릭으로 닫히는지 확인할 수 있습니다.</p>
+      </div>
+
+      <template #footer>
+        <BaseButton variant="secondary" @click="isModalOpen = false">취소</BaseButton>
+        <BaseButton @click="isModalOpen = false">확인</BaseButton>
+      </template>
+    </BaseModal>
+  </div>
+</template>


### PR DESCRIPTION
## 📋 작업 내용

<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
SalesBoost 화면설계서 기준으로 1차 공통 컴포넌트 세트를 구현했습니다.
BaseButton, BaseTextField, BaseSelect, BaseTextarea, SearchInput, StatusBadge, InfoField, BaseTable, BaseModal, PageTitleBar를 추가하고, 기본 동작을 한 화면에서 확인할 수 있도록 `/common-preview` 테스트 페이지와 라우트를 함께 구성했습니다.


## 🔗 관련 이슈

<!-- 관련 이슈 번호를 적어주세요 (자동으로 이슈가 닫힙니다) -->
- closes #10 

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->
<img width="2670" height="1802" alt="image" src="https://github.com/user-attachments/assets/67de38a3-8082-4034-9497-d47f0c2ab791" />
<img width="2648" height="1714" alt="image" src="https://github.com/user-attachments/assets/31a87ba8-f0b9-4818-bec0-a7917318fcd5" />

## ✅ 체크리스트
- [x] 정상 동작 확인
## 💬 리뷰어에게

<!-- 리뷰할 때 중점적으로 봐줬으면 하는 부분이 있다면 적어주세요 -->

공통 컴포넌트를 1차로 구현해본 PR입니다.
나중에 화면 작업할 때 재사용(공통)으로 활용 가능한 구조인지, /common-preview에서 기본 동작 확인용으로 충분한지 편하게 봐주시면 됩니다. 
디자인 요소는 추후 변경할 예정이오니 참고 부탁드리겠습니다.
