### PR TITLE
[refactor] 메인 대시보드 UI 정합성 및 스타일 마감

### DIFF
--- a/src/components/common/CollapsibleFilterCard.vue
+++ b/src/components/common/CollapsibleFilterCard.vue
@@ -6,35 +6,11 @@ defineProps({
     type: Boolean,
     default: false,
   },
-  title: {
-    type: String,
-    default: '상세검색',
-  },
 })
-
-const emit = defineEmits(['toggle'])
 </script>
 
 <template>
-  <BaseCard body-class="p-0">
-    <button
-      type="button"
-      class="flex w-full items-center justify-between px-5 py-3 text-left transition hover:bg-slate-50"
-      @click="emit('toggle')"
-    >
-      <span class="flex items-center gap-2 text-sm font-semibold text-slate-700">
-        <i class="fas fa-filter text-xs text-brand-500" aria-hidden="true"></i>
-        {{ title }}
-      </span>
-      <i
-        class="fas fa-chevron-up text-xs text-slate-400 transition-transform"
-        :class="open ? '' : 'rotate-180'"
-        aria-hidden="true"
-      ></i>
-    </button>
-
-    <div v-if="open" class="border-t border-slate-100 px-5 pb-3 pt-3">
+  <BaseCard v-if="open" body-class="px-5 pb-3 pt-3">
       <slot />
-    </div>
   </BaseCard>
 </template>

