### PR TITLE
refactor: PageHeader·DetailPageHeader 공통 컴포넌트 생성 (#87)

### DIFF
--- a/src/components/common/DetailPageHeader.vue
+++ b/src/components/common/DetailPageHeader.vue
@@ -1,0 +1,37 @@
+<script setup>
+import StatusBadge from '@/components/common/StatusBadge.vue'
+
+defineProps({
+  title: {
+    type: String,
+    required: true,
+  },
+  status: {
+    type: String,
+    default: '',
+  },
+})
+
+const emit = defineEmits(['back'])
+</script>
+
+<template>
+  <div class="flex flex-wrap items-center gap-3">
+    <button
+      type="button"
+      class="flex h-9 w-9 items-center justify-center rounded-lg text-slate-400 transition hover:bg-slate-100 hover:text-slate-700"
+      @click="emit('back')"
+    >
+      <i class="fas fa-arrow-left" aria-hidden="true"></i>
+    </button>
+    <h2 class="text-xl font-bold text-slate-900">{{ title }}</h2>
+    <slot name="status">
+      <StatusBadge v-if="status" :value="status" />
+    </slot>
+    <div class="flex-1"></div>
+
+    <div v-if="$slots.actions" class="flex flex-wrap items-center gap-2">
+      <slot name="actions" />
+    </div>
+  </div>
+</template>

--- a/src/components/common/DocumentPageHeader.vue
+++ b/src/components/common/DocumentPageHeader.vue
@@ -1,30 +1,5 @@
-<script setup>
-defineProps({
-  title: {
-    type: String,
-    required: true,
-  },
-  iconClass: {
-    type: String,
-    required: true,
-  },
-})
+<script>
+// DEPRECATED: DocumentPageHeader → PageHeader로 이름 변경
+// 기존 import 호환을 위한 re-export. 서비스별 리팩토링 시 PageHeader로 교체 예정
+export { default } from './PageHeader.vue'
 </script>
-
-<template>
-  <section class="flex flex-col items-start justify-between gap-3 sm:flex-row sm:items-center sm:gap-4">
-    <h2 class="flex items-center gap-2.5 text-xl font-bold text-slate-900">
-      <div class="flex h-9 w-9 items-center justify-center rounded-lg bg-slate-50">
-        <i :class="[iconClass, 'text-sm text-brand-600']" aria-hidden="true"></i>
-      </div>
-      {{ title }}
-    </h2>
-
-    <div
-      v-if="$slots.actions"
-      class="flex w-full flex-wrap items-center justify-end gap-2 sm:w-auto sm:flex-nowrap"
-    >
-      <slot name="actions" />
-    </div>
-  </section>
-</template>

--- a/src/components/common/PageHeader.vue
+++ b/src/components/common/PageHeader.vue
@@ -1,0 +1,30 @@
+<script setup>
+defineProps({
+  title: {
+    type: String,
+    required: true,
+  },
+  iconClass: {
+    type: String,
+    required: true,
+  },
+})
+</script>
+
+<template>
+  <section class="flex flex-col items-start justify-between gap-3 sm:flex-row sm:items-center sm:gap-4">
+    <h2 class="flex items-center gap-2.5 text-xl font-bold text-slate-900">
+      <div class="flex h-9 w-9 items-center justify-center rounded-lg bg-slate-50">
+        <i :class="[iconClass, 'text-sm text-brand-600']" aria-hidden="true"></i>
+      </div>
+      {{ title }}
+    </h2>
+
+    <div
+      v-if="$slots.actions"
+      class="flex w-full flex-wrap items-center justify-end gap-2 sm:w-auto sm:flex-nowrap"
+    >
+      <slot name="actions" />
+    </div>
+  </section>
+</template>


### PR DESCRIPTION
## 📋 작업 내용

목록·상세 페이지에서 헤더 패턴이 2종류로 분열된 구조를 공통 컴포넌트로 통일할 수 있도록 기반 컴포넌트를 생성합니다.

### 신규 컴포넌트

**`PageHeader`** — 목록 페이지 표준 헤더
- Props: `title`, `iconClass`
- Slots: `actions`
- 기존 `DocumentPageHeader`와 동일 스타일, 이름만 범용화

**`DetailPageHeader`** — 상세 페이지 표준 헤더
- Props: `title`, `status`
- Emits: `back`
- Slots: `status` (StatusBadge 커스텀 가능), `actions`
- `!important` 오버라이드 없이 사용 가능한 설계

### 하위 호환
- `DocumentPageHeader.vue`를 `PageHeader` re-export로 변경 → 기존 import 깨지지 않음
- 서비스별 리팩토링 시 `PageHeader`로 교체 + `PageTitleBar` 사용처도 `PageHeader`로 교체 예정

## 🔗 관련 이슈

- closes #87

## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

이 PR은 컴포넌트 생성만 포함합니다. 각 서비스 페이지에서의 적용은 도메인별 이슈로 분리하여 병렬 작업 예정입니다.