### PR TITLE
fix: 사용자 관리 라우트를 /users로 통일 (#21)

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -72,12 +72,6 @@ const routes = [
           title: 'Clients',
           serviceName: '거래처 관리',
           description: '거래처 조회 및 관리 화면',
-        path: 'auth',
-        name: 'auth',
-        component: () => import('@/views/auth/UserManagementPage.vue'),
-        meta: {
-          title: 'Auth',
-          serviceName: '사용자 관리',
         },
       },
       {
@@ -213,11 +207,10 @@ const routes = [
       {
         path: 'users',
         name: 'users',
-        component: ServicePage,
+        component: () => import('@/views/auth/UserManagementPage.vue'),
         meta: {
           title: 'Users',
           serviceName: '사용자 관리',
-          description: '사용자 및 자사 정보 화면',
         },
       },
     ],


### PR DESCRIPTION
## Summary
- 사이드바 네비게이션이 `/users`를 가리키는데 구현이 `/auth`에 있던 불일치 수정
- `/auth` 라우트 제거, `/users`의 ServicePage를 UserManagementPage로 교체

## Test plan
- [x] 사이드바에서 "사용자 관리" 클릭 → `/users`로 이동, UserManagementPage 표시
- [x] `/login`, `/forgot-password` 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)