### PR TITLE
[feat] 도메인 공통 컴포넌트 2차 구현 및 프리뷰 페이지 추가

### DIFF
--- a/db.json
+++ b/db.json
@@ -2,13 +2,14 @@
   "navigationItems": [
     { "id": 1, "label": "Dashboard", "path": "/", "caption": "공통" },
     { "id": 2, "label": "Common Preview", "path": "/common-preview", "caption": "공통 UI 테스트" },
-    { "id": 3, "label": "Auth", "path": "/auth", "caption": "인증/권한" },
-    { "id": 4, "label": "Master", "path": "/master", "caption": "기준정보" },
-    { "id": 5, "label": "Order", "path": "/order", "caption": "주문/출고" },
-    { "id": 6, "label": "Document", "path": "/document", "caption": "문서관리" },
-    { "id": 7, "label": "Sales", "path": "/sales", "caption": "매출분석" },
-    { "id": 8, "label": "PDF", "path": "/pdf", "caption": "문서출력" },
-    { "id": 9, "label": "Notification", "path": "/notification", "caption": "메일/알림" }
+    { "id": 3, "label": "Domain Preview", "path": "/domain-preview", "caption": "도메인 UI 테스트" },
+    { "id": 4, "label": "Auth", "path": "/auth", "caption": "인증/권한" },
+    { "id": 5, "label": "Master", "path": "/master", "caption": "기준정보" },
+    { "id": 6, "label": "Order", "path": "/order", "caption": "주문/출고" },
+    { "id": 7, "label": "Document", "path": "/document", "caption": "문서관리" },
+    { "id": 8, "label": "Sales", "path": "/sales", "caption": "매출분석" },
+    { "id": 9, "label": "PDF", "path": "/pdf", "caption": "문서출력" },
+    { "id": 10, "label": "Notification", "path": "/notification", "caption": "메일/알림" }
   ],
   "dashboardKpis": [
     { "id": 1, "title": "진행 화면", "value": "24", "change": "+6" },

--- a/src/components/domain/activity/ActivityDetailModal.vue
+++ b/src/components/domain/activity/ActivityDetailModal.vue
@@ -1,0 +1,39 @@
+<script setup>
+import BaseModal from '@/components/common/BaseModal.vue'
+import InfoField from '@/components/common/InfoField.vue'
+import ActivityTypeBadge from '@/components/domain/activity/ActivityTypeBadge.vue'
+
+defineProps({
+  open: {
+    type: Boolean,
+    default: false,
+  },
+  activity: {
+    type: Object,
+    default: () => ({}),
+  },
+})
+
+defineEmits(['close'])
+</script>
+
+<template>
+  <BaseModal
+    :open="open"
+    :title="activity.title || '활동 상세'"
+    description="활동 기록 상세 내용을 확인하는 공통 모달"
+    @close="$emit('close')"
+  >
+    <div class="space-y-4">
+      <InfoField label="유형">
+        <ActivityTypeBadge :value="activity.type || '메모/노트'" />
+      </InfoField>
+      <InfoField label="거래처" :value="activity.client" />
+      <InfoField label="작성일" :value="activity.date" />
+      <InfoField label="작성자" :value="activity.author" />
+      <InfoField label="내용" stacked>
+        <p class="leading-6 text-slate-600">{{ activity.content || '-' }}</p>
+      </InfoField>
+    </div>
+  </BaseModal>
+</template>

--- a/src/components/domain/activity/ActivityTypeBadge.vue
+++ b/src/components/domain/activity/ActivityTypeBadge.vue
@@ -1,0 +1,29 @@
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  value: {
+    type: String,
+    default: '',
+  },
+})
+
+const variantMap = {
+  '미팅/협의': 'bg-sky-50 text-sky-700 border-sky-200',
+  '메모/노트': 'bg-slate-100 text-slate-700 border-slate-200',
+  '이슈': 'bg-rose-50 text-rose-700 border-rose-200',
+  '코멘트': 'bg-violet-50 text-violet-700 border-violet-200',
+  '일정': 'bg-amber-50 text-amber-700 border-amber-200',
+}
+
+const badgeClasses = computed(() => variantMap[props.value] || 'bg-slate-100 text-slate-700 border-slate-200')
+</script>
+
+<template>
+  <span
+    class="inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-semibold"
+    :class="badgeClasses"
+  >
+    {{ value }}
+  </span>
+</template>

