### PR TITLE
[feat] 출하지시서·생산지시서 상세 및 문서 액션 연결

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -12,8 +12,11 @@ import PLPage from '@/views/documents/PLPage.vue'
 import POPage from '@/views/documents/POPage.vue'
 import PODetailPage from '@/views/documents/PODetailPage.vue'
 import ProductionOrderPage from '@/views/documents/ProductionOrderPage.vue'
+import ProductionOrderDetailPage from '@/views/documents/ProductionOrderDetailPage.vue'
 import ShipmentsPage from '@/views/documents/ShipmentsPage.vue'
+import ShipmentsDetailPage from '@/views/documents/ShipmentsDetailPage.vue'
 import ShipmentOrderPage from '@/views/documents/ShipmentOrderPage.vue'
+import ShipmentOrderDetailPage from '@/views/documents/ShipmentOrderDetailPage.vue'
 import ServicePage from '@/views/ServicePage.vue'
 import ActivityListPage from '@/views/activity/ActivityListPage.vue'
 import ActivityCreatePage from '@/views/activity/ActivityCreatePage.vue'
@@ -200,6 +203,16 @@ const routes = [
         },
       },
       {
+        path: 'production/:id',
+        name: 'production-detail',
+        component: ProductionOrderDetailPage,
+        meta: {
+          title: 'Production Detail',
+          serviceName: '생산지시서 상세',
+          description: '생산지시서 상세 조회 화면',
+        },
+      },
+      {
         path: 'shipment-orders',
         name: 'shipment-orders',
         component: ShipmentOrderPage,
@@ -207,6 +220,16 @@ const routes = [
           title: 'Shipment Orders',
           serviceName: '출하 관리',
           description: '출하지시서 관리 화면',
+        },
+      },
+      {
+        path: 'shipment-orders/:id',
+        name: 'shipment-order-detail',
+        component: ShipmentOrderDetailPage,
+        meta: {
+          title: 'Shipment Order Detail',
+          serviceName: '출하지시서 상세',
+          description: '출하지시서 상세 조회 화면',
         },
       },
       {
@@ -227,6 +250,16 @@ const routes = [
           title: 'Shipments',
           serviceName: '출하현황',
           description: '출하 진행 현황 화면',
+        },
+      },
+      {
+        path: 'shipments/:id',
+        name: 'shipment-detail',
+        component: ShipmentsDetailPage,
+        meta: {
+          title: 'Shipment Detail',
+          serviceName: '출하현황 상세',
+          description: '출하현황 상세 조회 화면',
         },
       },
       {

--- a/src/utils/documentOutput.js
+++ b/src/utils/documentOutput.js
@@ -1,0 +1,102 @@
+export function buildDocumentOutputHtml({ title, documentId, fields = [], lineItems = [] }) {
+  const fieldRows = fields.map((field) => `
+    <tr>
+      <th>${escapeHtml(field.label)}</th>
+      <td>${escapeHtml(field.value ?? '-')}</td>
+    </tr>
+  `).join('')
+
+  const lineItemRows = lineItems.length
+    ? lineItems.map((item) => `
+        <tr>
+          <td>${escapeHtml(item.name ?? '-')}</td>
+          <td>${escapeHtml(item.quantity ?? '-')}</td>
+          <td>${escapeHtml(item.unitPrice ?? '-')}</td>
+          <td>${escapeHtml(item.amount ?? '-')}</td>
+        </tr>
+      `).join('')
+    : '<tr><td colspan="4" class="empty">품목 정보가 없습니다.</td></tr>'
+
+  return `<!doctype html>
+  <html lang="ko">
+    <head>
+      <meta charset="UTF-8" />
+      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+      <title>${escapeHtml(title)} - ${escapeHtml(documentId)}</title>
+      <style>
+        body { font-family: Arial, sans-serif; margin: 32px; color: #0f172a; }
+        .header { margin-bottom: 24px; }
+        .title { font-size: 28px; font-weight: 700; margin: 0 0 6px; }
+        .subtitle { font-size: 14px; color: #64748b; margin: 0; }
+        .section { margin-top: 24px; }
+        .section-title { font-size: 16px; font-weight: 700; margin: 0 0 12px; }
+        table { width: 100%; border-collapse: collapse; }
+        th, td { border: 1px solid #cbd5e1; padding: 10px 12px; font-size: 13px; }
+        th { background: #f8fafc; text-align: left; width: 180px; }
+        .line-items th { width: auto; text-align: center; }
+        .line-items td { text-align: center; }
+        .line-items td:first-child, .line-items th:first-child { text-align: left; }
+        .empty { color: #94a3b8; }
+        @media print {
+          body { margin: 16px; }
+        }
+      </style>
+    </head>
+    <body>
+      <div class="header">
+        <h1 class="title">${escapeHtml(title)}</h1>
+        <p class="subtitle">문서번호: ${escapeHtml(documentId)}</p>
+      </div>
+
+      <section class="section">
+        <h2 class="section-title">기본 정보</h2>
+        <table>
+          <tbody>${fieldRows}</tbody>
+        </table>
+      </section>
+
+      <section class="section">
+        <h2 class="section-title">품목 목록</h2>
+        <table class="line-items">
+          <thead>
+            <tr>
+              <th>품목</th>
+              <th>수량</th>
+              <th>단가</th>
+              <th>금액</th>
+            </tr>
+          </thead>
+          <tbody>${lineItemRows}</tbody>
+        </table>
+      </section>
+    </body>
+  </html>`
+}
+
+export function openDocumentOutput({ title, documentId, fields, lineItems, autoPrint = false }) {
+  const printWindow = window.open('', '_blank', 'noopener,noreferrer,width=960,height=800')
+  if (!printWindow) return false
+
+  const html = buildDocumentOutputHtml({ title, documentId, fields, lineItems })
+  printWindow.document.open()
+  printWindow.document.write(html)
+  printWindow.document.close()
+  printWindow.focus()
+
+  if (autoPrint) {
+    setTimeout(() => {
+      printWindow.print()
+    }, 250)
+  }
+
+  return true
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;')
+}

--- a/src/views/documents/ProductionOrderDetailPage.vue
+++ b/src/views/documents/ProductionOrderDetailPage.vue
@@ -1,0 +1,213 @@
+<script setup>
+import { computed, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
+import BaseButton from '@/components/common/BaseButton.vue'
+import StatusBadge from '@/components/common/StatusBadge.vue'
+import DocumentPreviewModal from '@/components/domain/document/DocumentPreviewModal.vue'
+import { useToast } from '@/composables/useToast'
+import { openDocumentOutput } from '@/utils/documentOutput'
+
+const route = useRoute()
+const router = useRouter()
+const toast = useToast()
+
+const previewOpen = ref(false)
+
+const detailMap = {
+  MO2026001: {
+    id: 'MO2026001',
+    status: '완료',
+    issueDate: '2026/02/24',
+    poId: 'PO26001',
+    country: '말레이시아',
+    clientName: 'COOLSAY SDN BHD',
+    itemName: 'H-Beam 482x300x11x15',
+    manager: '김영업',
+    dueDate: '2026/04/20',
+    items: [
+      { name: 'H-Beam 482x300x11x15', quantity: '30', unitPrice: '$850', amount: '$25,500' },
+    ],
+  },
+  MO2026002: {
+    id: 'MO2026002',
+    status: '진행중',
+    issueDate: '2026/03/03',
+    poId: 'PO26002',
+    country: '독일',
+    clientName: 'TechBridge GmbH',
+    itemName: 'H-Beam 482x300x11x15',
+    manager: '김영업',
+    dueDate: '2026/05/25',
+    items: [
+      { name: 'H-Beam 482x300x11x15', quantity: '80', unitPrice: '€855', amount: '€68,400' },
+    ],
+  },
+  MO2026003: {
+    id: 'MO2026003',
+    status: '대기',
+    issueDate: '2026/03/14',
+    poId: 'PO26003',
+    country: '미국',
+    clientName: 'Pacific Trading Inc.',
+    itemName: 'Lubricant Oil SAE 10W-40',
+    manager: '정영업',
+    dueDate: '2026/06/05',
+    items: [
+      { name: 'Lubricant Oil SAE 10W-40', quantity: '520', unitPrice: '$30', amount: '$15,600' },
+    ],
+  },
+}
+
+const detail = computed(() => detailMap[route.params.id] ?? null)
+
+const previewFields = computed(() => {
+  if (!detail.value) return []
+  return [
+    { label: '생산지시일', value: detail.value.issueDate },
+    { label: 'PO', value: detail.value.poId },
+    { label: '국가', value: detail.value.country },
+    { label: '거래처', value: detail.value.clientName },
+    { label: '품목명', value: detail.value.itemName },
+    { label: '영업담당자', value: detail.value.manager },
+    { label: '상태', value: detail.value.status },
+    { label: '납기일', value: detail.value.dueDate },
+  ]
+})
+
+function goBack() {
+  router.push({ name: 'production' })
+}
+
+function openPreview() {
+  previewOpen.value = true
+}
+
+function handlePrint() {
+  if (!detail.value) return
+  openDocumentOutput({
+    title: '생산지시서',
+    documentId: detail.value.id,
+    fields: previewFields.value,
+    lineItems: detail.value.items,
+    autoPrint: true,
+  })
+}
+
+function handlePdfDownload() {
+  if (!detail.value) return
+  const opened = openDocumentOutput({
+    title: '생산지시서',
+    documentId: detail.value.id,
+    fields: previewFields.value,
+    lineItems: detail.value.items,
+    autoPrint: true,
+  })
+  if (opened) {
+    toast.info('브라우저 인쇄 창에서 PDF로 저장할 수 있습니다.', 'PDF')
+  }
+}
+</script>
+
+<template>
+  <div v-if="detail" class="fade-in">
+    <div class="mb-6 flex flex-wrap items-center gap-3">
+      <button
+        type="button"
+        class="flex h-9 w-9 items-center justify-center rounded-lg text-slate-400 transition hover:bg-slate-100 hover:text-slate-700"
+        @click="goBack"
+      >
+        <i class="fas fa-arrow-left" aria-hidden="true"></i>
+      </button>
+      <h2 class="text-xl font-bold text-slate-900">{{ detail.id }}</h2>
+      <StatusBadge :value="detail.status" />
+      <div class="flex-1"></div>
+
+      <BaseButton variant="secondary" class="!h-auto !rounded-xl !px-4 !py-2.5" @click="openPreview">
+        <template #leading>
+          <i class="fas fa-eye text-xs text-brand-500" aria-hidden="true"></i>
+        </template>
+        미리보기
+      </BaseButton>
+      <BaseButton variant="secondary" class="!h-auto !rounded-xl !px-4 !py-2.5" @click="handlePrint">
+        <template #leading>
+          <i class="fas fa-print text-xs text-slate-400" aria-hidden="true"></i>
+        </template>
+        인쇄
+      </BaseButton>
+      <BaseButton class="!h-auto !rounded-xl !px-4 !py-2.5" @click="handlePdfDownload">
+        <template #leading>
+          <i class="fas fa-file-pdf text-xs" aria-hidden="true"></i>
+        </template>
+        PDF 다운로드
+      </BaseButton>
+    </div>
+
+    <div class="grid grid-cols-1 gap-6 lg:grid-cols-3">
+      <div class="space-y-4 lg:col-span-2">
+        <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+          <h3 class="mb-4 font-bold text-slate-800">기본 정보</h3>
+          <div class="grid grid-cols-1 gap-4 text-sm sm:grid-cols-2">
+            <div><span class="text-slate-500">생산지시일</span><div class="mt-0.5 font-medium">{{ detail.issueDate }}</div></div>
+            <div><span class="text-slate-500">PO</span><div class="mt-0.5 font-medium">{{ detail.poId }}</div></div>
+            <div><span class="text-slate-500">국가</span><div class="mt-0.5">{{ detail.country }}</div></div>
+            <div><span class="text-slate-500">거래처</span><div class="mt-0.5 font-medium">{{ detail.clientName }}</div></div>
+            <div><span class="text-slate-500">영업담당자</span><div class="mt-0.5">{{ detail.manager }}</div></div>
+            <div><span class="text-slate-500">납기일</span><div class="mt-0.5">{{ detail.dueDate }}</div></div>
+          </div>
+        </div>
+
+        <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+          <h3 class="mb-4 font-bold text-slate-800">품목 목록</h3>
+          <div class="overflow-x-auto">
+            <table class="w-full min-w-[620px] text-sm">
+              <thead class="bg-gray-50">
+                <tr>
+                  <th class="p-3 text-left">품목</th>
+                  <th class="p-3 text-right">수량</th>
+                  <th class="p-3 text-right">단가</th>
+                  <th class="p-3 text-right">금액</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y">
+                <tr v-for="item in detail.items" :key="`${detail.id}-${item.name}`">
+                  <td class="p-3">{{ item.name }}</td>
+                  <td class="p-3 text-right">{{ item.quantity }}</td>
+                  <td class="p-3 text-right">{{ item.unitPrice }}</td>
+                  <td class="p-3 text-right font-semibold">{{ item.amount }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
+      <div class="space-y-4">
+        <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+          <h3 class="mb-3 font-bold text-slate-800">연결 문서</h3>
+          <a href="#" class="flex items-center gap-2 rounded-lg p-2.5 text-brand-500 transition hover:bg-slate-50" @click.prevent>
+            <i class="fas fa-file-contract" aria-hidden="true"></i>
+            {{ detail.poId }}
+          </a>
+        </div>
+
+        <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+          <h3 class="mb-3 font-bold text-slate-800">담당자</h3>
+          <div class="text-sm">{{ detail.manager }}</div>
+        </div>
+      </div>
+    </div>
+
+    <DocumentPreviewModal
+      :open="previewOpen"
+      title="생산지시서 미리보기"
+      :document-title="detail.id"
+      :fields="previewFields"
+      @close="previewOpen = false"
+    />
+  </div>
+
+  <div v-else class="flex items-center justify-center py-20 text-slate-400">
+    생산지시서를 찾을 수 없습니다.
+  </div>
+</template>

--- a/src/views/documents/ProductionOrderPage.vue
+++ b/src/views/documents/ProductionOrderPage.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { computed, ref } from 'vue'
+import { useRouter } from 'vue-router'
 
 import BaseButton from '@/components/common/BaseButton.vue'
 import BaseTable from '@/components/common/BaseTable.vue'
@@ -9,14 +10,23 @@ import DocumentPageHeader from '@/components/common/DocumentPageHeader.vue'
 import DocumentPreviewModal from '@/components/domain/document/DocumentPreviewModal.vue'
 import FilterToolbarCard from '@/components/common/FilterToolbarCard.vue'
 import FormField from '@/components/common/FormField.vue'
+import SearchModal from '@/components/common/SearchModal.vue'
 import SearchTriggerField from '@/components/common/SearchTriggerField.vue'
 import SearchableCombobox from '@/components/common/SearchableCombobox.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
 import { useToast } from '@/composables/useToast'
+import { openDocumentOutput } from '@/utils/documentOutput'
 
+const router = useRouter()
 const isAdvancedOpen = ref(true)
 const previewTarget = ref(null)
 const toast = useToast()
+const clientSearchOpen = ref(false)
+const clientSearchKeyword = ref('')
+const codeSearchOpen = ref(false)
+const codeSearchKeyword = ref('')
+const productSearchOpen = ref(false)
+const productSearchKeyword = ref('')
 
 const filters = ref({
   keyword: '',
@@ -106,6 +116,12 @@ const rows = [
   },
 ]
 
+const clientRowsSource = [
+  { id: 'CL001', name: 'COOLSAY SDN BHD', country: '말레이시아' },
+  { id: 'CL002', name: 'TechBridge GmbH', country: '독일' },
+  { id: 'CL003', name: 'Pacific Trading Inc.', country: '미국' },
+]
+
 function normalizeDate(value) {
   return String(value ?? '').replaceAll('/', '-')
 }
@@ -166,6 +182,28 @@ const previewFields = computed(() => {
   ]
 })
 
+const clientRows = computed(() => {
+  const keyword = clientSearchKeyword.value.trim().toLowerCase()
+  if (!keyword) return clientRowsSource
+  return clientRowsSource.filter((row) => [row.id, row.name, row.country].some((value) => String(value).toLowerCase().includes(keyword)))
+})
+
+const codeRows = computed(() => {
+  const keyword = codeSearchKeyword.value.trim().toLowerCase()
+  const source = rows.map((row) => ({ id: row.id, issueDate: row.issueDate, clientName: row.clientName }))
+  if (!keyword) return source
+  return source.filter((row) => [row.id, row.issueDate, row.clientName].some((value) => String(value).toLowerCase().includes(keyword)))
+})
+
+const productRows = computed(() => {
+  const keyword = productSearchKeyword.value.trim().toLowerCase()
+  const source = [...new Map(rows.map((row) => [row.itemName, { name: row.itemName, country: row.country, manager: row.manager }])).values()]
+  if (!keyword) return source
+  return source.filter((row) => [row.name, row.country, row.manager].some((value) => String(value).toLowerCase().includes(keyword)))
+})
+
+const currentOutputTarget = computed(() => previewTarget.value ?? filteredRows.value[0] ?? null)
+
 function resetFilters() {
   filters.value = {
     keyword: '',
@@ -186,11 +224,17 @@ function resetFilters() {
   }
 }
 
-function openClientSearch() {}
+function openClientSearch() {
+  clientSearchOpen.value = true
+}
 
-function openCodeSearch() {}
+function openCodeSearch() {
+  codeSearchOpen.value = true
+}
 
-function openProductSearch() {}
+function openProductSearch() {
+  productSearchOpen.value = true
+}
 
 function searchRows() {
   appliedFilters.value = {
@@ -206,12 +250,71 @@ function closePreview() {
   previewTarget.value = null
 }
 
+function goToDetail(id) {
+  router.push({ name: 'production-detail', params: { id } })
+}
+
+function handleClientSelect(client) {
+  filters.value.clientName = client.name
+  clientSearchOpen.value = false
+  clientSearchKeyword.value = ''
+}
+
+function handleCodeSelect(code) {
+  filters.value.code = code.id
+  codeSearchOpen.value = false
+  codeSearchKeyword.value = ''
+}
+
+function handleProductSelect(product) {
+  filters.value.productName = product.name
+  productSearchOpen.value = false
+  productSearchKeyword.value = ''
+}
+
 function printDocument(row) {
-  toast.info(`${row.id} 인쇄 기능은 다음 단계에서 연결됩니다.`, '인쇄')
+  openDocumentOutput({
+    title: '생산지시서',
+    documentId: row.id,
+    fields: [
+      { label: '생산지시일', value: row.issueDate },
+      { label: 'PO', value: row.poId },
+      { label: '국가', value: row.country },
+      { label: '거래처', value: row.clientName },
+      { label: '품목명', value: row.itemName },
+      { label: '영업담당자', value: row.manager },
+      { label: '상태', value: row.status },
+      { label: '납기일', value: row.dueDate },
+    ],
+    lineItems: [
+      { name: row.itemName, quantity: '-', unitPrice: '-', amount: '-' },
+    ],
+    autoPrint: true,
+  })
 }
 
 function downloadPdf(row) {
-  toast.info(`${row.id} PDF 다운로드 기능은 다음 단계에서 연결됩니다.`, 'PDF')
+  const opened = openDocumentOutput({
+    title: '생산지시서',
+    documentId: row.id,
+    fields: [
+      { label: '생산지시일', value: row.issueDate },
+      { label: 'PO', value: row.poId },
+      { label: '국가', value: row.country },
+      { label: '거래처', value: row.clientName },
+      { label: '품목명', value: row.itemName },
+      { label: '영업담당자', value: row.manager },
+      { label: '상태', value: row.status },
+      { label: '납기일', value: row.dueDate },
+    ],
+    lineItems: [
+      { name: row.itemName, quantity: '-', unitPrice: '-', amount: '-' },
+    ],
+    autoPrint: true,
+  })
+  if (opened) {
+    toast.info('브라우저 인쇄 창에서 PDF로 저장할 수 있습니다.', 'PDF')
+  }
 }
 </script>
 
@@ -219,13 +322,13 @@ function downloadPdf(row) {
   <div class="fade-in space-y-5">
     <DocumentPageHeader title="생산지시서" icon-class="fas fa-industry">
       <template #actions>
-        <BaseButton variant="secondary" size="sm" @click="toast.info('생산지시서 인쇄 기능은 다음 단계에서 연결됩니다.', '인쇄')">
+        <BaseButton variant="secondary" size="sm" @click="currentOutputTarget ? printDocument(currentOutputTarget) : toast.info('출력할 생산지시서가 없습니다.', '인쇄')">
           <template #leading>
             <i class="fas fa-print text-xs" aria-hidden="true"></i>
           </template>
           인쇄
         </BaseButton>
-        <BaseButton size="sm" @click="toast.info('생산지시서 PDF 다운로드 기능은 다음 단계에서 연결됩니다.', 'PDF')">
+        <BaseButton size="sm" @click="currentOutputTarget ? downloadPdf(currentOutputTarget) : toast.info('출력할 생산지시서가 없습니다.', 'PDF')">
           <template #leading>
             <i class="fas fa-file-pdf text-xs" aria-hidden="true"></i>
           </template>
@@ -329,11 +432,15 @@ function downloadPdf(row) {
     <BaseTable
       :columns="columns"
       :rows="filteredRows"
+      clickable-rows
       empty-text="데이터가 없습니다."
       :footer-text="`총 ${filteredRows.length}건`"
+      @row-click="goToDetail($event.id)"
     >
       <template #cell-id="{ value }">
-        <span class="font-mono text-xs font-semibold text-brand-600">{{ value }}</span>
+        <button type="button" class="font-mono text-xs font-semibold text-brand-600 hover:underline" @click.stop="goToDetail(value)">
+          {{ value }}
+        </button>
       </template>
 
       <template #cell-poId="{ value }">
@@ -346,13 +453,13 @@ function downloadPdf(row) {
 
       <template #cell-actions="{ row }">
         <div class="flex items-center justify-center gap-2">
-          <button type="button" class="text-xs text-brand-500 transition hover:underline" :title="`${row.id} 미리보기`" @click="openPreview(row)">
+          <button type="button" class="text-xs text-brand-500 transition hover:underline" :title="`${row.id} 미리보기`" @click.stop="openPreview(row)">
             <i class="fas fa-eye" aria-hidden="true"></i>
           </button>
-          <button type="button" class="text-xs text-slate-400 transition hover:text-slate-700" :title="`${row.id} 인쇄`" @click="printDocument(row)">
+          <button type="button" class="text-xs text-slate-400 transition hover:text-slate-700" :title="`${row.id} 인쇄`" @click.stop="printDocument(row)">
             <i class="fas fa-print" aria-hidden="true"></i>
           </button>
-          <button type="button" class="text-xs text-slate-400 transition hover:text-slate-700" :title="`${row.id} PDF 다운로드`" @click="downloadPdf(row)">
+          <button type="button" class="text-xs text-slate-400 transition hover:text-slate-700" :title="`${row.id} PDF 다운로드`" @click.stop="downloadPdf(row)">
             <i class="fas fa-file-pdf" aria-hidden="true"></i>
           </button>
         </div>
@@ -365,6 +472,51 @@ function downloadPdf(row) {
       :document-title="previewTarget?.id ?? ''"
       :fields="previewFields"
       @close="closePreview"
+    />
+
+    <SearchModal
+      :open="clientSearchOpen"
+      title="거래처 검색"
+      :columns="[
+        { key: 'id', label: '코드' },
+        { key: 'name', label: '거래처명' },
+        { key: 'country', label: '국가' },
+      ]"
+      :rows="clientRows"
+      :search-keyword="clientSearchKeyword"
+      @update:search-keyword="clientSearchKeyword = $event"
+      @close="clientSearchOpen = false"
+      @select="handleClientSelect"
+    />
+
+    <SearchModal
+      :open="codeSearchOpen"
+      title="지시서번호 검색"
+      :columns="[
+        { key: 'id', label: '지시서번호' },
+        { key: 'issueDate', label: '생산지시일' },
+        { key: 'clientName', label: '거래처명' },
+      ]"
+      :rows="codeRows"
+      :search-keyword="codeSearchKeyword"
+      @update:search-keyword="codeSearchKeyword = $event"
+      @close="codeSearchOpen = false"
+      @select="handleCodeSelect"
+    />
+
+    <SearchModal
+      :open="productSearchOpen"
+      title="품목명 검색"
+      :columns="[
+        { key: 'name', label: '품목명' },
+        { key: 'country', label: '국가' },
+        { key: 'manager', label: '영업담당자' },
+      ]"
+      :rows="productRows"
+      :search-keyword="productSearchKeyword"
+      @update:search-keyword="productSearchKeyword = $event"
+      @close="productSearchOpen = false"
+      @select="handleProductSelect"
     />
   </div>
 </template>

--- a/src/views/documents/ShipmentOrderDetailPage.vue
+++ b/src/views/documents/ShipmentOrderDetailPage.vue
@@ -1,0 +1,213 @@
+<script setup>
+import { computed, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
+import BaseButton from '@/components/common/BaseButton.vue'
+import StatusBadge from '@/components/common/StatusBadge.vue'
+import DocumentPreviewModal from '@/components/domain/document/DocumentPreviewModal.vue'
+import { useToast } from '@/composables/useToast'
+import { openDocumentOutput } from '@/utils/documentOutput'
+
+const route = useRoute()
+const router = useRouter()
+const toast = useToast()
+
+const previewOpen = ref(false)
+
+const detailMap = {
+  SO2026001: {
+    id: 'SO2026001',
+    status: '출하완료',
+    issueDate: '2026/02/24',
+    poId: 'PO26001',
+    clientName: 'COOLSAY SDN BHD',
+    country: '말레이시아',
+    itemName: 'H-Beam 482x300x11x15',
+    manager: '김영업',
+    dueDate: '2026/04/20',
+    items: [
+      { name: 'H-Beam 482x300x11x15', quantity: '30', unitPrice: '$850', amount: '$25,500' },
+    ],
+  },
+  SO2026002: {
+    id: 'SO2026002',
+    status: '준비완료',
+    issueDate: '2026/03/03',
+    poId: 'PO26002',
+    clientName: 'TechBridge GmbH',
+    country: '독일',
+    itemName: 'H-Beam 482x300x11x15',
+    manager: '김영업',
+    dueDate: '2026/05/25',
+    items: [
+      { name: 'H-Beam 482x300x11x15', quantity: '80', unitPrice: '€855', amount: '€68,400' },
+    ],
+  },
+  SO2026003: {
+    id: 'SO2026003',
+    status: '준비완료',
+    issueDate: '2026/03/14',
+    poId: 'PO26003',
+    clientName: 'Pacific Trading Inc.',
+    country: '미국',
+    itemName: 'Lubricant Oil SAE 10W-40',
+    manager: '정영업',
+    dueDate: '2026/06/05',
+    items: [
+      { name: 'Lubricant Oil SAE 10W-40', quantity: '520', unitPrice: '$30', amount: '$15,600' },
+    ],
+  },
+}
+
+const detail = computed(() => detailMap[route.params.id] ?? null)
+
+const previewFields = computed(() => {
+  if (!detail.value) return []
+  return [
+    { label: '출하지시일', value: detail.value.issueDate },
+    { label: 'PO', value: detail.value.poId },
+    { label: '거래처', value: detail.value.clientName },
+    { label: '국가', value: detail.value.country },
+    { label: '품목명', value: detail.value.itemName },
+    { label: '영업담당자', value: detail.value.manager },
+    { label: '상태', value: detail.value.status },
+    { label: '납기일', value: detail.value.dueDate },
+  ]
+})
+
+function goBack() {
+  router.push({ name: 'shipment-orders' })
+}
+
+function openPreview() {
+  previewOpen.value = true
+}
+
+function handlePrint() {
+  if (!detail.value) return
+  openDocumentOutput({
+    title: '출하지시서',
+    documentId: detail.value.id,
+    fields: previewFields.value,
+    lineItems: detail.value.items,
+    autoPrint: true,
+  })
+}
+
+function handlePdfDownload() {
+  if (!detail.value) return
+  const opened = openDocumentOutput({
+    title: '출하지시서',
+    documentId: detail.value.id,
+    fields: previewFields.value,
+    lineItems: detail.value.items,
+    autoPrint: true,
+  })
+  if (opened) {
+    toast.info('브라우저 인쇄 창에서 PDF로 저장할 수 있습니다.', 'PDF')
+  }
+}
+</script>
+
+<template>
+  <div v-if="detail" class="fade-in">
+    <div class="mb-6 flex flex-wrap items-center gap-3">
+      <button
+        type="button"
+        class="flex h-9 w-9 items-center justify-center rounded-lg text-slate-400 transition hover:bg-slate-100 hover:text-slate-700"
+        @click="goBack"
+      >
+        <i class="fas fa-arrow-left" aria-hidden="true"></i>
+      </button>
+      <h2 class="text-xl font-bold text-slate-900">{{ detail.id }}</h2>
+      <StatusBadge :value="detail.status" />
+      <div class="flex-1"></div>
+
+      <BaseButton variant="secondary" class="!h-auto !rounded-xl !px-4 !py-2.5" @click="openPreview">
+        <template #leading>
+          <i class="fas fa-eye text-xs text-brand-500" aria-hidden="true"></i>
+        </template>
+        미리보기
+      </BaseButton>
+      <BaseButton variant="secondary" class="!h-auto !rounded-xl !px-4 !py-2.5" @click="handlePrint">
+        <template #leading>
+          <i class="fas fa-print text-xs text-slate-400" aria-hidden="true"></i>
+        </template>
+        인쇄
+      </BaseButton>
+      <BaseButton class="!h-auto !rounded-xl !px-4 !py-2.5" @click="handlePdfDownload">
+        <template #leading>
+          <i class="fas fa-file-pdf text-xs" aria-hidden="true"></i>
+        </template>
+        PDF 다운로드
+      </BaseButton>
+    </div>
+
+    <div class="grid grid-cols-1 gap-6 lg:grid-cols-3">
+      <div class="space-y-4 lg:col-span-2">
+        <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+          <h3 class="mb-4 font-bold text-slate-800">기본 정보</h3>
+          <div class="grid grid-cols-1 gap-4 text-sm sm:grid-cols-2">
+            <div><span class="text-slate-500">출하지시일</span><div class="mt-0.5 font-medium">{{ detail.issueDate }}</div></div>
+            <div><span class="text-slate-500">PO</span><div class="mt-0.5 font-medium">{{ detail.poId }}</div></div>
+            <div><span class="text-slate-500">거래처</span><div class="mt-0.5 font-medium">{{ detail.clientName }}</div></div>
+            <div><span class="text-slate-500">국가</span><div class="mt-0.5">{{ detail.country }}</div></div>
+            <div><span class="text-slate-500">영업담당자</span><div class="mt-0.5">{{ detail.manager }}</div></div>
+            <div><span class="text-slate-500">납기일</span><div class="mt-0.5">{{ detail.dueDate }}</div></div>
+          </div>
+        </div>
+
+        <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+          <h3 class="mb-4 font-bold text-slate-800">품목 목록</h3>
+          <div class="overflow-x-auto">
+            <table class="w-full min-w-[620px] text-sm">
+              <thead class="bg-gray-50">
+                <tr>
+                  <th class="p-3 text-left">품목</th>
+                  <th class="p-3 text-right">수량</th>
+                  <th class="p-3 text-right">단가</th>
+                  <th class="p-3 text-right">금액</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y">
+                <tr v-for="item in detail.items" :key="`${detail.id}-${item.name}`">
+                  <td class="p-3">{{ item.name }}</td>
+                  <td class="p-3 text-right">{{ item.quantity }}</td>
+                  <td class="p-3 text-right">{{ item.unitPrice }}</td>
+                  <td class="p-3 text-right font-semibold">{{ item.amount }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+
+      <div class="space-y-4">
+        <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+          <h3 class="mb-3 font-bold text-slate-800">연결 문서</h3>
+          <a href="#" class="flex items-center gap-2 rounded-lg p-2.5 text-brand-500 transition hover:bg-slate-50" @click.prevent>
+            <i class="fas fa-file-contract" aria-hidden="true"></i>
+            {{ detail.poId }}
+          </a>
+        </div>
+
+        <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+          <h3 class="mb-3 font-bold text-slate-800">담당자</h3>
+          <div class="text-sm">{{ detail.manager }}</div>
+        </div>
+      </div>
+    </div>
+
+    <DocumentPreviewModal
+      :open="previewOpen"
+      title="출하지시서 미리보기"
+      :document-title="detail.id"
+      :fields="previewFields"
+      @close="previewOpen = false"
+    />
+  </div>
+
+  <div v-else class="flex items-center justify-center py-20 text-slate-400">
+    출하지시서를 찾을 수 없습니다.
+  </div>
+</template>

--- a/src/views/documents/ShipmentOrderPage.vue
+++ b/src/views/documents/ShipmentOrderPage.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { computed, ref } from 'vue'
+import { useRouter } from 'vue-router'
 
 import BaseButton from '@/components/common/BaseButton.vue'
 import BaseTable from '@/components/common/BaseTable.vue'
@@ -9,14 +10,23 @@ import DocumentPageHeader from '@/components/common/DocumentPageHeader.vue'
 import DocumentPreviewModal from '@/components/domain/document/DocumentPreviewModal.vue'
 import FilterToolbarCard from '@/components/common/FilterToolbarCard.vue'
 import FormField from '@/components/common/FormField.vue'
+import SearchModal from '@/components/common/SearchModal.vue'
 import SearchTriggerField from '@/components/common/SearchTriggerField.vue'
 import SearchableCombobox from '@/components/common/SearchableCombobox.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
 import { useToast } from '@/composables/useToast'
+import { openDocumentOutput } from '@/utils/documentOutput'
 
+const router = useRouter()
 const isAdvancedOpen = ref(true)
 const previewTarget = ref(null)
 const toast = useToast()
+const clientSearchOpen = ref(false)
+const clientSearchKeyword = ref('')
+const codeSearchOpen = ref(false)
+const codeSearchKeyword = ref('')
+const productSearchOpen = ref(false)
+const productSearchKeyword = ref('')
 
 const filters = ref({
   keyword: '',
@@ -105,6 +115,12 @@ const rows = [
   },
 ]
 
+const clientRowsSource = [
+  { id: 'CL001', name: 'COOLSAY SDN BHD', country: '말레이시아' },
+  { id: 'CL002', name: 'TechBridge GmbH', country: '독일' },
+  { id: 'CL003', name: 'Pacific Trading Inc.', country: '미국' },
+]
+
 function normalizeDate(value) {
   return String(value ?? '').replaceAll('/', '-')
 }
@@ -165,6 +181,28 @@ const previewFields = computed(() => {
   ]
 })
 
+const clientRows = computed(() => {
+  const keyword = clientSearchKeyword.value.trim().toLowerCase()
+  if (!keyword) return clientRowsSource
+  return clientRowsSource.filter((row) => [row.id, row.name, row.country].some((value) => String(value).toLowerCase().includes(keyword)))
+})
+
+const codeRows = computed(() => {
+  const keyword = codeSearchKeyword.value.trim().toLowerCase()
+  const source = rows.map((row) => ({ id: row.id, issueDate: row.issueDate, clientName: row.clientName }))
+  if (!keyword) return source
+  return source.filter((row) => [row.id, row.issueDate, row.clientName].some((value) => String(value).toLowerCase().includes(keyword)))
+})
+
+const productRows = computed(() => {
+  const keyword = productSearchKeyword.value.trim().toLowerCase()
+  const source = [...new Map(rows.map((row) => [row.itemName, { name: row.itemName, country: row.country, manager: row.manager }])).values()]
+  if (!keyword) return source
+  return source.filter((row) => [row.name, row.country, row.manager].some((value) => String(value).toLowerCase().includes(keyword)))
+})
+
+const currentOutputTarget = computed(() => previewTarget.value ?? filteredRows.value[0] ?? null)
+
 function resetFilters() {
   filters.value = {
     keyword: '',
@@ -185,11 +223,17 @@ function resetFilters() {
   }
 }
 
-function openClientSearch() {}
+function openClientSearch() {
+  clientSearchOpen.value = true
+}
 
-function openCodeSearch() {}
+function openCodeSearch() {
+  codeSearchOpen.value = true
+}
 
-function openProductSearch() {}
+function openProductSearch() {
+  productSearchOpen.value = true
+}
 
 function searchRows() {
   appliedFilters.value = {
@@ -205,12 +249,71 @@ function closePreview() {
   previewTarget.value = null
 }
 
+function goToDetail(id) {
+  router.push({ name: 'shipment-order-detail', params: { id } })
+}
+
+function handleClientSelect(client) {
+  filters.value.clientName = client.name
+  clientSearchOpen.value = false
+  clientSearchKeyword.value = ''
+}
+
+function handleCodeSelect(code) {
+  filters.value.code = code.id
+  codeSearchOpen.value = false
+  codeSearchKeyword.value = ''
+}
+
+function handleProductSelect(product) {
+  filters.value.productName = product.name
+  productSearchOpen.value = false
+  productSearchKeyword.value = ''
+}
+
 function printDocument(row) {
-  toast.info(`${row.id} 인쇄 기능은 다음 단계에서 연결됩니다.`, '인쇄')
+  openDocumentOutput({
+    title: '출하지시서',
+    documentId: row.id,
+    fields: [
+      { label: '출하지시일', value: row.issueDate },
+      { label: 'PO', value: row.poId },
+      { label: '거래처', value: row.clientName },
+      { label: '국가', value: row.country },
+      { label: '품목명', value: row.itemName },
+      { label: '영업담당자', value: row.manager },
+      { label: '상태', value: row.status },
+      { label: '납기일', value: row.dueDate },
+    ],
+    lineItems: [
+      { name: row.itemName, quantity: '-', unitPrice: '-', amount: '-' },
+    ],
+    autoPrint: true,
+  })
 }
 
 function downloadPdf(row) {
-  toast.info(`${row.id} PDF 다운로드 기능은 다음 단계에서 연결됩니다.`, 'PDF')
+  const opened = openDocumentOutput({
+    title: '출하지시서',
+    documentId: row.id,
+    fields: [
+      { label: '출하지시일', value: row.issueDate },
+      { label: 'PO', value: row.poId },
+      { label: '거래처', value: row.clientName },
+      { label: '국가', value: row.country },
+      { label: '품목명', value: row.itemName },
+      { label: '영업담당자', value: row.manager },
+      { label: '상태', value: row.status },
+      { label: '납기일', value: row.dueDate },
+    ],
+    lineItems: [
+      { name: row.itemName, quantity: '-', unitPrice: '-', amount: '-' },
+    ],
+    autoPrint: true,
+  })
+  if (opened) {
+    toast.info('브라우저 인쇄 창에서 PDF로 저장할 수 있습니다.', 'PDF')
+  }
 }
 </script>
 
@@ -218,13 +321,13 @@ function downloadPdf(row) {
   <div class="fade-in space-y-5">
     <DocumentPageHeader title="출하지시서" icon-class="fas fa-truck-loading">
       <template #actions>
-        <BaseButton variant="secondary" size="sm" @click="toast.info('출하지시서 인쇄 기능은 다음 단계에서 연결됩니다.', '인쇄')">
+        <BaseButton variant="secondary" size="sm" @click="currentOutputTarget ? printDocument(currentOutputTarget) : toast.info('출력할 출하지시서가 없습니다.', '인쇄')">
           <template #leading>
             <i class="fas fa-print text-xs" aria-hidden="true"></i>
           </template>
           인쇄
         </BaseButton>
-        <BaseButton size="sm" @click="toast.info('출하지시서 PDF 다운로드 기능은 다음 단계에서 연결됩니다.', 'PDF')">
+        <BaseButton size="sm" @click="currentOutputTarget ? downloadPdf(currentOutputTarget) : toast.info('출력할 출하지시서가 없습니다.', 'PDF')">
           <template #leading>
             <i class="fas fa-file-pdf text-xs" aria-hidden="true"></i>
           </template>
@@ -328,11 +431,15 @@ function downloadPdf(row) {
     <BaseTable
       :columns="columns"
       :rows="filteredRows"
+      clickable-rows
       empty-text="데이터가 없습니다."
       :footer-text="`총 ${filteredRows.length}건`"
+      @row-click="goToDetail($event.id)"
     >
       <template #cell-id="{ value }">
-        <span class="font-mono text-xs font-semibold text-brand-600">{{ value }}</span>
+        <button type="button" class="font-mono text-xs font-semibold text-brand-600 hover:underline" @click.stop="goToDetail(value)">
+          {{ value }}
+        </button>
       </template>
 
       <template #cell-poId="{ value }">
@@ -349,7 +456,7 @@ function downloadPdf(row) {
             type="button"
             class="text-xs text-brand-500 transition hover:underline"
             :title="`${row.id} 미리보기`"
-            @click="openPreview(row)"
+            @click.stop="openPreview(row)"
           >
             <i class="fas fa-eye" aria-hidden="true"></i>
           </button>
@@ -357,7 +464,7 @@ function downloadPdf(row) {
             type="button"
             class="text-xs text-slate-400 transition hover:text-slate-700"
             :title="`${row.id} 인쇄`"
-            @click="printDocument(row)"
+            @click.stop="printDocument(row)"
           >
             <i class="fas fa-print" aria-hidden="true"></i>
           </button>
@@ -365,7 +472,7 @@ function downloadPdf(row) {
             type="button"
             class="text-xs text-slate-400 transition hover:text-slate-700"
             :title="`${row.id} PDF 다운로드`"
-            @click="downloadPdf(row)"
+            @click.stop="downloadPdf(row)"
           >
             <i class="fas fa-file-pdf" aria-hidden="true"></i>
           </button>
@@ -379,6 +486,51 @@ function downloadPdf(row) {
       :document-title="previewTarget?.id"
       :fields="previewFields"
       @close="closePreview"
+    />
+
+    <SearchModal
+      :open="clientSearchOpen"
+      title="거래처 검색"
+      :columns="[
+        { key: 'id', label: '코드' },
+        { key: 'name', label: '거래처명' },
+        { key: 'country', label: '국가' },
+      ]"
+      :rows="clientRows"
+      :search-keyword="clientSearchKeyword"
+      @update:search-keyword="clientSearchKeyword = $event"
+      @close="clientSearchOpen = false"
+      @select="handleClientSelect"
+    />
+
+    <SearchModal
+      :open="codeSearchOpen"
+      title="지시서번호 검색"
+      :columns="[
+        { key: 'id', label: '지시서번호' },
+        { key: 'issueDate', label: '출하지시일' },
+        { key: 'clientName', label: '거래처명' },
+      ]"
+      :rows="codeRows"
+      :search-keyword="codeSearchKeyword"
+      @update:search-keyword="codeSearchKeyword = $event"
+      @close="codeSearchOpen = false"
+      @select="handleCodeSelect"
+    />
+
+    <SearchModal
+      :open="productSearchOpen"
+      title="품목명 검색"
+      :columns="[
+        { key: 'name', label: '품목명' },
+        { key: 'country', label: '국가' },
+        { key: 'manager', label: '영업담당자' },
+      ]"
+      :rows="productRows"
+      :search-keyword="productSearchKeyword"
+      @update:search-keyword="productSearchKeyword = $event"
+      @close="productSearchOpen = false"
+      @select="handleProductSelect"
     />
   </div>
 </template>

--- a/src/views/documents/ShipmentsDetailPage.vue
+++ b/src/views/documents/ShipmentsDetailPage.vue
@@ -1,0 +1,179 @@
+<script setup>
+import { computed, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
+import BaseButton from '@/components/common/BaseButton.vue'
+import StatusBadge from '@/components/common/StatusBadge.vue'
+import { useToast } from '@/composables/useToast'
+
+const route = useRoute()
+const router = useRouter()
+const toast = useToast()
+
+const detailMap = {
+  SH26001: {
+    id: 'SH26001',
+    status: '출하준비',
+    clientName: 'COOLSAY SDN BHD',
+    poId: 'PO26001',
+    shipmentOrderId: 'SO26001',
+    requestDate: '2026/03/26',
+    dueDate: '2026/04/05',
+    updatedAt: '2026/03/28 14:30',
+    items: [
+      { name: 'H-Beam 482x300x11x15', quantity: '30 EA' },
+      { name: 'Lubricant Oil SAE 10W-40', quantity: '200 EA' },
+      { name: 'Industrial Grease EP-2', quantity: '100 EA' },
+      { name: 'Hydraulic Oil ISO VG 46', quantity: '32 EA' },
+    ],
+  },
+  SH26004: {
+    id: 'SH26004',
+    status: '출하준비',
+    clientName: 'Viet Steel JSC',
+    poId: 'PO26004',
+    shipmentOrderId: 'SO26004',
+    requestDate: '2026/03/29',
+    dueDate: '2026/04/30',
+    updatedAt: '2026/03/30 09:40',
+    items: [
+      { name: 'H-Beam 482x300x11x15', quantity: '40 EA' },
+    ],
+  },
+  SH26005: {
+    id: 'SH26005',
+    status: '출하완료',
+    clientName: 'Pacific Trading Inc.',
+    poId: 'PO26003',
+    shipmentOrderId: 'SO26005',
+    requestDate: '2026/03/18',
+    dueDate: '2026/06/05',
+    updatedAt: '2026/03/31 18:10',
+    items: [
+      { name: 'Lubricant Oil SAE 10W-40', quantity: '520 EA' },
+    ],
+  },
+}
+
+const detail = ref(
+  detailMap[route.params.id]
+    ? { ...detailMap[route.params.id], items: [...detailMap[route.params.id].items] }
+    : null,
+)
+
+const currentStep = computed(() => (detail.value?.status === '출하완료' ? 2 : 1))
+
+function goBack() {
+  router.push({ name: 'shipments' })
+}
+
+function goToPo() {
+  router.push({ name: 'po-detail', params: { id: detail.value?.poId } })
+}
+
+function goToShipmentOrder() {
+  router.push({ name: 'shipment-order-detail', params: { id: detail.value?.shipmentOrderId } })
+}
+
+function completeShipment() {
+  if (!detail.value || detail.value.status === '출하완료') return
+  detail.value.status = '출하완료'
+  detail.value.updatedAt = '2026/03/31 10:00'
+  toast.success(`${detail.value.id}가 출하완료 처리되었습니다.`)
+}
+</script>
+
+<template>
+  <div v-if="detail" class="fade-in">
+    <div class="mb-6 flex items-center gap-3">
+      <button
+        type="button"
+        class="flex h-9 w-9 items-center justify-center rounded-lg text-slate-400 transition hover:bg-slate-100 hover:text-slate-700"
+        @click="goBack"
+      >
+        <i class="fas fa-arrow-left" aria-hidden="true"></i>
+      </button>
+      <h2 class="text-xl font-bold text-slate-900">{{ detail.id }}</h2>
+      <StatusBadge :value="detail.status" />
+      <div class="flex-1"></div>
+      <BaseButton
+        class="!h-auto !rounded-xl !bg-slate-500 !px-4 !py-2.5"
+        :disabled="detail.status === '출하완료'"
+        @click="completeShipment"
+      >
+        <template #leading>
+          <i class="fas fa-check-circle text-xs" aria-hidden="true"></i>
+        </template>
+        출하완료 처리
+      </BaseButton>
+    </div>
+
+    <div class="grid grid-cols-1 gap-6 lg:grid-cols-3">
+      <div class="space-y-4 lg:col-span-2">
+        <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+          <h3 class="mb-4 font-bold text-slate-800">출하 정보</h3>
+          <div class="grid grid-cols-1 gap-4 text-sm sm:grid-cols-2">
+            <div><span class="text-slate-500">출하번호</span><div class="mt-0.5 font-mono font-medium">{{ detail.id }}</div></div>
+            <div><span class="text-slate-500">거래처</span><div class="mt-0.5 font-medium">{{ detail.clientName }}</div></div>
+            <div>
+              <span class="text-slate-500">원천 PO</span>
+              <div class="mt-0.5">
+                <button type="button" class="text-brand-500 hover:underline" @click="goToPo">{{ detail.poId }}</button>
+              </div>
+            </div>
+            <div><span class="text-slate-500">출하지시서</span><div class="mt-0.5">{{ detail.shipmentOrderId }}</div></div>
+            <div><span class="text-slate-500">출하요청일</span><div class="mt-0.5 font-medium">{{ detail.requestDate }}</div></div>
+            <div><span class="text-slate-500">납기일</span><div class="mt-0.5 font-medium">{{ detail.dueDate }}</div></div>
+            <div><span class="text-slate-500">최종 업데이트</span><div class="mt-0.5 text-xs text-slate-400">{{ detail.updatedAt }}</div></div>
+          </div>
+        </div>
+
+        <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+          <h3 class="mb-4 font-bold text-slate-800">진행 단계</h3>
+          <div class="flex items-center justify-center py-4">
+            <div class="flex items-center gap-0.5">
+              <div class="flex h-9 w-9 items-center justify-center rounded-full text-sm font-bold" :class="currentStep >= 1 ? 'bg-slate-500 text-white' : 'bg-slate-200 text-slate-400'">1</div>
+              <div class="h-0.5 w-5 bg-slate-200"></div>
+              <div class="flex h-9 w-9 items-center justify-center rounded-full text-sm font-bold" :class="currentStep >= 2 ? 'bg-slate-500 text-white' : 'bg-slate-200 text-slate-400'">2</div>
+              <span class="ml-2 text-xs font-medium text-brand-600">{{ detail.status }}</span>
+            </div>
+          </div>
+          <div class="mt-4 rounded-lg bg-slate-50 p-3 text-xs text-brand-500">
+            <i class="fas fa-info-circle mr-1" aria-hidden="true"></i>
+            출하팀 담당자 또는 관리자가 출하 상태를 변경할 수 있습니다.
+          </div>
+        </div>
+      </div>
+
+      <div class="space-y-4">
+        <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+          <h3 class="mb-3 font-bold text-slate-800">연결 문서</h3>
+          <div class="space-y-2 text-sm">
+            <button type="button" class="flex w-full items-center gap-2 rounded-lg p-2.5 text-left text-brand-500 transition hover:bg-slate-50" @click="goToPo">
+              <i class="fas fa-file-contract" aria-hidden="true"></i>
+              PO: {{ detail.poId }}
+            </button>
+            <button type="button" class="flex w-full cursor-pointer items-center gap-2 rounded-lg bg-slate-50 p-2.5 text-left text-slate-600 transition hover:bg-slate-100" @click="goToShipmentOrder">
+              <i class="fas fa-truck" aria-hidden="true"></i>
+              출하지시서: {{ detail.shipmentOrderId }}
+            </button>
+          </div>
+        </div>
+
+        <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+          <h3 class="mb-3 font-bold text-slate-800">PO 품목</h3>
+          <div class="space-y-2 text-xs">
+            <div v-for="item in detail.items" :key="item.name" class="flex justify-between rounded bg-slate-50 p-2">
+              <span>{{ item.name }}</span>
+              <span class="font-medium">{{ item.quantity }}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div v-else class="flex items-center justify-center py-20 text-slate-400">
+    출하 현황 문서를 찾을 수 없습니다.
+  </div>
+</template>

--- a/src/views/documents/ShipmentsPage.vue
+++ b/src/views/documents/ShipmentsPage.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { computed, ref } from 'vue'
+import { useRouter } from 'vue-router'
 
 import BaseButton from '@/components/common/BaseButton.vue'
 import BaseCard from '@/components/common/BaseCard.vue'
@@ -9,11 +10,15 @@ import DateField from '@/components/common/DateField.vue'
 import DocumentPageHeader from '@/components/common/DocumentPageHeader.vue'
 import FilterToolbarCard from '@/components/common/FilterToolbarCard.vue'
 import FormField from '@/components/common/FormField.vue'
+import SearchModal from '@/components/common/SearchModal.vue'
 import SearchTriggerField from '@/components/common/SearchTriggerField.vue'
 import SearchableCombobox from '@/components/common/SearchableCombobox.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
 
+const router = useRouter()
 const isAdvancedOpen = ref(true)
+const clientSearchOpen = ref(false)
+const clientSearchKeyword = ref('')
 
 const filters = ref({
   keyword: '',
@@ -39,7 +44,7 @@ const countryOptions = [
 ]
 
 const statusOptions = [
-  { value: '준비중', label: '준비중' },
+  { value: '출하준비', label: '출하준비' },
   { value: '출하완료', label: '출하완료' },
 ]
 
@@ -55,13 +60,13 @@ const columns = [
 
 const rows = [
   {
-    id: 'SH26002',
+    id: 'SH26001',
     clientName: 'COOLSAY SDN BHD',
     country: '말레이시아',
     poId: 'PO26001',
-    requestDate: '2026/02/24',
-    dueDate: '2026/04/20',
-    status: '출하완료',
+    requestDate: '2026/03/26',
+    dueDate: '2026/04/05',
+    status: '출하준비',
   },
   {
     id: 'SH26004',
@@ -70,7 +75,7 @@ const rows = [
     poId: 'PO26004',
     requestDate: '2026/03/12',
     dueDate: '2026/04/30',
-    status: '준비중',
+    status: '출하준비',
   },
   {
     id: 'SH26005',
@@ -79,8 +84,14 @@ const rows = [
     poId: 'PO26003',
     requestDate: '2026/03/18',
     dueDate: '2026/06/05',
-    status: '준비중',
+    status: '출하완료',
   },
+]
+
+const clientRowsSource = [
+  { id: 'CL001', name: 'COOLSAY SDN BHD', country: '말레이시아' },
+  { id: 'CL002', name: 'Viet Steel JSC', country: '베트남' },
+  { id: 'CL003', name: 'Pacific Trading Inc.', country: '미국' },
 ]
 
 function normalizeDate(value) {
@@ -122,8 +133,13 @@ const filteredRows = computed(() => {
   })
 })
 
-const preparingCount = computed(() => filteredRows.value.filter((row) => row.status === '준비중').length)
+const preparingCount = computed(() => filteredRows.value.filter((row) => row.status === '출하준비').length)
 const completedCount = computed(() => filteredRows.value.filter((row) => row.status === '출하완료').length)
+const clientRows = computed(() => {
+  const keyword = clientSearchKeyword.value.trim().toLowerCase()
+  if (!keyword) return clientRowsSource
+  return clientRowsSource.filter((row) => [row.id, row.name, row.country].some((value) => String(value).toLowerCase().includes(keyword)))
+})
 
 function resetFilters() {
   filters.value = {
@@ -143,7 +159,19 @@ function resetFilters() {
   }
 }
 
-function openClientSearch() {}
+function openClientSearch() {
+  clientSearchOpen.value = true
+}
+
+function handleClientSelect(client) {
+  filters.value.clientName = client.name
+  clientSearchOpen.value = false
+  clientSearchKeyword.value = ''
+}
+
+function goToDetail(id) {
+  router.push({ name: 'shipment-detail', params: { id } })
+}
 
 function searchRows() {
   appliedFilters.value = {
@@ -251,11 +279,15 @@ function searchRows() {
     <BaseTable
       :columns="columns"
       :rows="filteredRows"
+      clickable-rows
       empty-text="데이터가 없습니다."
       :footer-text="`총 ${filteredRows.length}건`"
+      @row-click="goToDetail($event.id)"
     >
       <template #cell-id="{ value }">
-        <span class="font-mono text-xs font-semibold text-slate-700">{{ value }}</span>
+        <button type="button" class="font-mono text-xs font-semibold text-slate-700 hover:underline" @click.stop="goToDetail(value)">
+          {{ value }}
+        </button>
       </template>
 
       <template #cell-poId="{ value }">
@@ -270,5 +302,20 @@ function searchRows() {
         <StatusBadge :value="value" />
       </template>
     </BaseTable>
+
+    <SearchModal
+      :open="clientSearchOpen"
+      title="거래처 검색"
+      :columns="[
+        { key: 'id', label: '코드' },
+        { key: 'name', label: '거래처명' },
+        { key: 'country', label: '국가' },
+      ]"
+      :rows="clientRows"
+      :search-keyword="clientSearchKeyword"
+      @update:search-keyword="clientSearchKeyword = $event"
+      @close="clientSearchOpen = false"
+      @select="handleClientSelect"
+    />
   </div>
 </template>


### PR DESCRIPTION
  ## 📋 작업 내용

출하지시서와 생산지시서 화면에서 상세 화면, 목록 상세 이동, 인쇄/PDF 액션까지 이어지는 흐름을 구현했습니다.
목록 화면에서는 행 클릭과 문서번호 클릭으로 상세 화면에 진입할 수 있도록 연결했고, 상세 화면에서는 기본 정보와 품목 목록을 확인한 뒤 미리보기, 인쇄, PDF 다운로드 액션을 수행할 수 있도록 정리했습니다.

추가로 인쇄/PDF는 별도 라이브러리 없이 브라우저 인쇄창 기반 공통 출력 유틸로 처리하도록 구현했습니다.
출하지시서/생산지시서 목록의 상세검색 돋보기도 SearchModal로 연결했고, 검토 과정에서 출하현황 화면의 거래처 돋보기 누락도 함께 보완했습니다.

  ## 🔗 관련 이슈

  - closes #68 

  ## 📸 스크린샷 (선택)

# 출하지시서 목록 → 상세 이동 화면
<img width="2826" height="1594" alt="image" src="https://github.com/user-attachments/assets/4f81db76-72d0-480d-9bab-f7dce56b0302" />

# 생산지시서 목록 → 상세 이동 화면
<img width="2840" height="1592" alt="image" src="https://github.com/user-attachments/assets/00e2891f-8d25-4ae2-92a0-886a37e7c0fd" />

# 출하지시서 상세 화면
<img width="2884" height="1242" alt="image" src="https://github.com/user-attachments/assets/5cc08c9f-490b-4946-87ac-ded2acf4f577" />

# 생산지시서 상세 화면
<img width="2868" height="1230" alt="image" src="https://github.com/user-attachments/assets/c6497254-c3da-4cd8-bf67-f7a65d975e13" />

# 인쇄 / PDF 다운로드 실행 화면
<img width="2910" height="1732" alt="image" src="https://github.com/user-attachments/assets/dd287079-7121-4303-ad04-a0566eaab88d" />

# 상세검색 거래처 / 지시서번호 / 품목명 검색 모달 화면
<img width="2588" height="1414" alt="image" src="https://github.com/user-attachments/assets/3cc68a40-2c8a-4141-9f39-0ed1d4330c95" />

  ## ✅ 체크리스트

  - [x] 정상 동작 확인
  - [x] 불필요한 코드/주석 제거
  - [x] 충돌(conflict) 해결 완료

  ## 💬 리뷰어에게

이번 PR은 지시서 화면의 조회 이후 액션 흐름을 마무리하는 작업입니다.
출하지시서와 생산지시서에 대해 상세 화면, 목록 상세 이동, 인쇄/PDF 처리 방식을 연결했고, 별도 PDF 라이브러리 대신 브라우저 인쇄창을 활용하는 방식으로 정리했습니다. 
목록과 상세의 이동 흐름이 자연스러운지, 그리고 인쇄/PDF 처리 방식이 현재 단계 기준으로 무리 없는지 중심으로 봐주시면 됩니다.
