### PR TITLE
[bug] BaseModal 스크롤 레이아웃 구조 보정

### DIFF
--- a/src/components/common/BaseModal.vue
+++ b/src/components/common/BaseModal.vue
@@ -43,10 +43,10 @@ function handleBackdropClick() {
       @click.self="handleBackdropClick"
     >
       <div
-        class="w-full max-h-[90vh] overflow-hidden rounded-lg bg-white shadow-2xl"
+        class="flex max-h-[90vh] w-full flex-col overflow-hidden rounded-lg bg-white shadow-2xl"
         :class="width"
       >
-        <div class="flex items-start justify-between gap-4 border-b border-slate-100 px-6 py-4">
+        <div class="flex flex-shrink-0 items-start justify-between gap-4 border-b border-slate-100 px-6 py-4">
           <div>
             <h2 class="text-lg font-bold text-ink">{{ title }}</h2>
             <p v-if="description" class="mt-1 text-sm text-slate-500">{{ description }}</p>
@@ -67,11 +67,11 @@ function handleBackdropClick() {
           </button>
         </div>
 
-        <div class="overflow-y-auto px-6 py-5">
+        <div class="min-h-0 flex-1 overflow-y-auto px-6 py-5">
           <slot />
         </div>
 
-        <div v-if="$slots.footer" class="flex justify-end gap-3 border-t border-slate-100 bg-slate-50/50 px-6 py-4">
+        <div v-if="$slots.footer" class="flex flex-shrink-0 justify-end gap-3 border-t border-slate-100 bg-slate-50/50 px-6 py-4">
           <slot name="footer" />
         </div>
       </div>


### PR DESCRIPTION
  BaseModal에서 내용이 길어질 때 하단 영역이 잘리고 footer 버튼이 보이지 않던 문제를 수정했습니다.
  모달 컨테이너를 세로 flex 레이아웃으로 변경하고, 본문 영역에만 스크롤이 적용되도록 구조를 보정해 헤더와 footer는 고정되고 내용만 스크롤되도록 정리했습니다.

  ## 🔗 관련 이슈

  - closes #34 

  ## 📸 스크린샷 (선택)

<img width="1348" height="1626" alt="image" src="https://github.com/user-attachments/assets/bad0ab52-24cd-4503-b4f0-4ba1072affab" />

  ## ✅ 체크리스트

  - [x] 정상 동작 확인
  - [x] 불필요한 코드/주석 제거
  - [x] 충돌(conflict) 해결 완료

  ## 💬 리뷰어에게

긴 폼이 들어가는 모달에서 footer가 잘리던 문제를 공통 BaseModal 레벨에서 해결한 PR입니다.
본문 스크롤이 자연스럽게 동작하는지, 헤더/푸터가 고정된 상태로 유지되는지 중심으로 봐주시면 됩니다.
