### PR TITLE
[feat] 메인 대시보드 액션 및 화면 이동 연결

### DIFF
--- a/src/components/layout/AppHeader.vue
+++ b/src/components/layout/AppHeader.vue
@@ -1,11 +1,12 @@
 <script setup>
 import { computed, onBeforeUnmount, ref } from 'vue'
-import { useRoute } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import PasswordChangeModal from '@/components/domain/auth/PasswordChangeModal.vue'
 import { useUiStore } from '@/stores/ui'
 
 const uiStore = useUiStore()
 const route = useRoute()
+const router = useRouter()
 const pageTitle = computed(() => String(route.meta.serviceName ?? '공통 대시보드'))
 const isNotificationOpen = ref(false)
 const isPasswordModalOpen = ref(false)
@@ -18,6 +19,11 @@ const notifications = [
     message: '김영업(과장)이 PO26002 수정 결재를 요청했습니다.',
     time: '2026/03/15 10:00',
     unread: true,
+    to: '/po',
+    query: {
+      code: 'PO26002',
+      source: 'header-notification',
+    },
   },
   {
     id: 2,
@@ -25,6 +31,11 @@ const notifications = [
     message: '정영업(대리)이 PO26004 삭제 결재를 요청했습니다.',
     time: '2026/03/14 09:30',
     unread: true,
+    to: '/po',
+    query: {
+      code: 'PO26004',
+      source: 'header-notification',
+    },
   },
   {
     id: 3,
@@ -32,6 +43,11 @@ const notifications = [
     message: 'SH26002 출하완료 처리되었습니다.',
     time: '2026/04/10 09:00',
     unread: true,
+    to: '/shipments',
+    query: {
+      code: 'SH26002',
+      source: 'header-notification',
+    },
   },
   {
     id: 4,
@@ -39,6 +55,11 @@ const notifications = [
     message: 'PO26003 잔금 입금 확인. 완납 처리.',
     time: '2026/05/05 11:00',
     unread: false,
+    to: '/collections',
+    query: {
+      code: 'PO26003',
+      source: 'header-notification',
+    },
   },
 ]
 
@@ -54,6 +75,14 @@ function openPasswordModal() {
 
 function closePasswordModal() {
   isPasswordModalOpen.value = false
+}
+
+function goToNotification(notification) {
+  isNotificationOpen.value = false
+  router.push({
+    path: notification.to,
+    query: notification.query,
+  })
 }
 
 function handleClickOutside(event) {
@@ -124,6 +153,7 @@ onBeforeUnmount(() => {
             class="cursor-pointer px-4 py-3 transition hover:bg-slate-50"
             :class="notification.unread ? 'bg-[#EEF2FF]' : ''"
             style="border-bottom: 1px solid #E5E7EB;"
+            @click="goToNotification(notification)"
           >
             <div class="text-sm font-medium" :class="notification.unread ? 'text-[#32363A]' : 'text-slate-500'">
               {{ notification.title }}

--- a/src/views/DashboardPage.vue
+++ b/src/views/DashboardPage.vue
@@ -1,8 +1,10 @@
 <script setup>
 import { ref } from 'vue'
-import { RouterLink } from 'vue-router'
+import { RouterLink, useRouter } from 'vue-router'
 import BaseCard from '@/components/common/BaseCard.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
+
+const router = useRouter()
 
 const summaryCards = ref([
   {
@@ -131,6 +133,38 @@ const recentActivities = [
     date: '2026/02/10',
   },
 ]
+
+function goToRequestItem(item) {
+  const targetPath = item.docType === 'PI' ? '/pi' : '/po'
+
+  router.push({
+    path: targetPath,
+    query: {
+      code: item.docId,
+      source: 'dashboard-request',
+    },
+  })
+}
+
+function goToActivityItem(item) {
+  router.push({
+    path: '/activities',
+    query: {
+      keyword: item.company,
+      source: 'dashboard-activity',
+    },
+  })
+}
+
+function goToShipmentItem(item) {
+  router.push({
+    path: '/shipments',
+    query: {
+      code: item.shipmentNo,
+      source: 'dashboard-shipment',
+    },
+  })
+}
 </script>
 
 <template>
@@ -176,6 +210,7 @@ const recentActivities = [
         v-for="item in requestItems"
         :key="item.id"
         class="flex cursor-pointer flex-col items-start gap-3 px-5 py-3.5 transition hover:bg-slate-50/50 sm:flex-row sm:items-center sm:justify-between"
+        @click="goToRequestItem(item)"
       >
         <div class="flex min-w-0 items-center gap-3">
           <div
@@ -224,6 +259,7 @@ const recentActivities = [
             v-for="item in recentActivities"
             :key="item.id"
             class="group flex cursor-pointer items-start gap-3 rounded-lg px-1 py-1 text-sm transition hover:bg-slate-50/70"
+            @click="goToActivityItem(item)"
           >
             <div class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-slate-50 text-xs text-slate-500">
               <i class="fas" :class="item.icon" />
@@ -250,6 +286,7 @@ const recentActivities = [
             v-for="item in shipmentItems"
             :key="item.id"
             class="flex cursor-pointer flex-col items-start gap-3 rounded-xl border border-slate-100 bg-slate-50/80 p-3.5 text-sm transition hover:border-slate-200 sm:flex-row sm:items-center sm:justify-between"
+            @click="goToShipmentItem(item)"
           >
             <div class="min-w-0">
               <div class="font-semibold text-slate-800">{{ item.shipmentNo }}</div>


### PR DESCRIPTION
  ## 📋 작업 내용

메인 대시보드에서 아직 연결되지 않았던 액션들을 실제 화면 이동 흐름에 맞게 연결했습니다.
결재란, 최근 활동, 출하 현황 리스트 항목 클릭 시 관련 화면으로 이동하도록 반영했고, 헤더 알림 항목도 유형에 따라 문서/현황 화면으로 이동하도록 정리했습니다.

추가로 대시보드와 공통 레이아웃 영역에서 반응형과 UI 정합성을 함께 보정했습니다.
사이드바 접힘 상태, 헤더 제목 overflow, 알림 드롭다운 폭, 상세검색 날짜 범위 레이아웃도 같이 정리해 화면 축소 시 깨지지 않도록 마감했습니다.

  ## 🔗 관련 이슈

  - closes #54 

  ## 📸 스크린샷 (선택)


  ## ✅ 체크리스트

  - [x] 정상 동작 확인
  - [x] 불필요한 코드/주석 제거
  - [x] 충돌(conflict) 해결 완료

  ## 💬 리뷰어에게

이번 PR은 메인 대시보드의 기능 연결 단계에 해당합니다.
이미 연결돼 있던 문서 카드와 전체보기를 제외하고, 남아 있던 리스트/알림 항목 이동을 중심으로 정리했습니다. 대시보드에서 각 항목 클릭 시 자연스럽게 관련 화면으로 이동하는지와, 최근 공통 레이아웃 수정이 다른 화면에 부작용 없이 적용되는지 중심으로 봐주시면 됩니다.