### PR TITLE
refactor: useDocumentFilter composable 및 공통 룩업 옵션 상수 추출 (#89)

### DIFF
--- a/src/composables/useDocumentFilter.js
+++ b/src/composables/useDocumentFilter.js
@@ -1,0 +1,95 @@
+import { computed, ref } from 'vue'
+
+/**
+ * 문서 목록 페이지 공통 필터 composable
+ *
+ * @param {import('vue').Ref<Array>} rows - 원본 데이터 배열 ref
+ * @param {Object} options
+ * @param {Array<string>} options.keywordFields - 키워드 검색 대상 필드명 배열
+ * @param {string} options.issueDateField - 발행일 필드명 (기본: 'issueDate')
+ * @param {string} options.deliveryDateField - 납기 필드명 (기본: 'deliveryDate')
+ * @param {string} options.codeField - 코드/번호 필드명 (기본: 'id')
+ * @param {string} options.clientField - 거래처 필드명 (기본: 'clientName')
+ * @param {string} options.productField - 품목 필드명 (기본: 'itemName')
+ */
+export function useDocumentFilter(rows, options = {}) {
+  const {
+    keywordFields = ['id', 'clientName', 'country', 'itemName', 'amount', 'manager', 'status', 'issueDate', 'deliveryDate'],
+    issueDateField = 'issueDate',
+    deliveryDateField = 'deliveryDate',
+    codeField = 'id',
+    clientField = 'clientName',
+    productField = 'itemName',
+  } = options
+
+  const filters = ref(getEmptyFilters())
+  const appliedFilters = ref(getEmptyFilters())
+
+  function getEmptyFilters() {
+    return {
+      keyword: '',
+      registeredFrom: '',
+      registeredTo: '',
+      manager: '',
+      clientName: '',
+      code: '',
+      productName: '',
+      country: '',
+      status: '',
+      deliveryFrom: '',
+      deliveryTo: '',
+    }
+  }
+
+  function normalizeDate(value) {
+    return String(value ?? '').replaceAll('/', '-')
+  }
+
+  function resetFilters() {
+    filters.value = getEmptyFilters()
+    appliedFilters.value = getEmptyFilters()
+  }
+
+  function applyFilters() {
+    appliedFilters.value = { ...filters.value }
+  }
+
+  const filteredRows = computed(() => {
+    return rows.value.filter((row) => {
+      const keyword = appliedFilters.value.keyword.trim().toLowerCase()
+
+      if (keyword) {
+        const matched = keywordFields.some(
+          (field) => String(row[field] ?? '').toLowerCase().includes(keyword),
+        )
+        if (!matched) return false
+      }
+
+      if (appliedFilters.value.manager && row.manager !== appliedFilters.value.manager) return false
+      if (appliedFilters.value.clientName && !String(row[clientField] ?? '').toLowerCase().includes(appliedFilters.value.clientName.toLowerCase())) return false
+      if (appliedFilters.value.code && !String(row[codeField] ?? '').toLowerCase().includes(appliedFilters.value.code.toLowerCase())) return false
+      if (appliedFilters.value.productName && !String(row[productField] ?? '').toLowerCase().includes(appliedFilters.value.productName.toLowerCase())) return false
+      if (appliedFilters.value.country && row.country !== appliedFilters.value.country) return false
+      if (appliedFilters.value.status && row.status !== appliedFilters.value.status) return false
+
+      const issueDate = normalizeDate(row[issueDateField])
+      const deliveryDate = normalizeDate(row[deliveryDateField])
+
+      if (appliedFilters.value.registeredFrom && issueDate < appliedFilters.value.registeredFrom) return false
+      if (appliedFilters.value.registeredTo && issueDate > appliedFilters.value.registeredTo) return false
+      if (appliedFilters.value.deliveryFrom && deliveryDate < appliedFilters.value.deliveryFrom) return false
+      if (appliedFilters.value.deliveryTo && deliveryDate > appliedFilters.value.deliveryTo) return false
+
+      return true
+    })
+  })
+
+  return {
+    filters,
+    appliedFilters,
+    filteredRows,
+    resetFilters,
+    applyFilters,
+    normalizeDate,
+  }
+}

--- a/src/constants/documentOptions.js
+++ b/src/constants/documentOptions.js
@@ -1,0 +1,20 @@
+/**
+ * 문서 페이지 공통 필터 옵션
+ * 각 페이지에서 import하여 사용
+ */
+
+export const managerOptions = [
+  { value: '김영업', label: '김영업' },
+  { value: '정영업', label: '정영업' },
+  { value: '최관리', label: '최관리' },
+]
+
+export const countryOptions = [
+  { value: '말레이시아', label: '말레이시아' },
+  { value: '독일', label: '독일' },
+  { value: '미국', label: '미국' },
+  { value: '태국', label: '태국' },
+  { value: '싱가포르', label: '싱가포르' },
+  { value: '인도', label: '인도' },
+  { value: '호주', label: '호주' },
+]


### PR DESCRIPTION
## 📋 작업 내용

8개 문서 목록 페이지에 복붙되던 필터 로직을 composable로 추출하고, 6개 페이지에 중복된 룩업 옵션을 공통 상수로 통일했습니다.

### 신규 파일

**`src/composables/useDocumentFilter.js`**
- `filters`, `appliedFilters` — 필터 상태 관리
- `filteredRows` — 키워드·필드·날짜 범위 필터링 computed
- `resetFilters`, `applyFilters` — 초기화/적용 액션
- `normalizeDate` — 날짜 형식 정규화
- 옵션: `keywordFields`, `issueDateField`, `deliveryDateField`, `codeField`, `clientField`, `productField`로 페이지별 커스텀 가능

**`src/constants/documentOptions.js`**
- `managerOptions` — 담당자 필터 옵션 (3명)
- `countryOptions` — 국가 필터 옵션 (7개국, 기존 일부 페이지에서 '호주' 누락 해소)

### 사용 예시
```js
import { useDocumentFilter } from '@/composables/useDocumentFilter'
import { managerOptions, countryOptions } from '@/constants/documentOptions'

const rowsData = ref([...])
const { filters, appliedFilters, filteredRows, resetFilters, applyFilters } = useDocumentFilter(rowsData)
```

## 🔗 관련 이슈

- closes #89

## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

이 PR은 composable/상수 생성만 포함합니다. 각 문서 페이지에서 기존 인라인 코드를 이 composable로 교체하는 작업은 Document 도메인 이슈(#93)에서 진행됩니다.