### PR TITLE
feat: SearchableCombobox 선택 후 전체 옵션 복원 기능 개선

### DIFF
--- a/src/components/common/SearchableCombobox.vue
+++ b/src/components/common/SearchableCombobox.vue
@@ -30,6 +30,7 @@ const wrapperRef = ref(null)
 const inputValue = ref('')
 const isOpen = ref(false)
 const highlightedIndex = ref(-1)
+const isSelected = ref(false)
 
 function normalizeOption(option) {
   if (typeof option === 'object' && option !== null) {
@@ -50,6 +51,10 @@ function normalizeOption(option) {
 const normalizedOptions = computed(() => props.options.map(normalizeOption))
 
 const filteredOptions = computed(() => {
+  if (isSelected.value) {
+    return normalizedOptions.value
+  }
+
   const query = inputValue.value.trim().toLowerCase()
 
   if (!query) {
@@ -86,6 +91,7 @@ function closeList() {
 
 function selectOption(option) {
   inputValue.value = option.label
+  isSelected.value = true
   emit('update:modelValue', option.value)
   emit('select', option)
   closeList()
@@ -115,9 +121,20 @@ function onKeydown(event) {
     return
   }
 
+  if (event.key === 'Tab' && highlightedIndex.value >= 0) {
+    event.preventDefault()
+    selectOption(filteredOptions.value[highlightedIndex.value])
+    return
+  }
+
   if (event.key === 'Escape') {
     closeList()
   }
+}
+
+function onInput() {
+  isSelected.value = false
+  openList()
 }
 
 function handleClickOutside(event) {
@@ -142,7 +159,7 @@ onBeforeUnmount(() => {
         :disabled="disabled"
         class="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 pr-10 text-sm text-ink transition duration-200 placeholder:text-slate-400 focus:border-brand focus:outline-none focus:ring-4 focus:ring-brand/15 disabled:cursor-not-allowed disabled:bg-slate-100 disabled:text-slate-400"
         @focus="openList"
-        @input="openList"
+        @input="onInput"
         @keydown="onKeydown"
       />
       <span class="pointer-events-none absolute inset-y-0 right-3 flex items-center text-slate-400">


### PR DESCRIPTION
## 📋 작업 내용

`SearchableCombobox` 컴포넌트 선택 완료 후 드롭다운 재오픈 시 전체 옵션 목록 복원 기능 개선

- `isSelected` 내부 상태 추가 — 선택 완료 여부 추적
- `filteredOptions` — `isSelected === true`이면 필터링 없이 전체 목록 반환
- `selectOption` — 항목 선택 시 `isSelected = true` 설정 (클릭·Enter·Tab 모두 동일)
- `onInput` 함수 분리 — 사용자가 다시 타이핑하면 `isSelected = false` → 필터링 모드 복귀
- Tab 키 선택 확정 추가 — `event.preventDefault()`로 포커스 이동 방지 후 선택 처리

**동작 흐름:**
1. 타이핑 → 키워드 기반 필터링 (기존 동작 유지)
2. 항목 선택 (클릭/Enter/Tab) → `isSelected = true`
3. 드롭다운 재오픈 → 전체 옵션 목록 표시
4. 다시 타이핑 → `isSelected = false` → 필터링 모드 복귀

## 🔗 관련 이슈

- closes #59

## 📸 스크린샷 (선택)

<!-- 선택 후 드롭다운 재오픈 시 전체 목록 표시 스크린샷 첨부 -->

## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

- `SearchableCombobox`는 활동기록·컨텍리스트·거래처·documents 등 공통으로 사용 중인 컴포넌트로, 이번 수정이 전체에 일괄 적용됩니다.
- 기존 동작(타이핑 시 필터링)은 그대로 유지되며, `isSelected` 상태만 추가하여 최소한의 변경으로 개선했습니다.
- 영향 범위가 넓은 컴포넌트인 만큼 꼼꼼한 리뷰 부탁드립니다.