### PR TITLE
[feat] ConfirmModal 공통 컴포넌트 추가

### DIFF
--- a/src/components/common/ConfirmModal.vue
+++ b/src/components/common/ConfirmModal.vue
@@ -1,0 +1,62 @@
+<script setup>
+import BaseButton from '@/components/common/BaseButton.vue'
+import BaseModal from '@/components/common/BaseModal.vue'
+
+const props = defineProps({
+  open: {
+    type: Boolean,
+    default: false,
+  },
+  title: {
+    type: String,
+    default: '확인',
+  },
+  message: {
+    type: String,
+    default: '',
+  },
+  detail: {
+    type: String,
+    default: '',
+  },
+  confirmLabel: {
+    type: String,
+    default: '확인',
+  },
+  cancelLabel: {
+    type: String,
+    default: '취소',
+  },
+  confirmVariant: {
+    type: String,
+    default: 'primary',
+  },
+})
+
+const emit = defineEmits(['confirm', 'cancel'])
+</script>
+
+<template>
+  <BaseModal
+    :open="open"
+    :title="title"
+    width="max-w-sm"
+    @close="emit('cancel')"
+  >
+    <div class="space-y-4 text-sm text-slate-600">
+      <p class="leading-6 text-slate-700">{{ message }}</p>
+      <div
+        v-if="detail"
+        class="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 font-medium text-slate-800"
+      >
+        {{ detail }}
+      </div>
+      <p class="text-xs text-slate-400">이 작업은 되돌릴 수 없습니다.</p>
+    </div>
+
+    <template #footer>
+      <BaseButton variant="secondary" @click="emit('cancel')">{{ cancelLabel }}</BaseButton>
+      <BaseButton :variant="confirmVariant" @click="emit('confirm')">{{ confirmLabel }}</BaseButton>
+    </template>
+  </BaseModal>
+</template>

--- a/src/views/CommonComponentsPage.vue
+++ b/src/views/CommonComponentsPage.vue
@@ -2,6 +2,7 @@
 import { reactive, ref } from 'vue'
 import BaseButton from '@/components/common/BaseButton.vue'
 import BaseCard from '@/components/common/BaseCard.vue'
+import ConfirmModal from '@/components/common/ConfirmModal.vue'
 import BaseTabs from '@/components/common/BaseTabs.vue'
 import FormField from '@/components/common/FormField.vue'
 import BaseModal from '@/components/common/BaseModal.vue'
@@ -24,6 +25,7 @@ const form = reactive({
 })
 
 const isModalOpen = ref(false)
+const isConfirmModalOpen = ref(false)
 const activeTab = ref('users')
 const fieldErrors = reactive({
   name: '',
@@ -181,6 +183,7 @@ function showErrorToast() {
           <div class="flex flex-wrap gap-3">
             <BaseButton @click="showSuccessToast">성공 토스트</BaseButton>
             <BaseButton variant="secondary" @click="showErrorToast">실패 토스트</BaseButton>
+            <BaseButton variant="danger" @click="isConfirmModalOpen = true">삭제 확인 모달</BaseButton>
           </div>
 
           <div class="space-y-4">
@@ -230,5 +233,16 @@ function showErrorToast() {
         <BaseButton @click="isModalOpen = false">확인</BaseButton>
       </template>
     </BaseModal>
+
+    <ConfirmModal
+      :open="isConfirmModalOpen"
+      title="기록 삭제"
+      message="아래 기록을 삭제하시겠습니까?"
+      detail="포장 규격 변경 요청"
+      confirm-label="삭제"
+      confirm-variant="danger"
+      @cancel="isConfirmModalOpen = false"
+      @confirm="isConfirmModalOpen = false"
+    />
   </div>
 </template>


### PR DESCRIPTION
  ## 📋 작업 내용

삭제, 취소, 초기화 같은 확인 패턴에 공통으로 사용할 수 있는 ConfirmModal 컴포넌트를 추가했습니다.
BaseModal과 BaseButton을 조합해 제목, 안내 문구, 대상명 강조, 확인/취소 버튼 구성을 공통화했고, `/common-preview`에서 기본 동작을 확인할 수 있도록 프리뷰도 함께 연결했습니다.

  ## 🔗 관련 이슈

  - closes #40 

## 📸 스크린샷 (선택)

<img width="1496" height="850" alt="image" src="https://github.com/user-attachments/assets/2aabecea-0f79-41a1-8fe7-a29558fa11d4" />

  ## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

  ## 💬 리뷰어에게

Activity를 포함한 여러 도메인에서 반복될 삭제/확인 모달 패턴을 공통 컴포넌트로 분리한 PR입니다.
도메인별로 제목, 문구, detail, 버튼 variant만 바꿔 재사용하기 괜찮은 구조인지 중심으로 봐주시면 됩니다.
