### PR TITLE
[feat] AppHeader에 비밀번호 변경 모달 연결

### DIFF
--- a/src/components/layout/AppHeader.vue
+++ b/src/components/layout/AppHeader.vue
@@ -1,12 +1,14 @@
 <script setup>
 import { computed, ref } from 'vue'
 import { useRoute } from 'vue-router'
+import PasswordChangeModal from '@/components/domain/auth/PasswordChangeModal.vue'
 import { useUiStore } from '@/stores/ui'
 
 const uiStore = useUiStore()
 const route = useRoute()
 const pageTitle = computed(() => String(route.meta.serviceName ?? '공통 대시보드'))
 const isNotificationOpen = ref(false)
+const isPasswordModalOpen = ref(false)
 
 const notifications = [
   {
@@ -43,6 +45,14 @@ const unreadCount = computed(() => notifications.filter((item) => item.unread).l
 
 function toggleNotifications() {
   isNotificationOpen.value = !isNotificationOpen.value
+}
+
+function openPasswordModal() {
+  isPasswordModalOpen.value = true
+}
+
+function closePasswordModal() {
+  isPasswordModalOpen.value = false
 }
 </script>
 
@@ -115,7 +125,12 @@ function toggleNotifications() {
         </div>
       </div>
 
-      <button type="button" class="flex h-7 w-7 cursor-pointer items-center justify-center rounded-lg text-xs text-slate-400 transition hover:bg-slate-50 hover:text-slate-700" title="비밀번호 변경">
+      <button
+        type="button"
+        class="flex h-7 w-7 cursor-pointer items-center justify-center rounded-lg text-xs text-slate-400 transition hover:bg-slate-50 hover:text-slate-700"
+        title="비밀번호 변경"
+        @click="openPasswordModal"
+      >
         <i class="fas fa-key text-xs" aria-hidden="true"></i>
       </button>
 
@@ -124,4 +139,6 @@ function toggleNotifications() {
       </button>
     </div>
   </header>
+
+  <PasswordChangeModal :open="isPasswordModalOpen" @close="closePasswordModal" @save="closePasswordModal" />
 </template>


### PR DESCRIPTION
  ## 📋 작업 내용

요첨하신 AppHeader 우측 사용자 액션 영역에 비밀번호 변경 기능을 연결했습니다.
기준 화면 구조에 맞춰 헤더의 열쇠 아이콘 버튼을 클릭하면 PasswordChangeModal이 열리도록 연결했고, 모달 열림/닫힘 상태를 헤더에서 관리하도록 반영했습니다.

  ## 🔗 관련 이슈

  - closes #35

  ## 📸 스크린샷 (선택)

 <img width="2344" height="1328" alt="image" src="https://github.com/user-attachments/assets/4e208699-d0cd-4b36-9170-dd07135e5deb" />

  ## ✅ 체크리스트

  - [ ] 정상 동작 확인
  - [ ] 불필요한 코드/주석 제거
  - [ ] 충돌(conflict) 해결 완료

  ## 💬 리뷰어에게

 헤더 구조가 기존 기준 화면과 어긋나지 않는지, 모달 열림/닫힘 흐름이 자연스러운지 중심으로 봐주시면 됩니다.