### PR TITLE
feat: BasePagination 공통 컴포넌트 구현

### DIFF
--- a/src/components/common/BasePagination.vue
+++ b/src/components/common/BasePagination.vue
@@ -1,0 +1,154 @@
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  currentPage: {
+    type: Number,
+    default: 1,
+  },
+  totalPages: {
+    type: Number,
+    default: 1,
+  },
+  maxVisiblePages: {
+    type: Number,
+    default: 5,
+  },
+})
+
+const emit = defineEmits(['update:currentPage'])
+
+// ── computed ───────────────────────────────────────────────
+const safeTotalPages = computed(() => Math.max(1, props.totalPages))
+
+const isFirst = computed(() => props.currentPage === 1)
+const isLast  = computed(() => props.currentPage === safeTotalPages.value)
+
+const visiblePages = computed(() => {
+  const total   = safeTotalPages.value
+  const current = props.currentPage
+  const max     = props.maxVisiblePages
+
+  if (total <= max) {
+    return Array.from({ length: total }, (_, i) => i + 1)
+  }
+
+  const half  = Math.floor((max - 1) / 2)
+  let start   = current - half
+  let end     = start + max - 1
+
+  if (start < 1) {
+    start = 1
+    end   = max
+  }
+
+  if (end > total) {
+    end   = total
+    start = total - max + 1
+  }
+
+  return Array.from({ length: end - start + 1 }, (_, i) => start + i)
+})
+
+const showStartEllipsis = computed(() => visiblePages.value[0] > 1)
+const showEndEllipsis   = computed(() => visiblePages.value[visiblePages.value.length - 1] < safeTotalPages.value)
+
+// ── methods ────────────────────────────────────────────────
+function goTo(page) {
+  if (page < 1 || page > safeTotalPages.value || page === props.currentPage) return
+  emit('update:currentPage', page)
+}
+</script>
+
+<template>
+  <div class="flex items-center justify-center gap-1">
+
+    <!-- 맨 처음 -->
+    <button
+      type="button"
+      class="flex h-8 w-8 items-center justify-center rounded-lg text-sm transition disabled:cursor-not-allowed disabled:opacity-30"
+      :class="isFirst ? 'text-slate-300' : 'text-slate-500 hover:bg-slate-100 hover:text-slate-700'"
+      :disabled="isFirst"
+      aria-label="첫 페이지"
+      @click="goTo(1)"
+    >
+      «
+    </button>
+
+    <!-- 이전 -->
+    <button
+      type="button"
+      class="flex h-8 w-8 items-center justify-center rounded-lg text-sm transition disabled:cursor-not-allowed disabled:opacity-30"
+      :class="isFirst ? 'text-slate-300' : 'text-slate-500 hover:bg-slate-100 hover:text-slate-700'"
+      :disabled="isFirst"
+      aria-label="이전 페이지"
+      @click="goTo(currentPage - 1)"
+    >
+      ‹
+    </button>
+
+    <!-- 앞 말줄임 -->
+    <template v-if="showStartEllipsis">
+      <button
+        type="button"
+        class="flex h-8 w-8 items-center justify-center rounded-lg text-sm text-slate-500 transition hover:bg-slate-100"
+        @click="goTo(1)"
+      >
+        1
+      </button>
+      <span class="flex h-8 w-6 items-center justify-center text-xs text-slate-400">···</span>
+    </template>
+
+    <!-- 페이지 번호 -->
+    <button
+      v-for="page in visiblePages"
+      :key="page"
+      type="button"
+      class="flex h-8 w-8 items-center justify-center rounded-lg text-sm font-medium transition"
+      :class="page === currentPage
+        ? 'bg-brand-500 text-white shadow-sm'
+        : 'text-slate-600 hover:bg-slate-100 hover:text-slate-800'"
+      :aria-current="page === currentPage ? 'page' : undefined"
+      @click="goTo(page)"
+    >
+      {{ page }}
+    </button>
+
+    <!-- 뒤 말줄임 -->
+    <template v-if="showEndEllipsis">
+      <span class="flex h-8 w-6 items-center justify-center text-xs text-slate-400">···</span>
+      <button
+        type="button"
+        class="flex h-8 w-8 items-center justify-center rounded-lg text-sm text-slate-500 transition hover:bg-slate-100"
+        @click="goTo(safeTotalPages)"
+      >
+        {{ safeTotalPages }}
+      </button>
+    </template>
+
+    <!-- 다음 -->
+    <button
+      type="button"
+      class="flex h-8 w-8 items-center justify-center rounded-lg text-sm transition disabled:cursor-not-allowed disabled:opacity-30"
+      :class="isLast ? 'text-slate-300' : 'text-slate-500 hover:bg-slate-100 hover:text-slate-700'"
+      :disabled="isLast"
+      aria-label="다음 페이지"
+      @click="goTo(currentPage + 1)"
+    >
+      ›
+    </button>
+
+    <!-- 맨 마지막 -->
+    <button
+      type="button"
+      class="flex h-8 w-8 items-center justify-center rounded-lg text-sm transition disabled:cursor-not-allowed disabled:opacity-30"
+      :class="isLast ? 'text-slate-300' : 'text-slate-500 hover:bg-slate-100 hover:text-slate-700'"
+      :disabled="isLast"
+      aria-label="마지막 페이지"
+      @click="goTo(safeTotalPages)"
+    >
+      »
+    </button>
+
+  </div>
+</template>


### PR DESCRIPTION
## 📋 작업 내용

`BasePagination.vue` 공통 페이지네이션 컴포넌트 구현

- 첫 페이지(`«`) / 이전(`‹`) / 페이지 번호 / 다음(`›`) / 마지막(`»`) 버튼 구현
- 현재 페이지 하이라이트 스타일 적용 (`bg-brand-500 text-white`)
- 첫 페이지에서 `«` `‹` 비활성화, 마지막 페이지에서 `›` `»` 비활성화
- 슬라이딩 윈도우 방식으로 페이지 범위 표시 (`maxVisiblePages` 기준)
- 범위 밖 앞/뒤에 말줄임(`···`) + 첫/끝 페이지 번호 버튼 표시
- `v-model:currentPage` 지원 (`update:currentPage` emit)
- `maxVisiblePages` 짝수 입력 시 버튼 수 정확히 보장하도록 슬라이딩 윈도우 로직 개선
- `totalPages === 0` 엣지케이스 `safeTotalPages = Math.max(1, totalPages)` 로 방어 처리

## 🔗 관련 이슈

- closes #49

## 📸 스크린샷 (선택)

<!-- 페이지네이션 UI 스크린샷 첨부 -->

## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

- `BasePagination`은 순수 UI 컴포넌트로 API 연동 없이 `totalPages` prop만 받아 동작합니다.
- 각 도메인 목록 화면에서 `v-model:current-page` + `:total-pages` 로 붙이면 됩니다.
- 사용 예시:
```vue
<BasePagination
  v-model:current-page="page"
  :total-pages="totalPages"
  :max-visible-pages="5"
/>
```