### PR TITLE
refactor: 거래처 목록 lookup id 타입 불일치 수정 (#81)

### DIFF
--- a/src/views/master/ClientListPage.vue
+++ b/src/views/master/ClientListPage.vue
@@ -63,22 +63,22 @@ const columns = [
 ]
 
 function getCountryName(countryId) {
-  const found = countries.value.find((c) => c.id === countryId)
+  const found = countries.value.find((c) => String(c.id) === String(countryId))
   return found ? found.name : '-'
 }
 
 function getPortName(portId) {
-  const found = ports.value.find((p) => p.id === portId)
+  const found = ports.value.find((p) => String(p.id) === String(portId))
   return found ? found.name : '-'
 }
 
 function getPaymentTermsCode(paymentTermsId) {
-  const found = paymentTerms.value.find((p) => p.id === paymentTermsId)
+  const found = paymentTerms.value.find((p) => String(p.id) === String(paymentTermsId))
   return found ? found.code : '-'
 }
 
 function getCurrencyCode(currencyId) {
-  const found = currencies.value.find((c) => c.id === currencyId)
+  const found = currencies.value.find((c) => String(c.id) === String(currencyId))
   return found ? found.code : '-'
 }
 


### PR DESCRIPTION
## 📋 작업 내용

거래처 목록 페이지에서 국가·도착항·결제조건·통화가 `"-"`으로 표시되던 문제를 수정했습니다.

- json-server v1 beta가 id를 문자열(`"1"`)로 반환하는데, foreignKey는 숫자(`1`)로 저장되어 strict equality(`===`) 비교 실패
- 4개 lookup 함수(`getCountryName`, `getPortName`, `getPaymentTermsCode`, `getCurrencyCode`)에서 `String()` 비교로 변경

## 🔗 관련 이슈

- closes #81

## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

ClientDetailPage는 이미 `String()` 비교를 사용하고 있어 변경 불필요했습니다. ClientListPage만 수정했습니다.