### PR TITLE
refactor: 거래처 폼 국가→항구·통화 2-step 필터링, GBP 추가, 데이터 정합성 보정 (#83)

### DIFF
--- a/db.json
+++ b/db.json
@@ -399,12 +399,6 @@
   ],
   "ports": [
     {
-      "id": "1",
-      "code": "KRPUS",
-      "name": "Busan",
-      "countryId": 9
-    },
-    {
       "id": "2",
       "code": "CNSHA",
       "name": "Shanghai",
@@ -500,31 +494,43 @@
       "id": "1",
       "code": "USD",
       "name": "US Dollar",
-      "symbol": "$"
+      "symbol": "$",
+      "countryIds": [1, 7, 8, 9, 10, 12, 13]
     },
     {
       "id": "2",
       "code": "EUR",
       "name": "Euro",
-      "symbol": "€"
+      "symbol": "€",
+      "countryIds": [2, 6, 11]
     },
     {
       "id": "3",
       "code": "JPY",
       "name": "Japanese Yen",
-      "symbol": "¥"
+      "symbol": "¥",
+      "countryIds": [3]
     },
     {
       "id": "4",
       "code": "CNY",
       "name": "Chinese Yuan",
-      "symbol": "¥"
+      "symbol": "¥",
+      "countryIds": [4]
     },
     {
       "id": "5",
       "code": "KRW",
       "name": "Korean Won",
-      "symbol": "₩"
+      "symbol": "₩",
+      "countryIds": []
+    },
+    {
+      "id": "6",
+      "code": "GBP",
+      "name": "British Pound",
+      "symbol": "£",
+      "countryIds": [5]
     }
   ],
   "paymentTerms": [
@@ -567,7 +573,7 @@
       "nameKr": "글로벌 스틸",
       "countryId": 1,
       "city": "Houston",
-      "portId": 3,
+      "portId": 13,
       "address": "1234 Industrial Blvd, Houston, TX",
       "tel": "+1-713-555-0101",
       "email": "contact@globalsteel.com",
@@ -640,7 +646,7 @@
       "tel": "+44-20-555-0505",
       "email": "metals@londonmetals.co.uk",
       "paymentTermsId": 2,
-      "currencyId": 1,
+      "currencyId": 6,
       "manager": "James Brown",
       "status": "비활성",
       "regDate": "2025-04-01"

--- a/src/components/domain/master/ClientFormModal.vue
+++ b/src/components/domain/master/ClientFormModal.vue
@@ -29,17 +29,25 @@ const countryOptions = computed(() =>
   props.countries.map((c) => ({ label: `${c.nameKr} (${c.name})`, value: c.id })),
 )
 
-const portOptions = computed(() =>
-  props.ports.map((p) => ({ label: p.name, value: p.id })),
-)
+const portOptions = computed(() => {
+  if (!form.value.countryId) return []
+  const cid = String(form.value.countryId)
+  return props.ports
+    .filter((p) => String(p.countryId) === cid)
+    .map((p) => ({ label: p.name, value: p.id }))
+})
 
 const paymentTermsOptions = computed(() =>
   props.paymentTerms.map((p) => ({ label: `${p.code} (${p.description})`, value: p.id })),
 )
 
-const currencyOptions = computed(() =>
-  props.currencies.map((c) => ({ label: `${c.code} (${c.symbol})`, value: c.id })),
-)
+const currencyOptions = computed(() => {
+  if (!form.value.countryId) return []
+  const cid = Number(form.value.countryId)
+  return props.currencies
+    .filter((c) => c.countryIds?.includes(cid))
+    .map((c) => ({ label: `${c.code} (${c.symbol})`, value: c.id }))
+})
 
 const statusOptions = [
   { label: '활성', value: '활성' },
@@ -100,6 +108,20 @@ watch(
       form.value = getInitialForm()
       form.value.code = generateNextCode()
     }
+  },
+)
+
+watch(
+  () => form.value.countryId,
+  (newId, oldId) => {
+    if (oldId == null || newId === oldId) return
+    // 국가 변경 시 해당 국가에 속하지 않는 항구·통화 초기화
+    const cid = String(newId)
+    const portBelongs = props.ports.some((p) => String(p.countryId) === cid && String(p.id) === String(form.value.portId))
+    if (!portBelongs) form.value.portId = null
+    const numId = Number(newId)
+    const currBelongs = props.currencies.some((c) => c.countryIds?.includes(numId) && String(c.id) === String(form.value.currencyId))
+    if (!currBelongs) form.value.currencyId = null
   },
 )
 
@@ -179,7 +201,7 @@ function handleSave() {
         </FormField>
 
         <FormField label="도착항">
-          <SearchableCombobox v-model="form.portId" :options="portOptions" placeholder="도착항을 검색하세요" />
+          <SearchableCombobox v-model="form.portId" :options="portOptions" :disabled="!form.countryId" :placeholder="form.countryId ? '도착항을 검색하세요' : '국가를 먼저 선택하세요'" />
         </FormField>
 
         <FormField label="주소">
@@ -205,7 +227,7 @@ function handleSave() {
         </FormField>
 
         <FormField label="통화">
-          <BaseSelect v-model="form.currencyId" :options="currencyOptions" placeholder="통화를 선택하세요" />
+          <BaseSelect v-model="form.currencyId" :options="currencyOptions" :disabled="!form.countryId" :placeholder="form.countryId ? '통화를 선택하세요' : '국가를 먼저 선택하세요'" />
         </FormField>
 
         <FormField label="상태">


### PR DESCRIPTION
## 📋 작업 내용

거래처 등록/수정 모달에서 국가·항구·통화가 독립 선택이던 구조를 **국가(대분류) → 항구/통화(중분류)** 2-step 연동으로 개선했습니다.

### UI 변경
- 국가 선택 전: 도착항·통화 필드 **비활성화** + "국가를 먼저 선택하세요" 안내
- 국가 선택 후: 해당 국가의 항구·통화만 드롭다운에 표시
- 국가 변경 시: 기존 항구·통화가 새 국가에 속하지 않으면 자동 초기화

### 데이터 변경 (db.json)
| 항목 | 변경 내용 |
|------|-----------|
| currencies | GBP(£) 추가 (id: 6), 모든 통화에 `countryIds` 매핑 필드 추가 |
| CLI005 (런던 메탈) | currencyId 1(USD) → 6(GBP) |
| CLI001 (글로벌 스틸) | portId 3(LA) → 13(Houston) — 거래처 소재지와 일치 |
| 부산항 (KRPUS) | 삭제 — 출발항으로 도착항 목록에 부적합, countryId 오류, 참조 없음 |

### 통화-국가 매핑
| 통화 | 매핑 국가 |
|------|-----------|
| USD ($) | 미국, 인도, 브라질, 싱가포르, 베트남, 호주, 캐나다 |
| EUR (€) | 독일, 프랑스, 네덜란드 |
| JPY (¥) | 일본 |
| CNY (¥) | 중국 |
| GBP (£) | 영국 |
| KRW (₩) | (내부 통화, 매핑 없음) |

## 🔗 관련 이슈

- closes #83

## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

- 항구 필터링은 ports의 기존 `countryId` 필드를 활용했고, 통화는 새로 추가한 `countryIds` 배열로 필터링합니다.
- json-server v1의 id 문자열 이슈를 고려해 비교 시 `String()` / `Number()` 변환을 사용했습니다.
- 수정 모드에서 기존 데이터 로드 시에는 항구·통화가 초기화되지 않도록 `oldId == null` 가드를 넣었습니다.