### PR TITLE
기록 관리 , 메일 이력 상세검색 공통 컴포넌트 적용 및 필터 UX 개선

### DIFF
--- a/src/views/activity/ActivityListPage.vue
+++ b/src/views/activity/ActivityListPage.vue
@@ -6,16 +6,19 @@ import ActivityEditModal from '@/components/domain/activity/ActivityEditModal.vu
 import ActivityTypeBadge from '@/components/domain/activity/ActivityTypeBadge.vue'
 import BaseButton from '@/components/common/BaseButton.vue'
 import BaseTable from '@/components/common/BaseTable.vue'
+import CollapsibleFilterCard from '@/components/common/CollapsibleFilterCard.vue'
 import ConfirmModal from '@/components/common/ConfirmModal.vue'
-import BaseTextField from '@/components/common/BaseTextField.vue'
 import DateRangeField from '@/components/common/DateRangeField.vue'
+import FilterToolbarCard from '@/components/common/FilterToolbarCard.vue'
+import FormField from '@/components/common/FormField.vue'
 import PageTitleBar from '@/components/layout/PageTitleBar.vue'
 import SearchableCombobox from '@/components/common/SearchableCombobox.vue'
+import SearchTriggerField from '@/components/common/SearchTriggerField.vue'
 
 const router = useRouter()
 
 // ── 필터 상태 ──────────────────────────────────────────────
-const isFilterOpen = ref(true)
+const isFilterOpen = ref(false)
 const filterDateFrom = ref('')
 const filterDateTo = ref('')
 const filterAuthor = ref('')
@@ -37,13 +40,28 @@ const authorOptions = [
   { label: '이철수', value: '이철수' },
 ]
 
+// 실제 적용된 필터 (검색 버튼 클릭 시에만 반영)
+const applied = ref({ title: '', dateFrom: '', dateTo: '', author: '', po: '', type: '' })
+
+function applySearch() {
+  applied.value = {
+    title:    filterTitle.value,
+    dateFrom: filterDateFrom.value,
+    dateTo:   filterDateTo.value,
+    author:   filterAuthor.value,
+    po:       filterPo.value,
+    type:     filterType.value,
+  }
+}
+
 function resetFilters() {
   filterDateFrom.value = ''
-  filterDateTo.value = ''
-  filterAuthor.value = ''
-  filterPo.value = ''
-  filterType.value = ''
-  filterTitle.value = ''
+  filterDateTo.value   = ''
+  filterAuthor.value   = ''
+  filterPo.value       = ''
+  filterType.value     = ''
+  filterTitle.value    = ''
+  applied.value = { title: '', dateFrom: '', dateTo: '', author: '', po: '', type: '' }
 }
 
 // ── 더미 데이터 ────────────────────────────────────────────
@@ -120,15 +138,15 @@ const activities = ref([
   },
 ])
 
-// ── 필터 computed ──────────────────────────────────────────
+// ── 필터 computed (applied 기준) ───────────────────────────
 const filteredActivities = computed(() => {
   return activities.value.filter((a) => {
-    const matchType = !filterType.value || a.type === filterType.value
-    const matchTitle = !filterTitle.value || a.title.includes(filterTitle.value) || a.client.includes(filterTitle.value)
-    const matchAuthor = !filterAuthor.value || a.author === filterAuthor.value
-    const matchPo = !filterPo.value || a.poId.includes(filterPo.value)
-    const matchFrom = !filterDateFrom.value || a.date >= filterDateFrom.value
-    const matchTo = !filterDateTo.value || a.date <= filterDateTo.value
+    const matchType   = !applied.value.type   || a.type === applied.value.type
+    const matchTitle  = !applied.value.title  || a.title.includes(applied.value.title) || a.client.includes(applied.value.title)
+    const matchAuthor = !applied.value.author || a.author === applied.value.author
+    const matchPo     = !applied.value.po     || a.poId.includes(applied.value.po)
+    const matchFrom   = !applied.value.dateFrom || a.date >= applied.value.dateFrom
+    const matchTo     = !applied.value.dateTo   || a.date <= applied.value.dateTo
     return matchType && matchTitle && matchAuthor && matchPo && matchFrom && matchTo
   })
 })
