### PR TITLE
[refactor} SearchableCombobox 선택 후 전체 옵션 복원 및 IME 입력 처리 개선 (#59)

### DIFF
--- a/src/components/common/SearchableCombobox.vue
+++ b/src/components/common/SearchableCombobox.vue
@@ -28,9 +28,11 @@ const emit = defineEmits(['update:modelValue', 'select'])
 
 const wrapperRef = ref(null)
 const inputValue = ref('')
+const rawQuery = ref('') // event.target.value 기반 — IME 조합 중에도 실시간 반영
 const isOpen = ref(false)
 const highlightedIndex = ref(-1)
 const isSelected = ref(false)
+const lastSelectedLabel = ref('')
 
 function normalizeOption(option) {
   if (typeof option === 'object' && option !== null) {
@@ -55,15 +57,15 @@ const filteredOptions = computed(() => {
     return normalizedOptions.value
   }
 
-  const query = inputValue.value.trim().toLowerCase()
+  const query = rawQuery.value.trim().toLowerCase()
 
   if (!query) {
     return normalizedOptions.value
   }
 
   return normalizedOptions.value.filter((option) => (
-    option.label.toLowerCase().includes(query) ||
-    option.sublabel.toLowerCase().includes(query)
+    option.label.toLowerCase().startsWith(query) ||
+    option.sublabel.toLowerCase().startsWith(query)
   ))
 })
 
@@ -71,10 +73,17 @@ watch(
   () => props.modelValue,
   (value) => {
     const matched = normalizedOptions.value.find((option) => String(option.value) === String(value))
-    inputValue.value = matched?.label ?? ''
+    const label = matched?.label ?? ''
+    inputValue.value = label
+    rawQuery.value = label
   },
   { immediate: true },
 )
+
+function onInput(event) {
+  rawQuery.value = event.target.value
+  openList()
+}
 
 function openList() {
   if (props.disabled) {
@@ -91,6 +100,8 @@ function closeList() {
 
 function selectOption(option) {
   inputValue.value = option.label
+  rawQuery.value = option.label
+  lastSelectedLabel.value = option.label
   isSelected.value = true
   emit('update:modelValue', option.value)
   emit('select', option)
@@ -98,6 +109,9 @@ function selectOption(option) {
 }
 
 function onKeydown(event) {
+  // IME 조합 중(한글·일본어·중국어 입력 중)에는 키보드 처리 건너뜀
+  if (event.isComposing) return
+
   if (!isOpen.value && ['ArrowDown', 'ArrowUp'].includes(event.key)) {
     openList()
     return
@@ -115,9 +129,13 @@ function onKeydown(event) {
     return
   }
 
-  if (event.key === 'Enter' && highlightedIndex.value >= 0) {
+  if (event.key === 'Enter') {
     event.preventDefault()
-    selectOption(filteredOptions.value[highlightedIndex.value])
+    if (!isOpen.value) return
+    const target = highlightedIndex.value >= 0
+      ? filteredOptions.value[highlightedIndex.value]
+      : filteredOptions.value[0]
+    if (target) selectOption(target)
     return
   }
 
@@ -127,15 +145,26 @@ function onKeydown(event) {
     return
   }
 
+  if (event.key === 'Backspace') {
+    event.preventDefault()
+    inputValue.value = ''
+    rawQuery.value = ''
+    isSelected.value = false
+    lastSelectedLabel.value = ''
+    emit('update:modelValue', '')
+    return
+  }
+
   if (event.key === 'Escape') {
     closeList()
   }
 }
 
-function onInput() {
-  isSelected.value = false
-  openList()
-}
+watch(rawQuery, (newValue) => {
+  if (isSelected.value && newValue !== lastSelectedLabel.value) {
+    isSelected.value = false
+  }
+}, { flush: 'sync' })
 
 function handleClickOutside(event) {
   if (wrapperRef.value && !wrapperRef.value.contains(event.target)) {


### PR DESCRIPTION
## 📋 작업 내용

<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
`SearchableCombobox` 선택 완료 후 전체 옵션 복원 및 IME(한글) 입력 처리 개선

  - `isSelected` / `rawQuery` / `lastSelectedLabel` 내부 상태 추가
  - 항목 선택 후 드롭다운 재오픈 시 전체 목록 표시
  - 재타이핑 시 `rawQuery` 기반으로 필터링 모드 자동 복귀
  - `event.target.value` 기반 `rawQuery`로 한글 IME 조합 중에도 실시간 필터링 동작
  - `startsWith` 필터링 적용 — 입력값으로 시작하는 옵션만 표시
  - Enter 키 — 드롭다운 열려있을 때만 선택 처리 (선택 후 재Enter 방지)
  - Enter 키 — 하이라이트 없으면 첫 번째 옵션 자동 선택
  - Tab 키 — 선택 확정 + `event.preventDefault()`로 포커스 이동 방지
  - Backspace 키 — 입력값 전체 삭제 및 상태 초기화
  - IME 조합 중 `event.isComposing` 체크로 키보드 핸들러 건너뜀


## 🔗 관련 이슈

<!-- 관련 이슈 번호를 적어주세요 (자동으로 이슈가 닫힙니다) -->
- closes 59#

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->



## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

<!-- 리뷰할 때 중점적으로 봐줬으면 하는 부분이 있다면 적어주세요 -->
- `SearchableCombobox`는 활동기록·컨텍리스트·거래처·CI/PO 등 전 도메인에서 공통으로 사용 중이므로 꼼꼼한 리뷰
  부탁드립니다.
- `rawQuery`(`event.target.value` 기반)를 필터링 쿼리로 분리하여 `v-model`의 IME 지연 업데이트 문제를
  해결했습니다.
- 기존 영문 입력 동작은 그대로 유지됩니다.

