### PR TITLE
refactor: alert→useToast 통일, ConfirmModal 통일, BaseButton primary 색상 보정 (#90)

### DIFF
--- a/src/components/common/BaseButton.vue
+++ b/src/components/common/BaseButton.vue
@@ -25,7 +25,7 @@ const props = defineProps({
 })
 
 const variantClasses = {
-  primary: 'border-slate-500 bg-slate-500 text-white shadow-sm hover:border-brand-600 hover:bg-brand-600 focus-visible:ring-brand/30',
+  primary: 'border-brand bg-brand text-white shadow-sm hover:border-brand-600 hover:bg-brand-600 focus-visible:ring-brand/30',
   secondary: 'border-slate-200 bg-white text-slate-600 hover:bg-slate-50 focus-visible:ring-slate-300',
   ghost: 'border-slate-100 bg-slate-100 text-slate-700 hover:border-slate-200 hover:bg-slate-200 focus-visible:ring-slate-300',
   danger: 'border-red-200 bg-red-50 text-red-700 hover:bg-red-100 focus-visible:ring-red-200',

--- a/src/components/layout/AppHeader.vue
+++ b/src/components/layout/AppHeader.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import ConfirmModal from '@/components/common/ConfirmModal.vue'
 import PasswordChangeModal from '@/components/domain/auth/PasswordChangeModal.vue'
 import { useUiStore } from '@/stores/ui'
 import { useAuthStore } from '@/stores/auth'
@@ -96,8 +97,14 @@ const userRole = computed(() => {
   return roles[loggedInUser.value?.role] || ''
 })
 
+const isLogoutConfirmOpen = ref(false)
+
 function handleLogout() {
-  if (!confirm('로그아웃 하시겠습니까?')) return
+  isLogoutConfirmOpen.value = true
+}
+
+function confirmLogout() {
+  isLogoutConfirmOpen.value = false
   authStore.logout()
   router.push({ name: 'login' })
 }
@@ -212,4 +219,13 @@ onBeforeUnmount(() => {
   </header>
 
   <PasswordChangeModal :open="isPasswordModalOpen" @close="closePasswordModal" @save="closePasswordModal" />
+
+  <ConfirmModal
+    :open="isLogoutConfirmOpen"
+    title="로그아웃"
+    message="로그아웃 하시겠습니까?"
+    confirm-label="로그아웃"
+    @confirm="confirmLogout"
+    @cancel="isLogoutConfirmOpen = false"
+  />
 </template>

--- a/src/views/activity/ActivityCreatePage.vue
+++ b/src/views/activity/ActivityCreatePage.vue
@@ -3,6 +3,7 @@ import { computed, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { createActivity, fetchActivityClients, fetchPOsByClient } from '@/api/activity'
 import { useAuthStore } from '@/stores/auth'
+import { useToast } from '@/composables/useToast'
 import BaseButton from '@/components/common/BaseButton.vue'
 import BaseCard from '@/components/common/BaseCard.vue'
 import BaseSelect from '@/components/common/BaseSelect.vue'
@@ -13,6 +14,8 @@ import PageTitleBar from '@/components/layout/PageTitleBar.vue'
 import SearchableCombobox from '@/components/common/SearchableCombobox.vue'
 import SearchModal from '@/components/common/SearchModal.vue'
 import SearchTriggerField from '@/components/common/SearchTriggerField.vue'
+
+const { success, error: showError } = useToast()
 
 const router = useRouter()
 const authStore = useAuthStore()
@@ -78,7 +81,7 @@ const filteredPoList = computed(() => {
 
 async function openPoSearch() {
   if (!formClient.value) {
-    alert('거래처를 먼저 선택해주세요.')
+    showError('거래처를 먼저 선택해주세요.')
     return
   }
   try {
@@ -104,7 +107,10 @@ function clearPo() {
 }
 
 async function handleSubmit() {
-  if (!formClient.value || !formType.value || !formDate.value || !formTitle.value || !formAuthor.value) return
+  if (!formClient.value || !formType.value || !formDate.value || !formTitle.value || !formAuthor.value) {
+    showError('거래처, 유형, 날짜, 제목, 작성자는 필수 항목입니다.')
+    return
+  }
   try {
     await createActivity({
       clientId: formClient.value,
@@ -119,7 +125,7 @@ async function handleSubmit() {
     router.push('/activities')
   } catch (e) {
     console.error('기록 등록 실패', e)
-    alert('기록 등록에 실패했습니다. 다시 시도해주세요.')
+    showError('기록 등록에 실패했습니다. 다시 시도해주세요.')
   }
 }
 </script>

--- a/src/views/activity/ActivityListPage.vue
+++ b/src/views/activity/ActivityListPage.vue
@@ -18,7 +18,10 @@ import SearchableCombobox from '@/components/common/SearchableCombobox.vue'
 import TableActions from '@/components/common/TableActions.vue'
 import SearchTriggerField from '@/components/common/SearchTriggerField.vue'
 
+import { useToast } from '@/composables/useToast'
+
 const router = useRouter()
+const { error: showError } = useToast()
 
 // ── 필터 상태 ──────────────────────────────────────────────
 const isFilterOpen = ref(false)
@@ -165,7 +168,7 @@ async function handleSave(updated) {
     closeEdit()
   } catch (e) {
     console.error('기록 수정 실패', e)
-    alert('기록 수정에 실패했습니다. 다시 시도해주세요.')
+    showError('기록 수정에 실패했습니다. 다시 시도해주세요.')
   }
 }
 
@@ -190,7 +193,7 @@ async function handleDelete() {
     closeDelete()
   } catch (e) {
     console.error('기록 삭제 실패', e)
-    alert('기록 삭제에 실패했습니다. 다시 시도해주세요.')
+    showError('기록 삭제에 실패했습니다. 다시 시도해주세요.')
   }
 }
 

--- a/src/views/contacts/ContactListPage.vue
+++ b/src/views/contacts/ContactListPage.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { computed, onMounted, ref } from 'vue'
+import { useToast } from '@/composables/useToast'
 import { fetchBuyers, createBuyer, updateBuyer, deleteBuyer } from '@/api/contacts'
 import { fetchActivityClients } from '@/api/activity'
 import BaseButton from '@/components/common/BaseButton.vue'
@@ -11,6 +12,8 @@ import InfoField from '@/components/common/InfoField.vue'
 import PageTitleBar from '@/components/layout/PageTitleBar.vue'
 import SearchableCombobox from '@/components/common/SearchableCombobox.vue'
 import TableActions from '@/components/common/TableActions.vue'
+
+const { error: showError } = useToast()
 
 // ── 데이터 ─────────────────────────────────────────────────
 const clients = ref([])
@@ -112,7 +115,10 @@ function openEdit(contact) {
 }
 
 async function handleFormSubmit() {
-  if (!formClientId.value || !formName.value || !formEmail.value) return
+  if (!formClientId.value || !formName.value || !formEmail.value) {
+    showError('거래처, 이름, 이메일은 필수 항목입니다.')
+    return
+  }
   const payload = {
     clientId:    formClientId.value,
     name:        formName.value,
@@ -133,7 +139,7 @@ async function handleFormSubmit() {
     closeForm()
   } catch (e) {
     console.error('연락처 저장 실패', e)
-    alert('저장에 실패했습니다. 다시 시도해주세요.')
+    showError('저장에 실패했습니다. 다시 시도해주세요.')
   }
 }
 
@@ -163,7 +169,7 @@ async function handleDelete() {
     closeDelete()
   } catch (e) {
     console.error('연락처 삭제 실패', e)
-    alert('삭제에 실패했습니다. 다시 시도해주세요.')
+    showError('삭제에 실패했습니다. 다시 시도해주세요.')
   }
 }
 </script>


### PR DESCRIPTION
## 📋 작업 내용

프로젝트 전체에서 에러 피드백·확인 모달·버튼 스타일이 일부 페이지에서만 다른 패턴을 사용하던 문제를 통일했습니다.

### 변경 사항

| 파일 | Before | After |
|------|--------|-------|
| `BaseButton.vue` | primary `bg-slate-500` (회색) | `bg-brand` (브랜드색) |
| `ActivityCreatePage.vue` | `alert()` 2건, 필수값 무시 시 무반응 | `useToast` + 필수값 에러 메시지 |
| `ActivityListPage.vue` | `alert()` 2건 | `useToast` |
| `ContactListPage.vue` | `alert()` 2건, 필수값 무시 시 무반응 | `useToast` + 필수값 에러 메시지 |
| `AppHeader.vue` | `window.confirm()` | `ConfirmModal` |

## 🔗 관련 이슈

- closes #90

## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

`alert()` 6건 전부 `useToast`로 교체, `window.confirm()` 1건 `ConfirmModal`로 교체했습니다. 이제 프로젝트 전체에서 네이티브 다이얼로그를 사용하는 곳이 없습니다.