--- a/src/components/layout/AppHeader.vue
+++ b/src/components/layout/AppHeader.vue
@@ -74,15 +74,19 @@ onBeforeUnmount(() => {
     class="sticky top-0 z-20 flex h-[77px] flex-shrink-0 items-center justify-between gap-4 border-b border-slate-200 bg-white/90 px-6 no-print"
     style="height: 77px; min-height: 77px; backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px);"
   >
-    <div class="flex items-center gap-3">
-      <button class="flex h-9 w-9 items-center justify-center rounded-lg text-slate-400 transition hover:bg-slate-50 hover:text-slate-700 lg:hidden" @click="uiStore.toggleSidebar">
-        <span class="sr-only">메뉴</span>
-        <i class="fas fa-bars text-sm" aria-hidden="true"></i>
+    <div class="min-w-0 flex items-center gap-3">
+      <button
+        type="button"
+        class="flex h-9 w-9 items-center justify-center rounded-lg text-slate-400 transition hover:bg-slate-50 hover:text-slate-700"
+        @click="uiStore.toggleSidebar"
+      >
+        <span class="sr-only">사이드바 토글</span>
+        <i class="fas text-sm" :class="uiStore.sidebarOpen ? 'fa-bars-staggered' : 'fa-bars'" aria-hidden="true"></i>
       </button>
-      <span class="text-sm font-semibold text-[#32363A]">{{ pageTitle }}</span>
+      <span class="min-w-0 flex-1 truncate text-sm font-semibold text-[#32363A] sm:max-w-none">{{ pageTitle }}</span>
     </div>
 
-    <div class="flex items-center gap-2 sm:gap-3">
+    <div class="ml-2 flex flex-shrink-0 items-center gap-2 sm:gap-3">
       <div class="relative hidden lg:block">
         <input
           class="w-48 rounded-lg border border-slate-200 px-4 py-1.5 pl-8 text-xs font-medium text-slate-600"
@@ -111,7 +115,7 @@ onBeforeUnmount(() => {
 
         <div
           v-if="isNotificationOpen"
-          class="absolute right-0 top-11 z-50 max-h-80 w-80 overflow-y-auto rounded-xl border border-slate-200 bg-white shadow-2xl"
+          class="absolute right-0 top-11 z-50 max-h-80 w-[min(20rem,calc(100vw-2rem))] overflow-y-auto rounded-xl border border-slate-200 bg-white shadow-2xl"
         >
           <div class="border-b border-slate-200 px-4 py-3 text-sm font-semibold text-[#32363A]">알림</div>
           <div

--- a/src/components/layout/AppSidebar.vue
+++ b/src/components/layout/AppSidebar.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { computed, onMounted, ref } from 'vue'
 import { fetchNavigationItems } from '@/api/navigation'
-import { useRoute } from 'vue-router'
+import { RouterLink, useRoute } from 'vue-router'
 import { useUiStore } from '@/stores/ui'
 
 const uiStore = useUiStore()
@@ -51,12 +51,25 @@ onMounted(async () => {
 
 <template>
   <aside
-    class="fixed inset-y-3 left-3 z-30 flex w-[220px] flex-col overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm transition-transform lg:translate-x-0"
-    :class="uiStore.sidebarOpen ? 'translate-x-0' : '-translate-x-[120%]'"
+    class="fixed inset-y-3 left-3 z-30 flex w-[220px] flex-col overflow-visible rounded-lg border border-slate-200 bg-white shadow-sm transition-transform duration-200"
+    :class="uiStore.sidebarOpen ? 'translate-x-0' : '-translate-x-[188px]'"
   >
+    <button
+      type="button"
+      class="absolute -right-3 top-1/2 z-40 hidden h-16 w-3 -translate-y-1/2 items-center justify-center rounded-r-md border border-l-0 border-slate-300 bg-slate-200 text-slate-500 transition-colors duration-200 hover:bg-brand-100 hover:text-brand-600 lg:flex"
+      :aria-label="uiStore.sidebarOpen ? '사이드바 접기' : '사이드바 펼치기'"
+      @click="uiStore.toggleSidebar"
+    >
+      <i
+        class="fas text-[8px] transition-transform duration-200"
+        :class="uiStore.sidebarOpen ? 'fa-chevron-left' : 'fa-chevron-right'"
+        aria-hidden="true"
+      ></i>
+    </button>
+
     <div class="flex h-[77px] flex-shrink-0 items-center border-b border-slate-200 px-4">
-      <div class="flex w-full items-center justify-between gap-3">
-        <div class="flex items-center gap-3">
+      <div class="flex w-full items-center gap-3">
+        <RouterLink to="/" class="flex items-center gap-3">
           <div class="flex h-11 w-11 items-center justify-center overflow-hidden rounded-xl bg-white shadow-sm">
             <img src="/salesboost.svg" alt="SalesBoost" class="h-9 w-9 object-contain" />
           </div>
@@ -64,10 +77,7 @@ onMounted(async () => {
             <h1 class="truncate text-lg font-bold text-slate-900">SalesBoost</h1>
             <p class="mt-0.5 text-[11px] text-slate-400">해외 B2B 영업관리 시스템</p>
           </div>
-        </div>
-        <button class="flex h-8 w-8 items-center justify-center rounded-lg text-slate-400 transition hover:bg-slate-50 hover:text-slate-700 lg:hidden" @click="uiStore.closeSidebar">
-          닫기
-        </button>
+        </RouterLink>
       </div>
     </div>
 
@@ -89,7 +99,6 @@ onMounted(async () => {
           :to="item.path"
           class="mx-1 flex items-center gap-3 rounded-lg px-4 py-2.5 text-[12.5px] transition"
           :class="isActive(item.path) ? 'bg-slate-50 text-slate-900' : 'text-slate-600 hover:bg-slate-50 hover:text-slate-900'"
-          @click="uiStore.closeSidebar"
         >
           <i
             class="fas w-4 flex-shrink-0 text-center text-[13px]"

--- a/src/layouts/AppLayout.vue
+++ b/src/layouts/AppLayout.vue
@@ -1,15 +1,29 @@
 <script setup>
 import AppHeader from '@/components/layout/AppHeader.vue'
 import AppSidebar from '@/components/layout/AppSidebar.vue'
+import { useUiStore } from '@/stores/ui'
+
+const uiStore = useUiStore()
 </script>
 
 <template>
   <div class="min-h-screen bg-[#F5F6F7] p-3">
+    <button
+      v-if="uiStore.sidebarOpen"
+      type="button"
+      class="fixed inset-0 z-20 bg-slate-900/20 lg:hidden"
+      aria-label="사이드바 닫기"
+      @click="uiStore.closeSidebar"
+    />
+
     <AppSidebar />
 
-    <div class="flex h-[calc(100vh-1.5rem)] flex-col overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm lg:ml-[232px]">
+    <div
+      class="flex h-[calc(100vh-1.5rem)] flex-col overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm transition-[margin] duration-200"
+      :class="uiStore.sidebarOpen ? 'lg:ml-[232px]' : 'ml-[44px]'"
+    >
       <AppHeader />
-      <main class="flex-1 overflow-y-auto p-6">
+      <main class="flex-1 overflow-y-auto p-4 sm:p-6">
         <RouterView />
       </main>
     </div>

--- a/src/stores/ui.js
+++ b/src/stores/ui.js
@@ -2,7 +2,7 @@ import { ref } from 'vue'
 import { defineStore } from 'pinia'
 
 export const useUiStore = defineStore('ui', () => {
-  const sidebarOpen = ref(false)
+  const sidebarOpen = ref(typeof window !== 'undefined' ? window.innerWidth >= 1024 : true)
 
   function toggleSidebar() {
     sidebarOpen.value = !sidebarOpen.value

--- a/src/views/DashboardPage.vue
+++ b/src/views/DashboardPage.vue
@@ -1,7 +1,6 @@
 <script setup>
-import { onMounted, ref } from 'vue'
+import { ref } from 'vue'
 import { RouterLink } from 'vue-router'
-import { fetchDashboardKpis } from '@/api/dashboard'
 import BaseCard from '@/components/common/BaseCard.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
 
@@ -31,7 +30,6 @@ const summaryCards = ref([
     to: '/ci',
   },
 ])
-const isLoading = ref(true)
 
 const requestItems = [
   {
@@ -133,16 +131,6 @@ const recentActivities = [
     date: '2026/02/10',
   },
 ]
-
-onMounted(async () => {
-  try {
-    await fetchDashboardKpis()
-  } catch (error) {
-    console.error('Failed to fetch dashboard kpi data:', error)
-  } finally {
-    isLoading.value = false
-  }
-})
 </script>
 
 <template>
@@ -152,7 +140,7 @@ onMounted(async () => {
         v-for="card in summaryCards"
         :key="card.id"
         :to="card.to"
-        class="rounded-xl border border-slate-200 bg-white p-4 text-left shadow-sm transition hover:border-slate-300 hover:shadow-md"
+        class="min-h-[136px] rounded-xl border border-slate-200 bg-white p-4 text-left shadow-sm transition hover:border-slate-300 hover:shadow-md sm:min-h-[148px]"
       >
         <div class="flex items-start justify-between gap-3">
           <div class="flex h-10 w-10 items-center justify-center rounded-lg bg-slate-50">
@@ -164,13 +152,13 @@ onMounted(async () => {
           <StatusBadge :value="card.status" />
         </div>
         <div class="mt-4 flex items-end justify-between gap-3">
-          <div>
-            <div class="text-xs font-medium text-slate-500">{{ card.title }}</div>
+          <div class="min-w-0">
+            <div class="truncate text-xs font-medium text-slate-500">{{ card.title }}</div>
             <div class="mt-1 text-2xl font-bold text-slate-800">{{ card.count }}</div>
           </div>
           <i class="fas fa-chevron-right text-xs text-slate-300" />
         </div>
-        <div class="mt-3 text-xs text-slate-400">{{ card.helper }}</div>
+        <div class="mt-3 truncate text-xs text-slate-400">{{ card.helper }}</div>
       </RouterLink>
     </section>
 
@@ -189,9 +177,9 @@ onMounted(async () => {
         :key="item.id"
         class="flex cursor-pointer flex-col items-start gap-3 px-5 py-3.5 transition hover:bg-slate-50/50 sm:flex-row sm:items-center sm:justify-between"
       >
-          <div class="flex items-center gap-3">
+        <div class="flex min-w-0 items-center gap-3">
           <div
-            class="flex h-9 w-9 items-center justify-center rounded-lg"
+            class="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg"
             :class="item.actionLabel === '삭제' ? 'bg-red-50' : 'bg-blue-50'"
           >
             <i
@@ -199,16 +187,16 @@ onMounted(async () => {
               :class="item.actionLabel === '삭제' ? 'fa-trash text-red-400' : 'fa-edit text-blue-400'"
             />
           </div>
-          <div>
-            <div class="text-sm font-medium text-slate-800">
+          <div class="min-w-0">
+            <div class="truncate text-sm font-medium text-slate-800">
               {{ item.docType }} {{ item.docId }} — {{ item.actionLabel }} 결재
             </div>
-            <div class="text-xs text-slate-400">
+            <div class="truncate text-xs text-slate-400 sm:whitespace-normal">
               {{ item.company }} · 요청: {{ item.requester }} → 결재: {{ item.approver }}
             </div>
           </div>
         </div>
-          <div class="flex items-center gap-2 self-end sm:self-auto">
+        <div class="flex flex-shrink-0 items-center gap-2 self-end sm:self-auto">
           <span
             v-if="item.urgent"
             class="rounded px-1.5 py-0.5 text-[10px] font-bold text-red-600 bg-red-50"
@@ -237,13 +225,13 @@ onMounted(async () => {
             :key="item.id"
             class="group flex cursor-pointer items-start gap-3 rounded-lg px-1 py-1 text-sm transition hover:bg-slate-50/70"
           >
-          <div class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-slate-50 text-xs text-slate-500">
-            <i class="fas" :class="item.icon" />
-          </div>
-          <div class="min-w-0 flex-1">
-            <div class="truncate font-medium text-slate-800 transition group-hover:text-brand-600">{{ item.title }}</div>
-            <div class="text-xs text-slate-400">{{ item.company }} · {{ item.date }}</div>
-          </div>
+            <div class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-slate-50 text-xs text-slate-500">
+              <i class="fas" :class="item.icon" />
+            </div>
+            <div class="min-w-0 flex-1">
+              <div class="truncate font-medium text-slate-800 transition group-hover:text-brand-600">{{ item.title }}</div>
+              <div class="truncate text-xs text-slate-400 sm:whitespace-normal">{{ item.company }} · {{ item.date }}</div>
+            </div>
           </div>
         </div>
       </BaseCard>
@@ -261,14 +249,14 @@ onMounted(async () => {
           <div
             v-for="item in shipmentItems"
             :key="item.id"
-            class="flex cursor-pointer items-center justify-between rounded-xl border border-slate-100 bg-slate-50/80 p-3.5 text-sm transition hover:border-slate-200"
+            class="flex cursor-pointer flex-col items-start gap-3 rounded-xl border border-slate-100 bg-slate-50/80 p-3.5 text-sm transition hover:border-slate-200 sm:flex-row sm:items-center sm:justify-between"
           >
-            <div>
+            <div class="min-w-0">
               <div class="font-semibold text-slate-800">{{ item.shipmentNo }}</div>
-              <div class="mt-0.5 text-xs text-slate-400">{{ item.company }}</div>
-              <div class="mt-1 text-[11px] text-slate-400">{{ item.sourcePo }} · 납기 {{ item.dueDate }}</div>
+              <div class="truncate mt-0.5 text-xs text-slate-400 sm:whitespace-normal">{{ item.company }}</div>
+              <div class="truncate mt-1 text-[11px] text-slate-400 sm:whitespace-normal">{{ item.sourcePo }} · 납기 {{ item.dueDate }}</div>
             </div>
-            <div class="ml-4 flex shrink-0 items-center gap-2">
+            <div class="flex shrink-0 items-center gap-2 sm:ml-4">
               <StatusBadge :value="item.status" />
             </div>
           </div>

--- a/src/views/documents/CIPage.vue
+++ b/src/views/documents/CIPage.vue
@@ -120,15 +120,12 @@ function openProductSearch() {}
       @toggle-advanced="isAdvancedOpen = !isAdvancedOpen"
     />
 
-    <CollapsibleFilterCard
-      :open="isAdvancedOpen"
-      @toggle="isAdvancedOpen = !isAdvancedOpen"
-    >
+    <CollapsibleFilterCard :open="isAdvancedOpen">
       <div class="grid grid-cols-2 gap-3 text-sm md:grid-cols-3 lg:grid-cols-4">
         <FormField label="발행일" class="col-span-2">
-          <div class="grid grid-cols-[1fr_auto_1fr] items-end gap-1">
+          <div class="grid gap-2 sm:grid-cols-[1fr_auto_1fr] sm:items-end">
             <DateField v-model="filters.registeredFrom" />
-            <span class="pb-2 text-sm text-slate-400">~</span>
+            <span class="text-center text-sm text-slate-400 sm:pb-2">~</span>
             <DateField v-model="filters.registeredTo" />
           </div>
         </FormField>

--- a/src/views/documents/CollectionsPage.vue
+++ b/src/views/documents/CollectionsPage.vue
@@ -202,23 +202,20 @@ function formatAmount(value, currency) {
       @toggle-advanced="isAdvancedOpen = !isAdvancedOpen"
     />
 
-    <CollapsibleFilterCard
-      :open="isAdvancedOpen"
-      @toggle="isAdvancedOpen = !isAdvancedOpen"
-    >
+    <CollapsibleFilterCard :open="isAdvancedOpen">
         <div class="grid grid-cols-2 gap-x-4 gap-y-3 md:grid-cols-4">
           <FormField label="발행일" class="col-span-2">
-            <div class="grid grid-cols-[1fr_auto_1fr] items-end gap-2">
+            <div class="grid gap-2 sm:grid-cols-[1fr_auto_1fr] sm:items-end">
               <DateField v-model="filters.issueFrom" />
-              <span class="pb-2 text-xs text-slate-400">~</span>
+              <span class="text-center text-xs text-slate-400 sm:pb-2">~</span>
               <DateField v-model="filters.issueTo" />
             </div>
           </FormField>
 
           <FormField label="수금일" class="col-span-2">
-            <div class="grid grid-cols-[1fr_auto_1fr] items-end gap-2">
+            <div class="grid gap-2 sm:grid-cols-[1fr_auto_1fr] sm:items-end">
               <DateField v-model="filters.collectionFrom" />
-              <span class="pb-2 text-xs text-slate-400">~</span>
+              <span class="text-center text-xs text-slate-400 sm:pb-2">~</span>
               <DateField v-model="filters.collectionTo" />
             </div>
           </FormField>

--- a/src/views/documents/PIPage.vue
+++ b/src/views/documents/PIPage.vue
@@ -197,15 +197,12 @@ function openProductSearch() {}
       @toggle-advanced="isAdvancedOpen = !isAdvancedOpen"
     />
 
-    <CollapsibleFilterCard
-      :open="isAdvancedOpen"
-      @toggle="isAdvancedOpen = !isAdvancedOpen"
-    >
+    <CollapsibleFilterCard :open="isAdvancedOpen">
       <div class="grid grid-cols-2 gap-3 text-sm md:grid-cols-3 lg:grid-cols-4">
         <FormField label="발행일" class="col-span-2">
-          <div class="grid grid-cols-[1fr_auto_1fr] items-end gap-1">
+          <div class="grid gap-2 sm:grid-cols-[1fr_auto_1fr] sm:items-end">
             <DateField v-model="filters.registeredFrom" />
-            <span class="pb-2 text-sm text-slate-400">~</span>
+            <span class="text-center text-sm text-slate-400 sm:pb-2">~</span>
             <DateField v-model="filters.registeredTo" />
           </div>
         </FormField>
@@ -262,11 +259,11 @@ function openProductSearch() {}
         </FormField>
 
         <FormField label="납기일" class="col-span-2">
-          <div class="grid grid-cols-[1fr_auto_1fr] items-end gap-1">
+          <div class="grid gap-2 sm:grid-cols-[1fr_auto_1fr] sm:items-end">
             <div>
               <DateField v-model="filters.deliveryFrom" />
             </div>
-            <span class="pb-2 text-sm text-slate-400">~</span>
+            <span class="text-center text-sm text-slate-400 sm:pb-2">~</span>
             <div>
               <DateField v-model="filters.deliveryTo" />
             </div>

--- a/src/views/documents/PLPage.vue
+++ b/src/views/documents/PLPage.vue
@@ -120,15 +120,12 @@ function openProductSearch() {}
       @toggle-advanced="isAdvancedOpen = !isAdvancedOpen"
     />
 
-    <CollapsibleFilterCard
-      :open="isAdvancedOpen"
-      @toggle="isAdvancedOpen = !isAdvancedOpen"
-    >
+    <CollapsibleFilterCard :open="isAdvancedOpen">
       <div class="grid grid-cols-2 gap-3 text-sm md:grid-cols-3 lg:grid-cols-4">
         <FormField label="발행일" class="col-span-2">
-          <div class="grid grid-cols-[1fr_auto_1fr] items-end gap-1">
+          <div class="grid gap-2 sm:grid-cols-[1fr_auto_1fr] sm:items-end">
             <DateField v-model="filters.registeredFrom" />
-            <span class="pb-2 text-sm text-slate-400">~</span>
+            <span class="text-center text-sm text-slate-400 sm:pb-2">~</span>
             <DateField v-model="filters.registeredTo" />
           </div>
         </FormField>

--- a/src/views/documents/POPage.vue
+++ b/src/views/documents/POPage.vue
@@ -142,15 +142,12 @@ function openProductSearch() {}
       @toggle-advanced="isAdvancedOpen = !isAdvancedOpen"
     />
 
-    <CollapsibleFilterCard
-      :open="isAdvancedOpen"
-      @toggle="isAdvancedOpen = !isAdvancedOpen"
-    >
+    <CollapsibleFilterCard :open="isAdvancedOpen">
       <div class="grid grid-cols-2 gap-3 text-sm md:grid-cols-3 lg:grid-cols-4">
         <FormField label="발행일" class="col-span-2">
-          <div class="grid grid-cols-[1fr_auto_1fr] items-end gap-1">
+          <div class="grid gap-2 sm:grid-cols-[1fr_auto_1fr] sm:items-end">
             <DateField v-model="filters.registeredFrom" />
-            <span class="pb-2 text-sm text-slate-400">~</span>
+            <span class="text-center text-sm text-slate-400 sm:pb-2">~</span>
             <DateField v-model="filters.registeredTo" />
           </div>
         </FormField>
@@ -207,9 +204,9 @@ function openProductSearch() {}
         </FormField>
 
         <FormField label="납기일" class="col-span-2">
-          <div class="grid grid-cols-[1fr_auto_1fr] items-end gap-1">
+          <div class="grid gap-2 sm:grid-cols-[1fr_auto_1fr] sm:items-end">
             <DateField v-model="filters.deliveryFrom" />
-            <span class="pb-2 text-sm text-slate-400">~</span>
+            <span class="text-center text-sm text-slate-400 sm:pb-2">~</span>
             <DateField v-model="filters.deliveryTo" />
           </div>
         </FormField>

--- a/src/views/documents/ProductionOrderPage.vue
+++ b/src/views/documents/ProductionOrderPage.vue
@@ -146,15 +146,12 @@ function openProductSearch() {}
       @toggle-advanced="isAdvancedOpen = !isAdvancedOpen"
     />
 
-    <CollapsibleFilterCard
-      :open="isAdvancedOpen"
-      @toggle="isAdvancedOpen = !isAdvancedOpen"
-    >
+    <CollapsibleFilterCard :open="isAdvancedOpen">
       <div class="grid grid-cols-2 gap-3 text-sm md:grid-cols-3 lg:grid-cols-4">
         <FormField label="생산지시일" class="col-span-2">
-          <div class="grid grid-cols-[1fr_auto_1fr] items-end gap-1">
+          <div class="grid gap-2 sm:grid-cols-[1fr_auto_1fr] sm:items-end">
             <DateField v-model="filters.registeredFrom" />
-            <span class="pb-2 text-sm text-slate-400">~</span>
+            <span class="text-center text-sm text-slate-400 sm:pb-2">~</span>
             <DateField v-model="filters.registeredTo" />
           </div>
         </FormField>
@@ -211,9 +208,9 @@ function openProductSearch() {}
         </FormField>
 
         <FormField label="납기일" class="col-span-2">
-          <div class="grid grid-cols-[1fr_auto_1fr] items-end gap-1">
+          <div class="grid gap-2 sm:grid-cols-[1fr_auto_1fr] sm:items-end">
             <DateField v-model="filters.deliveryFrom" />
-            <span class="pb-2 text-sm text-slate-400">~</span>
+            <span class="text-center text-sm text-slate-400 sm:pb-2">~</span>
             <DateField v-model="filters.deliveryTo" />
           </div>
         </FormField>

--- a/src/views/documents/ShipmentOrderPage.vue
+++ b/src/views/documents/ShipmentOrderPage.vue
@@ -145,15 +145,12 @@ function openProductSearch() {}
       @toggle-advanced="isAdvancedOpen = !isAdvancedOpen"
     />
 
-    <CollapsibleFilterCard
-      :open="isAdvancedOpen"
-      @toggle="isAdvancedOpen = !isAdvancedOpen"
-    >
+    <CollapsibleFilterCard :open="isAdvancedOpen">
       <div class="grid grid-cols-2 gap-3 text-sm md:grid-cols-3 lg:grid-cols-4">
         <FormField label="출하지시일" class="col-span-2">
-          <div class="grid grid-cols-[1fr_auto_1fr] items-end gap-1">
+          <div class="grid gap-2 sm:grid-cols-[1fr_auto_1fr] sm:items-end">
             <DateField v-model="filters.registeredFrom" />
-            <span class="pb-2 text-sm text-slate-400">~</span>
+            <span class="text-center text-sm text-slate-400 sm:pb-2">~</span>
             <DateField v-model="filters.registeredTo" />
           </div>
         </FormField>
@@ -210,9 +207,9 @@ function openProductSearch() {}
         </FormField>
 
         <FormField label="납기일" class="col-span-2">
-          <div class="grid grid-cols-[1fr_auto_1fr] items-end gap-1">
+          <div class="grid gap-2 sm:grid-cols-[1fr_auto_1fr] sm:items-end">
             <DateField v-model="filters.deliveryFrom" />
-            <span class="pb-2 text-sm text-slate-400">~</span>
+            <span class="text-center text-sm text-slate-400 sm:pb-2">~</span>
             <DateField v-model="filters.deliveryTo" />
           </div>
         </FormField>

--- a/src/views/documents/ShipmentsPage.vue
+++ b/src/views/documents/ShipmentsPage.vue
@@ -108,15 +108,12 @@ function openClientSearch() {}
       @toggle-advanced="isAdvancedOpen = !isAdvancedOpen"
     />
 
-    <CollapsibleFilterCard
-      :open="isAdvancedOpen"
-      @toggle="isAdvancedOpen = !isAdvancedOpen"
-    >
+    <CollapsibleFilterCard :open="isAdvancedOpen">
         <div class="grid grid-cols-2 gap-x-4 gap-y-3 md:grid-cols-4">
           <FormField label="출하요청일" class="col-span-2">
-            <div class="grid grid-cols-[1fr_auto_1fr] items-end gap-2">
+            <div class="grid gap-2 sm:grid-cols-[1fr_auto_1fr] sm:items-end">
               <DateField v-model="filters.requestFrom" />
-              <span class="pb-2 text-xs text-slate-400">~</span>
+              <span class="text-center text-xs text-slate-400 sm:pb-2">~</span>
               <DateField v-model="filters.requestTo" />
             </div>
           </FormField>
@@ -139,9 +136,9 @@ function openClientSearch() {}
           </FormField>
 
           <FormField label="납기일" class="col-span-2">
-            <div class="grid grid-cols-[1fr_auto_1fr] items-end gap-2">
+            <div class="grid gap-2 sm:grid-cols-[1fr_auto_1fr] sm:items-end">
               <DateField v-model="filters.dueFrom" />
-              <span class="pb-2 text-xs text-slate-400">~</span>
+              <span class="text-center text-xs text-slate-400 sm:pb-2">~</span>
               <DateField v-model="filters.dueTo" />
             </div>
           </FormField>


### PR DESCRIPTION

  ## 📋 작업 내용

메인 대시보드 화면의 UI를 다시 점검하고, 문구/레이아웃/반응형 흐름을 최종 정리했습니다.
상단 사용자 액션 영역, 좌측 사이드바, 문서 카드 3종, 결재란, 최근 활동, 출하 현황 리스트의 간격과 정렬을 보정했고, 화면을 줄였을 때 제목/카드/리스트/상세검색 영역이 깨지지 않도록 반응형도 함께 마감했습니다.

추가로 사이드바 접기/펼치기 흐름을 보완해 접힌 상태에서도 일부가 보이도록 했고, 바깥 클릭으로 닫히는 동작과 로고 클릭 시 메인 이동 흐름도 정리했습니다.
상세검색 내부 중복 토글은 제거하고, 공통 상세검색 카드/헤더/레이아웃 수정 영향도 함께 확인했습니다.

  ## 🔗 관련 이슈

  - closes #50 

  ## 📸 스크린샷 (선택)

 
# 화면 축소 시 헤더/사이드바/카드/리스트 반응형 확인 화면
<img width="1128" height="1792" alt="image" src="https://github.com/user-attachments/assets/47334686-49e2-4cc5-93e2-82330d93895d" />


#  메인 대시보드 기본 화면
<img width="3400" height="1794" alt="image" src="https://github.com/user-attachments/assets/ed61dcec-9457-4c5e-994a-55efc6b0ac82" />

 # 사이드바 접기 
<img width="3404" height="1788" alt="image" src="https://github.com/user-attachments/assets/9e283cdc-bda5-4cf7-b7c2-d3864fbeeb93" />

# 상세검색 반응형 확인 화면
<img width="1768" height="1776" alt="image" src="https://github.com/user-attachments/assets/0a483625-666a-4d94-b128-84a08eef1bc0" />

  ## ✅ 체크리스트

  - [x] 정상 동작 확인
  - [x] 불필요한 코드/주석 제거
  - [x] 충돌(conflict) 해결 완료

  ## 💬 리뷰어에게

이번 PR은 기능 추가보다 메인 대시보드와 공통 레이아웃의 UI 정합성 마감에 초점을 둔 작업입니다.
특히 화면 축소 시 헤더 제목, 사이드바 접힘 상태, 대시보드 카드/리스트, 상세검색 날짜 범위가 자연스럽게 보이는지와 공통 레이아웃 수정이 다른 화면에 부작용 없이 적용되는지 중심으로 봐주시면 됩니다.
