### PR TITLE
refactor: 테이블 행 드래그 시 상세 화면 이동 방지 (#85)

### DIFF
--- a/src/components/common/BaseTable.vue
+++ b/src/components/common/BaseTable.vue
@@ -42,6 +42,9 @@ function onRowMouseDown(event) {
 }
 
 function onRowClick(event, row) {
+  // 버튼·링크 등 인터랙티브 요소 클릭 시 행 이동 무시
+  if (event.target.closest('button, a, [data-action]')) return
+
   // 텍스트가 선택된 경우 (드래그) → 클릭 무시
   const selection = window.getSelection()
   if (selection && selection.toString().length > 0) return

--- a/src/views/master/ClientListPage.vue
+++ b/src/views/master/ClientListPage.vue
@@ -190,39 +190,8 @@ async function handleSave(formData) {
   }
 }
 
-let rowMouseDownPos = null
-const DRAG_THRESHOLD = 5
-
-function handleRowMouseDown(event) {
-  rowMouseDownPos = { x: event.clientX, y: event.clientY }
-}
-
-function handleRowClick(event) {
-  // Ignore clicks on action buttons within the row
-  if (event.target.closest('[data-action]') || event.target.closest('button')) return
-
-  // 텍스트 선택(드래그) 시 클릭 무시
-  const selection = window.getSelection()
-  if (selection && selection.toString().length > 0) return
-  if (rowMouseDownPos) {
-    const dx = Math.abs(event.clientX - rowMouseDownPos.x)
-    const dy = Math.abs(event.clientY - rowMouseDownPos.y)
-    if (dx > DRAG_THRESHOLD || dy > DRAG_THRESHOLD) return
-  }
-
-  const tr = event.target.closest('tbody tr')
-  if (!tr) return
-  const rowKey = tr.dataset.rowKey ?? tr.getAttribute('data-row-key')
-  if (rowKey) {
-    router.push({ name: 'client-detail', params: { id: rowKey } })
-    return
-  }
-  // Fallback: match by DOM index against filtered array
-  const rows = Array.from(tr.parentElement.children)
-  const index = rows.indexOf(tr)
-  if (index >= 0 && index < filteredClients.value.length) {
-    router.push({ name: 'client-detail', params: { id: filteredClients.value[index].id } })
-  }
+function goToDetail(row) {
+  router.push({ name: 'client-detail', params: { id: row.id } })
 }
 </script>
 
@@ -247,10 +216,10 @@ function handleRowClick(event) {
       데이터를 불러오는 중입니다...
     </div>
 
-    <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events -->
-    <div v-else class="cursor-pointer" @mousedown="handleRowMouseDown" @click="handleRowClick">
-    <BaseTable :columns="columns" :rows="filteredClients" row-key="id"
+    <BaseTable v-else :columns="columns" :rows="filteredClients" row-key="id"
       :empty-text="searchKeyword || statusFilter ? '검색 결과가 없습니다.' : '등록된 거래처가 없습니다.'"
+      clickable-rows
+      @row-click="goToDetail"
     >
       <template #cell-code="{ row }">
         <span class="font-mono text-xs font-semibold text-brand-600">{{ row.code }}</span>
@@ -287,7 +256,6 @@ function handleRowClick(event) {
         <TableActions @edit="openEditModal(row)" @delete="confirmDelete(row)" />
       </template>
     </BaseTable>
-    </div>
 
     <div class="flex items-center justify-between rounded-xl bg-slate-50 px-4 py-3 text-sm text-slate-600">
       <span>총 {{ filteredClients.length }}건</span>

--- a/src/views/master/ItemListPage.vue
+++ b/src/views/master/ItemListPage.vue
@@ -136,39 +136,8 @@ async function handleSave(formData) {
   }
 }
 
-let rowMouseDownPos = null
-const DRAG_THRESHOLD = 5
-
-function handleRowMouseDown(event) {
-  rowMouseDownPos = { x: event.clientX, y: event.clientY }
-}
-
-function handleRowClick(event) {
-  // Ignore clicks on action buttons within the row
-  if (event.target.closest('[data-action]') || event.target.closest('button')) return
-
-  // 텍스트 선택(드래그) 시 클릭 무시
-  const selection = window.getSelection()
-  if (selection && selection.toString().length > 0) return
-  if (rowMouseDownPos) {
-    const dx = Math.abs(event.clientX - rowMouseDownPos.x)
-    const dy = Math.abs(event.clientY - rowMouseDownPos.y)
-    if (dx > DRAG_THRESHOLD || dy > DRAG_THRESHOLD) return
-  }
-
-  const tr = event.target.closest('tbody tr')
-  if (!tr) return
-  const rowKey = tr.dataset.rowKey ?? tr.getAttribute('data-row-key')
-  if (rowKey) {
-    router.push({ name: 'item-detail', params: { id: rowKey } })
-    return
-  }
-  // Fallback: match by DOM index against filtered array
-  const rows = Array.from(tr.parentElement.children)
-  const index = rows.indexOf(tr)
-  if (index >= 0 && index < filteredItems.value.length) {
-    router.push({ name: 'item-detail', params: { id: filteredItems.value[index].id } })
-  }
+function goToDetail(row) {
+  router.push({ name: 'item-detail', params: { id: row.id } })
 }
 </script>
 
@@ -193,10 +162,10 @@ function handleRowClick(event) {
       데이터를 불러오는 중입니다...
     </div>
 
-    <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events -->
-    <div v-else class="cursor-pointer" @mousedown="handleRowMouseDown" @click="handleRowClick">
-    <BaseTable :columns="columns" :rows="filteredItems" row-key="id"
+    <BaseTable v-else :columns="columns" :rows="filteredItems" row-key="id"
       :empty-text="searchKeyword || categoryFilter ? '검색 결과가 없습니다.' : '등록된 품목이 없습니다.'"
+      clickable-rows
+      @row-click="goToDetail"
     >
       <template #cell-code="{ row }">
         <span class="font-mono text-xs font-semibold text-brand-600">{{ row.code }}</span>
@@ -225,7 +194,6 @@ function handleRowClick(event) {
         <TableActions @edit="openEditModal(row)" @delete="confirmDelete(row)" />
       </template>
     </BaseTable>
-    </div>
 
     <div class="flex items-center justify-between rounded-xl bg-slate-50 px-4 py-3 text-sm text-slate-600">
       <span>총 {{ filteredItems.length }}건</span>


### PR DESCRIPTION
## 📋 작업 내용

테이블 행에서 텍스트를 드래그로 선택(복사)하면 mouseup이 클릭으로 처리되어 상세 화면으로 이동하던 문제를 수정하고, **행 클릭 방식을 전체 페이지에서 통일**했습니다.

### 드래그 판별 로직 (BaseTable, 2중 가드)
1. **버튼/링크 가드**: `button`, `a`, `[data-action]` 클릭은 행 이동 무시
2. **마우스 이동 거리**: mousedown 좌표를 기록, click 시 이동 거리가 5px 초과하면 드래그로 판단
3. **텍스트 선택 감지**: `window.getSelection().toString()` 길이가 0보다 크면 드래그로 판단

### 행 클릭 방식 통일
| Before | After |
|--------|-------|
| Master 페이지: 래퍼 div `@click` + DOM 탐색 (`closest('tbody tr')`) | **BaseTable `@row-click`** |
| 문서 페이지: BaseTable `@row-click` | BaseTable `@row-click` (변경 없음) |

Master 페이지의 래퍼 div, `handleRowClick`, DOM 인덱스 fallback 등 불필요한 코드를 전부 제거하고, 문서 페이지와 동일하게 `@row-click="goToDetail"` 패턴으로 통일했습니다. 드래그 가드는 BaseTable 한 곳에만 존재합니다.

### 변경 파일
| 파일 | 변경 내용 |
|------|-----------|
| `BaseTable.vue` | 드래그 가드 + 버튼 클릭 가드 추가 |
| `ClientListPage.vue` | 래퍼 div 제거, `@row-click` 사용으로 전환 (−50줄) |
| `ItemListPage.vue` | 래퍼 div 제거, `@row-click` 사용으로 전환 (−50줄) |

## 🔗 관련 이슈

- closes #85

## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

- 모든 목록 페이지가 이제 동일한 패턴(`BaseTable @row-click`)을 사용합니다.
- 드래그 가드 코드가 BaseTable 한 곳에만 있어 유지보수가 간편합니다.
- `clickable-rows` prop도 Master 페이지에 추가해 `cursor-pointer` 스타일이 적용됩니다.