--- a/src/components/domain/activity/FilterPanel.vue
+++ b/src/components/domain/activity/FilterPanel.vue
@@ -1,0 +1,82 @@
+<script setup>
+import BaseButton from '@/components/common/BaseButton.vue'
+import BaseCard from '@/components/common/BaseCard.vue'
+import BaseSelect from '@/components/common/BaseSelect.vue'
+import BaseTextField from '@/components/common/BaseTextField.vue'
+
+defineProps({
+  keyword: {
+    type: String,
+    default: '',
+  },
+  typeValue: {
+    type: [String, Number],
+    default: '',
+  },
+  dateFrom: {
+    type: String,
+    default: '',
+  },
+  dateTo: {
+    type: String,
+    default: '',
+  },
+  typeOptions: {
+    type: Array,
+    default: () => [],
+  },
+})
+
+defineEmits([
+  'update:keyword',
+  'update:typeValue',
+  'update:dateFrom',
+  'update:dateTo',
+  'reset',
+  'search',
+])
+</script>
+
+<template>
+  <BaseCard title="조회 조건" subtitle="유형, 기간, 키워드 기준으로 활동 내역을 필터링합니다.">
+    <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+      <div class="space-y-2">
+        <p class="text-sm font-medium text-slate-600">유형</p>
+        <BaseSelect
+          :model-value="typeValue"
+          :options="typeOptions"
+          placeholder="유형 선택"
+          @update:model-value="$emit('update:typeValue', $event)"
+        />
+      </div>
+      <div class="space-y-2">
+        <p class="text-sm font-medium text-slate-600">시작일</p>
+        <BaseTextField
+          :model-value="dateFrom"
+          type="date"
+          @update:model-value="$emit('update:dateFrom', $event)"
+        />
+      </div>
+      <div class="space-y-2">
+        <p class="text-sm font-medium text-slate-600">종료일</p>
+        <BaseTextField
+          :model-value="dateTo"
+          type="date"
+          @update:model-value="$emit('update:dateTo', $event)"
+        />
+      </div>
+      <div class="space-y-2">
+        <p class="text-sm font-medium text-slate-600">키워드</p>
+        <BaseTextField
+          :model-value="keyword"
+          placeholder="제목, 거래처, 작성자 검색"
+          @update:model-value="$emit('update:keyword', $event)"
+        />
+      </div>
+    </div>
+    <div class="mt-4 flex justify-end gap-3">
+      <BaseButton variant="secondary" @click="$emit('reset')">초기화</BaseButton>
+      <BaseButton @click="$emit('search')">검색</BaseButton>
+    </div>
+  </BaseCard>
+</template>

--- a/src/components/domain/document/DocumentHeaderActions.vue
+++ b/src/components/domain/document/DocumentHeaderActions.vue
@@ -1,0 +1,30 @@
+<script setup>
+import BaseButton from '@/components/common/BaseButton.vue'
+
+defineProps({
+  showPreview: {
+    type: Boolean,
+    default: true,
+  },
+  showPrint: {
+    type: Boolean,
+    default: true,
+  },
+  showPdf: {
+    type: Boolean,
+    default: true,
+  },
+})
+
+defineEmits(['edit', 'delete', 'preview', 'print', 'download'])
+</script>
+
+<template>
+  <div class="flex flex-wrap items-center gap-3">
+    <BaseButton variant="secondary" @click="$emit('edit')">수정</BaseButton>
+    <BaseButton variant="danger" @click="$emit('delete')">삭제</BaseButton>
+    <BaseButton v-if="showPreview" variant="ghost" @click="$emit('preview')">미리보기</BaseButton>
+    <BaseButton v-if="showPrint" variant="ghost" @click="$emit('print')">인쇄</BaseButton>
+    <BaseButton v-if="showPdf" variant="ghost" @click="$emit('download')">PDF 다운로드</BaseButton>
+  </div>
+</template>