@@ -215,37 +233,20 @@ const columns = [
       </template>
     </PageTitleBar>
 
-    <!-- 상세검색 필터 -->
-    <div class="rounded-xl border border-slate-200 bg-white shadow-sm">
-      <!-- 필터 토글 헤더 -->
-      <button
-        type="button"
-        class="flex w-full select-none items-center justify-between px-5 py-3 transition hover:bg-slate-50"
-        @click="isFilterOpen = !isFilterOpen"
-      >
-        <div class="flex items-center gap-2">
-          <svg class="h-4 w-4 text-brand-500" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-            <path fill-rule="evenodd" d="M2.628 1.601C5.028 1.206 7.49 1 10 1s4.973.206 7.372.601a.75.75 0 0 1 .628.74v2.288a2.25 2.25 0 0 1-.659 1.59l-4.682 4.683a2.25 2.25 0 0 0-.659 1.59v3.037c0 .684-.31 1.33-.844 1.757l-1.937 1.55A.75.75 0 0 1 8 18.25v-5.757a2.25 2.25 0 0 0-.659-1.591L2.66 6.22A2.25 2.25 0 0 1 2 4.629V2.34a.75.75 0 0 1 .628-.74Z" clip-rule="evenodd" />
-          </svg>
-          <span class="text-sm font-semibold text-slate-700">상세검색</span>
-        </div>
-        <svg
-          class="h-4 w-4 text-slate-400 transition-transform duration-200"
-          :class="isFilterOpen ? '' : 'rotate-180'"
-          viewBox="0 0 20 20"
-          fill="currentColor"
-          aria-hidden="true"
-        >
-          <path fill-rule="evenodd" d="M9.47 6.47a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 1 1-1.06 1.06L10 8.06l-3.72 3.72a.75.75 0 0 1-1.06-1.06l4.25-4.25Z" clip-rule="evenodd" />
-        </svg>
-      </button>
+    <!-- 키워드 검색 + 상세검색 토글 -->
+    <FilterToolbarCard
+      v-model="filterTitle"
+      placeholder="제목 검색..."
+      :advanced-open="isFilterOpen"
+      @toggle-advanced="isFilterOpen = !isFilterOpen"
+    />
 
-      <!-- 필터 바디 -->
-      <div v-show="isFilterOpen" class="border-t border-slate-100 px-5 pb-4">
-        <div class="grid grid-cols-2 gap-x-4 gap-y-3 pt-3 md:grid-cols-4">
-          <!-- 날짜 기간 -->
-          <div class="col-span-2 space-y-1.5">
-            <p class="text-[10px] font-semibold uppercase tracking-wide text-slate-500">날짜 기간</p>
+    <!-- 상세검색 패널 -->
+    <CollapsibleFilterCard :open="isFilterOpen" @toggle="isFilterOpen = !isFilterOpen">
+      <div class="grid grid-cols-2 gap-x-4 gap-y-4 md:grid-cols-4">
+        <!-- 날짜 기간 -->
+        <div class="col-span-2">
+          <FormField label="날짜 기간">
             <DateRangeField
               :start="filterDateFrom"
               :end="filterDateTo"
@@ -253,47 +254,42 @@ const columns = [
               @update:end="filterDateTo = $event"
               @reset="filterDateFrom = ''; filterDateTo = ''"
             />
-          </div>
-
-          <!-- 작성자 -->
-          <div class="space-y-1.5">
-            <p class="text-[10px] font-semibold uppercase tracking-wide text-slate-500">작성자</p>
-            <SearchableCombobox
-              v-model="filterAuthor"
-              :options="authorOptions"
-              placeholder="작성자 검색..."
-            />
-          </div>
-
-          <!-- PO -->
-          <div class="space-y-1.5">
-            <p class="text-[10px] font-semibold uppercase tracking-wide text-slate-500">PO</p>
-            <BaseTextField v-model="filterPo" placeholder="PO 번호 검색..." />
-          </div>
-
-          <!-- 유형 -->
-          <div class="space-y-1.5">
-            <p class="text-[10px] font-semibold uppercase tracking-wide text-slate-500">유형</p>
-            <SearchableCombobox
-              v-model="filterType"
-              :options="typeOptions"
-              placeholder="유형 선택..."
-            />
-          </div>
-
-          <!-- 제목 -->
-          <div class="space-y-1.5">
-            <p class="text-[10px] font-semibold uppercase tracking-wide text-slate-500">제목</p>
-            <BaseTextField v-model="filterTitle" placeholder="제목 검색" />
-          </div>
+          </FormField>
         </div>
 
-        <div class="mt-3 flex items-center justify-end gap-2 border-t border-slate-100 pt-3">
-          <BaseButton variant="secondary" size="sm" @click="resetFilters">초기화</BaseButton>
-          <BaseButton size="sm">검색</BaseButton>
-        </div>
+        <!-- 작성자 -->
+        <FormField label="작성자">
+          <SearchableCombobox
+            v-model="filterAuthor"
+            :options="authorOptions"
+            placeholder="작성자 검색..."
+          />
+        </FormField>
+
+        <!-- PO -->
+        <FormField label="PO">
+          <SearchTriggerField
+            v-model="filterPo"
+            placeholder="PO 검색..."
+            title="PO 검색"
+          />
+        </FormField>
+
+        <!-- 유형 -->
+        <FormField label="유형">
+          <SearchableCombobox
+            v-model="filterType"
+            :options="typeOptions"
+            placeholder="유형 선택..."
+          />
+        </FormField>
       </div>
-    </div>
+
+      <div class="mt-4 flex justify-end gap-2 border-t border-slate-100 pt-3">
+        <BaseButton variant="secondary" size="sm" @click="resetFilters">초기화</BaseButton>
+        <BaseButton size="sm" @click="applySearch">검색</BaseButton>
+      </div>
+    </CollapsibleFilterCard>
 
     <!-- 테이블 -->
     <div>

--- a/src/views/emails/EmailListPage.vue
+++ b/src/views/emails/EmailListPage.vue
@@ -1,10 +1,16 @@
 <script setup>
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import BaseButton from '@/components/common/BaseButton.vue'
 import BaseModal from '@/components/common/BaseModal.vue'
+import BaseSelect from '@/components/common/BaseSelect.vue'
 import BaseTable from '@/components/common/BaseTable.vue'
+import CollapsibleFilterCard from '@/components/common/CollapsibleFilterCard.vue'
+import DateRangeField from '@/components/common/DateRangeField.vue'
+import FilterToolbarCard from '@/components/common/FilterToolbarCard.vue'
+import FormField from '@/components/common/FormField.vue'
 import InfoField from '@/components/common/InfoField.vue'
 import PageTitleBar from '@/components/layout/PageTitleBar.vue'
+import SearchableCombobox from '@/components/common/SearchableCombobox.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
 
 // ── 더미 데이터 ────────────────────────────────────────────
@@ -15,7 +21,7 @@ const emails = ref([
     title: '[SalesBoost] PI-2025-001 발송',
     recipient: 'James Carter',
     email: 'james.carter@globaltech.com',
-    type: 'PI 발송',
+    type: 'PI',
     hasAttachment: true,
     status: '발송',
     sentAt: '2025-03-10',
@@ -27,7 +33,7 @@ const emails = ref([
     title: '[SalesBoost] PO-2025-001 발송',
     recipient: 'Hans Müller',
     email: 'hans.muller@eurosupply.de',
-    type: 'PO 발송',
+    type: 'PO',
     hasAttachment: true,
     status: '발송',
     sentAt: '2025-03-09',
@@ -39,7 +45,7 @@ const emails = ref([
     title: '[SalesBoost] CI-2025-001 발송',
     recipient: '',
     email: 'yuki.tanaka@asiaconnect.jp',
-    type: 'CI 발송',
+    type: 'CI',
     hasAttachment: false,
     status: '실패',
     sentAt: '2025-03-08',
@@ -51,7 +57,7 @@ const emails = ref([
     title: '[SalesBoost] PL-2025-001 발송',
     recipient: 'Sarah Johnson',
     email: 'sarah.johnson@globaltech.com',
-    type: 'PL 발송',
+    type: 'PL',
     hasAttachment: true,
     status: '발송',
     sentAt: '2025-03-07',
@@ -63,9 +69,9 @@ const emails = ref([
     title: '[SalesBoost] PI-2025-002 발송',
     recipient: 'Anna Schmidt',
     email: 'anna.schmidt@eurosupply.de',
-    type: 'PI 발송',
+    type: 'PI',
     hasAttachment: false,
-    status: '대기',
+    status: '발송',
     sentAt: '2025-03-06',
     sender: '김영희',
   },
@@ -75,7 +81,7 @@ const emails = ref([
     title: '[SalesBoost] PO-2025-002 발송',
     recipient: 'Kenji Sato',
     email: 'kenji.sato@asiaconnect.jp',
-    type: 'PO 발송',
+    type: 'PO',
     hasAttachment: true,
     status: '발송',
     sentAt: '2025-03-05',
@@ -87,7 +93,7 @@ const emails = ref([
     title: '[SalesBoost] CI-2025-002 발송',
     recipient: '',
     email: 'michael.brown@globaltech.com',
-    type: 'CI 발송',
+    type: 'CI',
     hasAttachment: false,
     status: '발송',
     sentAt: '2025-03-04',
@@ -99,13 +105,76 @@ const emails = ref([
     title: '[SalesBoost] PL-2025-002 발송',
     recipient: 'Hans Müller',
     email: 'hans.muller@eurosupply.de',
-    type: 'PL 발송',
+    type: 'PL',
     hasAttachment: true,
     status: '실패',
     sentAt: '2025-03-03',
     sender: '김영희',
   },
 ])
+
+// ── 필터 상태 ──────────────────────────────────────────────
+const isFilterOpen = ref(false)
+const filterKeyword = ref('')
+const filterType    = ref('')
+const filterStatus  = ref('')
+const filterSender  = ref('')
+const filterDateFrom = ref('')
+const filterDateTo   = ref('')
+
+const typeOptions = [
+  { label: 'PI', value: 'PI' },
+  { label: 'PO', value: 'PO' },
+  { label: 'CI', value: 'CI' },
+  { label: 'PL', value: 'PL' },
+]
+
+const statusOptions = [
+  { label: '발송', value: '발송' },
+  { label: '실패', value: '실패' },
+]
+
+const senderOptions = computed(() => {
+  const unique = [...new Set(emails.value.map((e) => e.sender))]
+  return unique.map((s) => ({ label: s, value: s }))
+})
+
+// 실제 적용된 필터 (검색 버튼 클릭 시에만 반영)
+const applied = ref({ keyword: '', type: '', status: '', sender: '', dateFrom: '', dateTo: '' })
+
+function applySearch() {
+  applied.value = {
+    keyword:  filterKeyword.value,
+    type:     filterType.value,
+    status:   filterStatus.value,
+    sender:   filterSender.value,
+    dateFrom: filterDateFrom.value,
+    dateTo:   filterDateTo.value,
+  }
+}
+
+function resetFilters() {
+  filterKeyword.value  = ''
+  filterType.value     = ''
+  filterStatus.value   = ''
+  filterSender.value   = ''
+  filterDateFrom.value = ''
+  filterDateTo.value   = ''
+  applied.value = { keyword: '', type: '', status: '', sender: '', dateFrom: '', dateTo: '' }
+}
+
+const filteredEmails = computed(() => {
+  return emails.value.filter((e) => {
+    const q = applied.value.keyword.trim().toLowerCase()
+    const matchKeyword = !q || e.title.toLowerCase().includes(q) || e.client.toLowerCase().includes(q)
+    const matchType    = !applied.value.type   || e.type === applied.value.type
+    const matchStatus  = !applied.value.status || e.status === applied.value.status
+    const matchSender  = !applied.value.sender || e.sender === applied.value.sender
+    const matchFrom    = !applied.value.dateFrom || e.sentAt >= applied.value.dateFrom
+    const matchTo      = !applied.value.dateTo   || e.sentAt <= applied.value.dateTo
+    return matchKeyword && matchType && matchStatus && matchSender && matchFrom && matchTo
+  })
+})
 
 // ── 상세 모달 ──────────────────────────────────────────────
 const selectedEmail = ref(null)
@@ -141,8 +210,66 @@ const columns = [
     <!-- 페이지 타이틀 -->
     <PageTitleBar title="메일 이력" description="발송된 메일 이력을 조회합니다." />
 
+    <!-- 키워드 검색 + 상세검색 토글 -->
+    <FilterToolbarCard
+      v-model="filterKeyword"
+      placeholder="제목, 거래처 검색..."
+      :advanced-open="isFilterOpen"
+      @toggle-advanced="isFilterOpen = !isFilterOpen"
+    />
+
+    <!-- 상세검색 패널 -->
+    <CollapsibleFilterCard :open="isFilterOpen" @toggle="isFilterOpen = !isFilterOpen">
+      <div class="grid grid-cols-2 gap-x-4 gap-y-4 md:grid-cols-4">
+        <!-- 기간 -->
+        <div class="col-span-2">
+          <FormField label="발송일 기간">
+            <DateRangeField
+              :start="filterDateFrom"
+              :end="filterDateTo"
+              @update:start="filterDateFrom = $event"
+              @update:end="filterDateTo = $event"
+              @reset="filterDateFrom = ''; filterDateTo = ''"
+            />
+          </FormField>
+        </div>
+
+        <!-- 유형 -->
+        <FormField label="유형">
+          <BaseSelect
+            v-model="filterType"
+            :options="typeOptions"
+            placeholder="유형 선택"
+          />
+        </FormField>
+
+        <!-- 상태 -->
+        <FormField label="상태">
+          <BaseSelect
+            v-model="filterStatus"
+            :options="statusOptions"
+            placeholder="상태 선택"
+          />
+        </FormField>
+
+        <!-- 발송자 -->
+        <FormField label="발송자">
+          <SearchableCombobox
+            v-model="filterSender"
+            :options="senderOptions"
+            placeholder="발송자 검색..."
+          />
+        </FormField>
+      </div>
+
+      <div class="mt-4 flex justify-end gap-2 border-t border-slate-100 pt-3">
+        <BaseButton variant="secondary" size="sm" @click="resetFilters">초기화</BaseButton>
+        <BaseButton size="sm" @click="applySearch">검색</BaseButton>
+      </div>
+    </CollapsibleFilterCard>
+
     <!-- 테이블 -->
-    <BaseTable :columns="columns" :rows="emails" row-key="id">
+    <BaseTable :columns="columns" :rows="filteredEmails" row-key="id">
 
       <!-- 항목 번호 -->
       <template #cell-index="{ row }">
@@ -192,7 +319,7 @@ const columns = [
 
     <!-- 하단 카운트 -->
     <div class="px-1 text-xs text-slate-500">
-      총 {{ emails.length }}건
+      총 {{ filteredEmails.length }}건
     </div>
 
     <!-- 메일 상세 모달 -->


### PR DESCRIPTION
## 📋 작업 내용

<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
  - `FilterToolbarCard` 공통 컴포넌트 적용 — 키워드 검색 + 상세검색 토글 버튼
  - `CollapsibleFilterCard` 공통 컴포넌트 적용 — 접기/펼치기 상세 필터 패널
  - `FormField` 공통 컴포넌트 적용 — 필터 라벨 래퍼 통일
  - `SearchTriggerField` 공통 컴포넌트 적용 — 기록 관리 PO 검색 필드
  - 상세검색 패널 기본값 닫힘으로 변경 (버튼 클릭 시에만 오픈)
  - 검색 버튼 클릭 시에만 필터 적용되도록 수정 (`filter*` / `applied` 상태 분리)
  - 메일 이력 유형 표기 변경 — `PI 발송` → `PI`, `PO 발송` → `PO` 등
  - 메일 이력 상태 필터에서 `대기` 제거, 더미 데이터 상태 `대기` → `발송` 수정



## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

<img width="1402" height="480" alt="image" src="https://github.com/user-attachments/assets/6a274708-5744-4e4d-a645-c3d6e004921b" />

<img width="1408" height="486" alt="image" src="https://github.com/user-attachments/assets/1b8425c7-5434-49b2-ab08-cfd11def5573" />




## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

<!-- 리뷰할 때 중점적으로 봐줬으면 하는 부분이 있다면 적어주세요 -->

- `FilterToolbarCard` + `CollapsibleFilterCard` 조합으로 기존 직접 구현했던 커스텀 토글 패널을 공통
  컴포넌트로 교체했습니다.
  - 검색 버튼 클릭 전까지 목록이 변경되지 않도록 `filter*`(입력값)와 `applied`(적용값)를 분리했습니다.
  - `FormField` 적용으로 필터 라벨 패턴이 `<p class="text-[10px]...">` 직접 구현에서 공통 컴포넌트로
  통일됐습니다.
