### PR TITLE
feat: TableActions 공통 컴포넌트 구현

### DIFF
--- a/src/components/common/TableActions.vue
+++ b/src/components/common/TableActions.vue
@@ -35,7 +35,7 @@ defineEmits(['edit', 'delete'])
         ? 'cursor-not-allowed text-slate-300'
         : 'text-brand-500 hover:text-brand-700'"
       :disabled="disabled"
-      @click.stop="$emit('edit')"
+      @click.stop="!disabled && $emit('edit')"
     >
       {{ editLabel }}
     </button>
@@ -48,7 +48,7 @@ defineEmits(['edit', 'delete'])
         ? 'cursor-not-allowed text-slate-300'
         : 'text-slate-400 hover:text-red-500'"
       :disabled="disabled"
-      @click.stop="$emit('delete')"
+      @click.stop="!disabled && $emit('delete')"
     >
       {{ deleteLabel }}
     </button>


### PR DESCRIPTION
## 📋 작업 내용

`TableActions.vue` 공통 테이블 액션 버튼 컴포넌트 구현

- 수정/삭제 버튼을 공통 컴포넌트로 통일 (activity 도메인 스타일 기준)
- `showEdit` / `showDelete` prop으로 버튼 노출 여부 제어
- `editLabel` / `deleteLabel` prop으로 버튼 텍스트 커스텀 가능 (기본값: `수정` / `삭제`)
- `disabled` prop 지원 — 비활성화 시 `text-slate-300 cursor-not-allowed`
- `@edit` / `@delete` 이벤트 emit
- `<slot />` 제공 — 미리보기·인쇄 등 추가 액션을 자유롭게 삽입 가능
- `@click.stop` 처리 — 테이블 행 클릭 이벤트와 충돌 방지

**사용 예시:**
```vue
<!-- 기본 사용 -->
<TableActions @edit="openEdit(row)" @delete="openDelete(row)" />

<!-- 버튼 일부만 표시 -->
<TableActions :show-delete="false" @edit="openEdit(row)" />

<!-- 추가 액션 삽입 -->
<TableActions @edit="openEdit(row)" @delete="openDelete(row)">
  <button class="text-xs text-slate-400 hover:text-slate-600" @click.stop="preview(row)">미리보기</button>
</TableActions>
```

## 🔗 관련 이슈

- closes #51

## 📸 스크린샷 (선택)

<!-- 테이블 액션 버튼 스크린샷 첨부 -->

## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

- activity 도메인 기준 스타일로 통일했습니다 (`text-brand-500` / `text-slate-400 hover:text-red-500`)
- `<slot />`으로 documents 도메인의 미리보기·인쇄 버튼 등 추가 액션도 유연하게 지원합니다.
- 기존 도메인 화면에서는 `#cell-actions` 슬롯 내의 버튼을 `<TableActions>`로 교체하면 됩니다.