--- a/src/components/domain/document/DocumentSummarySection.vue
+++ b/src/components/domain/document/DocumentSummarySection.vue
@@ -1,0 +1,37 @@
+<script setup>
+import BaseCard from '@/components/common/BaseCard.vue'
+import InfoField from '@/components/common/InfoField.vue'
+import StatusBadge from '@/components/common/StatusBadge.vue'
+
+defineProps({
+  title: {
+    type: String,
+    default: '기본 정보',
+  },
+  fields: {
+    type: Array,
+    default: () => [],
+  },
+})
+</script>
+
+<template>
+  <BaseCard :title="title" subtitle="문서 기본 정보 요약">
+    <div class="grid gap-4 md:grid-cols-2">
+      <InfoField
+        v-for="field in fields"
+        :key="field.label"
+        :label="field.label"
+        :value="field.value"
+      >
+        <StatusBadge
+          v-if="field.type === 'status'"
+          :value="field.value"
+        />
+        <template v-else>
+          {{ field.value || '-' }}
+        </template>
+      </InfoField>
+    </div>
+  </BaseCard>
+</template>

--- a/src/components/domain/document/LineItemTable.vue
+++ b/src/components/domain/document/LineItemTable.vue
@@ -1,0 +1,52 @@
+<script setup>
+import BaseTable from '@/components/common/BaseTable.vue'
+
+const props = defineProps({
+  items: {
+    type: Array,
+    default: () => [],
+  },
+  currencySymbol: {
+    type: String,
+    default: '$',
+  },
+  amountLabel: {
+    type: String,
+    default: '금액',
+  },
+})
+
+const columns = [
+  { key: 'description', label: '품목' },
+  { key: 'qty', label: '수량', align: 'right', width: '90px' },
+  { key: 'unitPrice', label: '단가', align: 'right', width: '120px' },
+  { key: 'amount', label: props.amountLabel, align: 'right', width: '140px' },
+]
+
+function formatAmount(value) {
+  if (value === null || value === undefined || value === '') {
+    return '-'
+  }
+
+  return `${props.currencySymbol}${Number(value).toLocaleString()}`
+}
+</script>
+
+<template>
+  <BaseTable
+    :columns="columns"
+    :rows="items"
+    row-key="id"
+    empty-text="등록된 품목이 없습니다."
+  >
+    <template #cell-qty="{ value }">
+      {{ Number(value || 0).toLocaleString() }}
+    </template>
+    <template #cell-unitPrice="{ value }">
+      {{ formatAmount(value) }}
+    </template>
+    <template #cell-amount="{ value }">
+      <span class="font-semibold text-ink">{{ formatAmount(value) }}</span>
+    </template>
+  </BaseTable>
+</template>

--- a/src/components/domain/document/LinkedDocumentList.vue
+++ b/src/components/domain/document/LinkedDocumentList.vue
@@ -1,0 +1,37 @@
+<script setup>
+import BaseCard from '@/components/common/BaseCard.vue'
+import BaseButton from '@/components/common/BaseButton.vue'
+import StatusBadge from '@/components/common/StatusBadge.vue'
+
+defineProps({
+  documents: {
+    type: Array,
+    default: () => [],
+  },
+})
+
+defineEmits(['select'])
+</script>
+
+<template>
+  <BaseCard title="연결 문서" subtitle="문서 간 연결 관계를 빠르게 확인하는 영역">
+    <div v-if="documents.length" class="space-y-3">
+      <button
+        v-for="document in documents"
+        :key="document.id || document.code"
+        type="button"
+        class="flex w-full items-center justify-between rounded-2xl border border-slate-200 bg-white px-4 py-3 text-left transition hover:border-brand/30 hover:bg-brand/5"
+        @click="$emit('select', document)"
+      >
+        <div>
+          <p class="text-sm font-semibold text-ink">{{ document.code }}</p>
+          <p class="mt-1 text-xs text-slate-500">{{ document.label }}</p>
+        </div>
+        <StatusBadge :value="document.status" />
+      </button>
+    </div>
+    <div v-else class="rounded-2xl border border-dashed border-slate-200 px-4 py-8 text-center text-sm text-slate-400">
+      연결된 문서가 없습니다.
+    </div>
+  </BaseCard>
+</template>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -2,6 +2,7 @@ import { createRouter, createWebHistory } from 'vue-router'
 import AppLayout from '@/layouts/AppLayout.vue'
 import CommonComponentsPage from '@/views/CommonComponentsPage.vue'
 import DashboardPage from '@/views/DashboardPage.vue'
