### PR TITLE
fix: 로그인 실패 수정 — json-server v1 쿼리 필터 호환 (#74)

### DIFF
--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -1,11 +1,12 @@
 import { api } from '@/lib/api'
 
 export async function login(email, pw) {
-  // TODO: [SECURITY] GET 요청으로 비밀번호를 쿼리 파라미터에 포함하면 URL이 서버 로그,
-  // 브라우저 히스토리, 프록시 등에 평문으로 노출됩니다.
-  // 백엔드 연동 시 반드시 POST /auth/login { email, password } 방식으로 교체해야 합니다.
-  const { data } = await api.get('/users', { params: { email, pw } })
-  return data[0] ?? null
+  // TODO: [SECURITY] 백엔드 연동 시 POST /auth/login { email, password } 방식으로 교체
+  // json-server v1 beta는 복수 쿼리 파라미터 필터링을 지원하지 않아 email로만 조회 후 pw 비교
+  const { data } = await api.get('/users', { params: { email } })
+  const user = data[0]
+  if (!user || user.pw !== pw) return null
+  return user
 }
 
 export async function fetchUsers() {


### PR DESCRIPTION
## 📋 작업 내용

json-server v1 beta에서 복수 쿼리 파라미터(`email` + `pw`) 동시 필터링이 빈 배열을 반환하여 로그인이 전혀 되지 않는 문제를 수정했습니다.

- `login()` API를 `email` 단일 파라미터로 조회하도록 변경
- 반환된 사용자 객체의 `pw`를 클라이언트에서 비교

## 🔗 관련 이슈

- closes #74

## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

`src/api/auth.js`의 `login()` 함수 한 곳만 변경했습니다. 백엔드 연동 시 POST 방식으로 교체 예정이므로 임시 조치입니다.