+import DomainComponentsPage from '@/views/DomainComponentsPage.vue'
 import ServicePage from '@/views/ServicePage.vue'
 
 const routes = [
@@ -26,6 +27,16 @@ const routes = [
           title: 'Common Preview',
           serviceName: '공통 컴포넌트 프리뷰',
           description: '1차 구현한 공통 컴포넌트의 동작 검증용 화면',
+        },
+      },
+      {
+        path: 'domain-preview',
+        name: 'domain-preview',
+        component: DomainComponentsPage,
+        meta: {
+          title: 'Domain Preview',
+          serviceName: '도메인 공통 컴포넌트 프리뷰',
+          description: '2차 구현한 문서/활동 도메인 공통 컴포넌트 검증용 화면',
         },
       },
       {

--- a/src/views/DomainComponentsPage.vue
+++ b/src/views/DomainComponentsPage.vue
@@ -1,0 +1,122 @@
+<script setup>
+import { reactive, ref } from 'vue'
+import BaseButton from '@/components/common/BaseButton.vue'
+import BaseCard from '@/components/common/BaseCard.vue'
+import PageTitleBar from '@/components/layout/PageTitleBar.vue'
+import ActivityDetailModal from '@/components/domain/activity/ActivityDetailModal.vue'
+import ActivityTypeBadge from '@/components/domain/activity/ActivityTypeBadge.vue'
+import FilterPanel from '@/components/domain/activity/FilterPanel.vue'
+import DocumentHeaderActions from '@/components/domain/document/DocumentHeaderActions.vue'
+import DocumentSummarySection from '@/components/domain/document/DocumentSummarySection.vue'
+import LineItemTable from '@/components/domain/document/LineItemTable.vue'
+import LinkedDocumentList from '@/components/domain/document/LinkedDocumentList.vue'
+
+const filterState = reactive({
+  keyword: '',
+  typeValue: '',
+  dateFrom: '2026-03-01',
+  dateTo: '2026-03-17',
+})
+
+const isActivityModalOpen = ref(false)
+
+const activityTypes = [
+  { label: '미팅/협의', value: '미팅/협의' },
+  { label: '메모/노트', value: '메모/노트' },
+  { label: '이슈', value: '이슈' },
+  { label: '코멘트', value: '코멘트' },
+  { label: '일정', value: '일정' },
+]
+
+const documentSummaryFields = [
+  { label: '문서번호', value: 'PI-2026-001' },
+  { label: '거래처', value: 'COOLSAY SDN BHD' },
+  { label: '담당자', value: '김영업' },
+  { label: '상태', value: '확정', type: 'status' },
+  { label: '통화', value: 'USD' },
+  { label: '납기일', value: '2026/04/15' },
+]
+
+const lineItems = [
+  { id: 1, description: 'H-Beam 482x300x11x15', qty: 30, unitPrice: 850, amount: 25500 },
+  { id: 2, description: 'Lubricant Oil SAE 10W-40', qty: 200, unitPrice: 30, amount: 6000 },
+]
+
+const linkedDocuments = [
+  { id: 1, code: 'PI-2026-001', label: 'Proforma Invoice', status: '확정' },
+  { id: 2, code: 'PO-2026-001', label: 'Purchase Order', status: '생산중' },
+  { id: 3, code: 'SO-2026-001', label: 'Shipment Order', status: '준비완료' },
+]
+
+const selectedActivity = {
+  type: '미팅/협의',
+  title: '초도 미팅 - 제품 사양 논의',
+  client: 'COOLSAY SDN BHD',
+  date: '2026/01/20',
+  author: '김영업',
+  content: 'COOLSAY 구매팀과 화상회의를 진행했고, 바이어 요청 사항을 다음 견적에 반영하기로 정리했습니다.',
+}
+
+function resetFilters() {
+  filterState.keyword = ''
+  filterState.typeValue = ''
+  filterState.dateFrom = ''
+  filterState.dateTo = ''
+}
+</script>
+
+<template>
+  <div class="space-y-6">
+    <PageTitleBar
+      title="도메인 공통 컴포넌트 프리뷰"
+      description="문서/활동 화면에서 반복되는 2차 공통 컴포넌트 기본 동작을 확인하는 테스트 페이지"
+    >
+      <template #actions>
+        <BaseButton variant="secondary" @click="isActivityModalOpen = true">활동 상세 보기</BaseButton>
+      </template>
+    </PageTitleBar>
+
+    <DocumentSummarySection :fields="documentSummaryFields" />
+
+    <section class="grid gap-6 xl:grid-cols-[1.2fr_0.8fr]">
+      <BaseCard title="DocumentHeaderActions" subtitle="문서 상세 상단 액션 묶음">
+        <DocumentHeaderActions />
+      </BaseCard>
+
+      <BaseCard title="ActivityTypeBadge" subtitle="활동 유형별 상태 표현">
+        <div class="flex flex-wrap gap-3">
+          <ActivityTypeBadge
+            v-for="type in activityTypes"
+            :key="type.value"
+            :value="type.value"
+          />
+        </div>
+      </BaseCard>
+    </section>
+
+    <section class="grid gap-6 xl:grid-cols-[1.2fr_0.8fr]">
+      <LineItemTable :items="lineItems" currency-symbol="$" />
+      <LinkedDocumentList :documents="linkedDocuments" />
+    </section>
+
+    <FilterPanel
+      :keyword="filterState.keyword"
+      :type-value="filterState.typeValue"
+      :date-from="filterState.dateFrom"
+      :date-to="filterState.dateTo"
+      :type-options="activityTypes"
+      @update:keyword="filterState.keyword = $event"
+      @update:type-value="filterState.typeValue = $event"
+      @update:date-from="filterState.dateFrom = $event"
+      @update:date-to="filterState.dateTo = $event"
+      @reset="resetFilters"
+      @search="null"
+    />
+
+    <ActivityDetailModal
+      :open="isActivityModalOpen"
+      :activity="selectedActivity"
+      @close="isActivityModalOpen = false"
+    />
+  </div>
+</template>


### PR DESCRIPTION
## 📋 작업 내용

<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- SalesBoost 2차 공통 컴포넌트를 구현하고, 문서/활동 도메인 공통 UI를 한 화면에서 확인할 수 있도록 `/domain-preview` 프리뷰 페이지를 추가했습니다.

- 문서 헤더 액션, 문서 요약 영역, 품목 테이블, 연결 문서 리스트, 필터 패널, 활동 유형 배지, 활동 상세 모달을 구현했고, 사이드바 메뉴와 라우트도 함께 연결했습니다.

## 🔗 관련 이슈

<!-- 관련 이슈 번호를 적어주세요 (자동으로 이슈가 닫힙니다) -->
- closes #14 

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->
<img width="2790" height="1578" alt="image" src="https://github.com/user-attachments/assets/2ae1e011-f6d6-4561-b5c5-2db465068f22" />

## ✅ 체크리스트

- [x] 정상 동작 확인

## 💬 리뷰어에게

<!-- 리뷰할 때 중점적으로 봐줬으면 하는 부분이 있다면 적어주세요 -->
2차 공통 컴포넌트를 실제 화면에 붙이기 전, 도메인 공통 UI 단위를 먼저 정리한 PR입니다.
문서/활동 도메인에서 반복되는 패턴을 공통 컴포넌트로 나눈 기준이 적절한지, `/domain-preview` 페이지에서 기본 동작 확인용으로 충분한지에 대한 것을 중점으로 봐주시면 됩니다.

