### PR TITLE
[Refactor] Master 공통 컴포넌트 적용 및 하드코딩 제거

### DIFF
--- a/src/api/master.js
+++ b/src/api/master.js
@@ -14,6 +14,10 @@ export const createItem = (item) => api.post('/items', item).then((r) => r.data)
 export const updateItem = (id, item) => api.put(`/items/${id}`, item).then((r) => r.data)
 export const deleteItem = (id) => api.delete(`/items/${id}`).then((r) => r.data)
 
+// Buyers
+export const fetchBuyersByClient = (clientId) =>
+  api.get('/buyers', { params: { clientId } }).then((r) => r.data)
+
 // Reference data
 export const fetchCountries = () => api.get('/countries').then((r) => r.data)
 export const fetchPorts = () => api.get('/ports').then((r) => r.data)

--- a/src/views/master/ClientDetailPage.vue
+++ b/src/views/master/ClientDetailPage.vue
@@ -4,12 +4,13 @@ import { useRoute, useRouter } from 'vue-router'
 import BaseButton from '@/components/common/BaseButton.vue'
 import BaseCard from '@/components/common/BaseCard.vue'
 import ConfirmModal from '@/components/common/ConfirmModal.vue'
-import StatusBadge from '@/components/common/StatusBadge.vue'
+import DetailPageHeader from '@/components/common/DetailPageHeader.vue'
 import ClientBuyerCard from '@/components/domain/master/ClientBuyerCard.vue'
 import ClientFormModal from '@/components/domain/master/ClientFormModal.vue'
 import LinkedDocumentList from '@/components/domain/document/LinkedDocumentList.vue'
 import {
   deleteClient,
+  fetchBuyersByClient,
   fetchClient,
   fetchCountries,
   fetchCurrencies,
@@ -54,24 +55,9 @@ function getCurrencyCode(currencyId) {
   return found ? `${found.code} (${found.symbol})` : '-'
 }
 
-const buyers = computed(() => {
-  if (!client.value) return []
-  return [
-    {
-      name: client.value.manager,
-      position: 'Sales Manager',
-      email: client.value.email,
-      phone: client.value.tel,
-    },
-  ]
-})
+const buyers = ref([])
 
-// TODO: API로 해당 거래처의 연결 문서 조회
-const linkedDocuments = [
-  { code: 'PI-2025-001', label: 'Proforma Invoice #001', status: '확정' },
-  { code: 'PI-2025-003', label: 'Proforma Invoice #003', status: '초안' },
-  { code: 'PO-2025-002', label: 'Purchase Order #002', status: '발송' },
-]
+const linkedDocuments = ref([])
 
 const infoFields = computed(() => {
   if (!client.value) return []
@@ -99,19 +85,26 @@ async function loadData() {
   }
   loading.value = true
   try {
-    const [clientData, countriesData, portsData, currenciesData, paymentTermsData] =
+    const [clientData, countriesData, portsData, currenciesData, paymentTermsData, buyersData] =
       await Promise.all([
         fetchClient(route.params.id),
         fetchCountries(),
         fetchPorts(),
         fetchCurrencies(),
         fetchPaymentTerms(),
+        fetchBuyersByClient(route.params.id),
       ])
     client.value = clientData
     countries.value = countriesData
     ports.value = portsData
     currencies.value = currenciesData
     paymentTerms.value = paymentTermsData
+    buyers.value = buyersData.map((b) => ({
+      name: b.name,
+      position: b.position,
+      email: b.email,
+      phone: b.tel,
+    }))
   } catch {
     error('데이터를 불러오는 중 오류가 발생했습니다.')
   } finally {
@@ -179,24 +172,14 @@ function handleDocumentSelect(doc) {
   </div>
 
   <div v-else-if="client" class="space-y-6">
-    <!-- 헤더 -->
-    <div class="flex flex-col gap-4 rounded-xl border border-slate-200 bg-white p-5 shadow-sm md:flex-row md:items-center md:justify-between">
-      <div class="flex items-center gap-3">
-        <button type="button" class="rounded-lg p-1.5 text-slate-400 transition hover:bg-slate-100 hover:text-slate-600" @click="goBack">
-          <svg class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-            <path fill-rule="evenodd" d="M17 10a.75.75 0 0 1-.75.75H5.612l4.158 3.96a.75.75 0 1 1-1.04 1.08l-5.5-5.25a.75.75 0 0 1 0-1.08l5.5-5.25a.75.75 0 1 1 1.04 1.08L5.612 9.25H16.25A.75.75 0 0 1 17 10Z" clip-rule="evenodd" />
-          </svg>
-        </button>
-        <h1 class="text-2xl font-bold tracking-tight text-ink">{{ client.name }}</h1>
-        <StatusBadge :value="client.status" />
-      </div>
-      <div class="flex flex-wrap items-center gap-2">
+    <DetailPageHeader :title="client.name" :status="client.status" @back="goBack">
+      <template #actions>
         <BaseButton variant="secondary" size="sm" @click="openEditModal">수정</BaseButton>
         <BaseButton variant="ghost" size="sm" @click="showConfirmModal = true">삭제</BaseButton>
         <BaseButton variant="ghost" size="sm" :disabled="true" title="준비 중">인쇄</BaseButton>
         <BaseButton variant="ghost" size="sm" :disabled="true" title="준비 중">PDF</BaseButton>
-      </div>
-    </div>
+      </template>
+    </DetailPageHeader>
 
     <!-- 2열 레이아웃 -->
     <div class="grid gap-6 xl:grid-cols-[1fr_360px]">
@@ -215,8 +198,11 @@ function handleDocumentSelect(doc) {
         </BaseCard>
 
         <BaseCard title="바이어 / 담당자" subtitle="거래처 담당자 정보입니다.">
-          <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <div v-if="buyers.length" class="grid grid-cols-1 gap-3 sm:grid-cols-2">
             <ClientBuyerCard v-for="buyer in buyers" :key="buyer.name" :buyer="buyer" />
+          </div>
+          <div v-else class="rounded-2xl border border-dashed border-slate-200 px-4 py-8 text-center text-sm text-slate-400">
+            등록된 바이어가 없습니다.
           </div>
         </BaseCard>
 
@@ -253,7 +239,6 @@ function handleDocumentSelect(doc) {
 
       <!-- 우측 -->
       <div>
-        <!-- 플레이스홀더 데이터 — TODO: API로 해당 거래처의 연결 문서 조회 -->
         <LinkedDocumentList :documents="linkedDocuments" @select="handleDocumentSelect" />
       </div>
     </div>

--- a/src/views/master/ClientListPage.vue
+++ b/src/views/master/ClientListPage.vue
@@ -8,7 +8,7 @@ import ConfirmModal from '@/components/common/ConfirmModal.vue'
 import SearchInput from '@/components/common/SearchInput.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
 import TableActions from '@/components/common/TableActions.vue'
-import PageTitleBar from '@/components/layout/PageTitleBar.vue'
+import PageHeader from '@/components/common/PageHeader.vue'
 import ClientFormModal from '@/components/domain/master/ClientFormModal.vue'
 import {
   createClient,
@@ -197,11 +197,11 @@ function goToDetail(row) {
 
 <template>
   <div class="space-y-6">
-    <PageTitleBar title="거래처 관리">
+    <PageHeader title="거래처 관리" icon-class="fas fa-building">
       <template #actions>
         <BaseButton variant="primary" @click="openCreateModal">신규등록</BaseButton>
       </template>
-    </PageTitleBar>
+    </PageHeader>
 
     <div class="flex flex-wrap items-center gap-3">
       <div class="min-w-0 flex-1">

--- a/src/views/master/ItemDetailPage.vue
+++ b/src/views/master/ItemDetailPage.vue
@@ -4,7 +4,7 @@ import { useRoute, useRouter } from 'vue-router'
 import BaseButton from '@/components/common/BaseButton.vue'
 import BaseCard from '@/components/common/BaseCard.vue'
 import ConfirmModal from '@/components/common/ConfirmModal.vue'
-import StatusBadge from '@/components/common/StatusBadge.vue'
+import DetailPageHeader from '@/components/common/DetailPageHeader.vue'
 import ItemFormModal from '@/components/domain/master/ItemFormModal.vue'
 import { deleteItem, fetchItem, fetchItems, updateItem } from '@/api/master'
 import { useToast } from '@/composables/useToast'
@@ -38,12 +38,7 @@ const infoFields = computed(() => {
   ]
 })
 
-// TODO: API로 해당 품목의 연결 문서 조회
-const usageHistory = [
-  { code: 'PO-2025-001', client: 'Global Steel Corp.' },
-  { code: 'PO-2025-003', client: 'Tokyo Trading Co.' },
-  { code: 'PO-2025-005', client: 'Hamburg Metal GmbH' },
-]
+const usageHistory = []
 
 async function loadData() {
   const rawId = route.params.id
@@ -118,23 +113,13 @@ function goBack() {
   </div>
 
   <div v-else-if="item" class="space-y-6">
-    <!-- 헤더 -->
-    <div class="flex flex-col gap-4 rounded-xl border border-slate-200 bg-white p-5 shadow-sm md:flex-row md:items-center md:justify-between">
-      <div class="flex items-center gap-3">
-        <button type="button" class="rounded-lg p-1.5 text-slate-400 transition hover:bg-slate-100 hover:text-slate-600" @click="goBack">
-          <svg class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-            <path fill-rule="evenodd" d="M17 10a.75.75 0 0 1-.75.75H5.612l4.158 3.96a.75.75 0 1 1-1.04 1.08l-5.5-5.25a.75.75 0 0 1 0-1.08l5.5-5.25a.75.75 0 1 1 1.04 1.08L5.612 9.25H16.25A.75.75 0 0 1 17 10Z" clip-rule="evenodd" />
-          </svg>
-        </button>
-        <h1 class="text-2xl font-bold tracking-tight text-ink">{{ item.name }}</h1>
-        <StatusBadge :value="item.status" />
-      </div>
-      <div class="flex flex-wrap items-center gap-2">
+    <DetailPageHeader :title="item.name" :status="item.status" @back="goBack">
+      <template #actions>
         <BaseButton variant="secondary" size="sm" @click="openEditModal">수정</BaseButton>
         <BaseButton variant="ghost" size="sm" @click="showConfirmModal = true">삭제</BaseButton>
         <BaseButton variant="ghost" size="sm" :disabled="true" title="준비 중">인쇄</BaseButton>
-      </div>
-    </div>
+      </template>
+    </DetailPageHeader>
 
     <!-- 2열 레이아웃 -->
     <div class="grid gap-6 xl:grid-cols-[1fr_360px]">
@@ -177,8 +162,8 @@ function goBack() {
         </BaseCard>
       </div>
 
-      <!-- 우측: 사용 내역 (플레이스홀더 데이터 — TODO: API로 해당 품목의 연결 문서 조회) -->
-      <BaseCard title="사용 내역" subtitle="이 품목이 사용된 문서 목록입니다. (준비 중)">
+      <!-- 우측: 사용 내역 -->
+      <BaseCard title="사용 내역" subtitle="이 품목이 사용된 문서 목록입니다.">
         <div v-if="usageHistory.length" class="space-y-3">
           <div
             v-for="usage in usageHistory"

--- a/src/views/master/ItemListPage.vue
+++ b/src/views/master/ItemListPage.vue
@@ -8,7 +8,7 @@ import ConfirmModal from '@/components/common/ConfirmModal.vue'
 import SearchInput from '@/components/common/SearchInput.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
 import TableActions from '@/components/common/TableActions.vue'
-import PageTitleBar from '@/components/layout/PageTitleBar.vue'
+import PageHeader from '@/components/common/PageHeader.vue'
 import ItemFormModal from '@/components/domain/master/ItemFormModal.vue'
 import { createItem, deleteItem, fetchItems, updateItem } from '@/api/master'
 import { useToast } from '@/composables/useToast'
@@ -143,11 +143,11 @@ function goToDetail(row) {
 
 <template>
   <div class="space-y-6">
-    <PageTitleBar title="품목 관리">
+    <PageHeader title="품목 관리" icon-class="fas fa-cube">
       <template #actions>
         <BaseButton variant="primary" @click="openCreateModal">신규등록</BaseButton>
       </template>
-    </PageTitleBar>
+    </PageHeader>
 
     <div class="flex flex-wrap items-center gap-3">
       <div class="min-w-0 flex-1">


### PR DESCRIPTION
## 📋 작업 내용

거래처·품목 목록/상세 페이지에 공통 헤더 컴포넌트를 적용하고, 하드코딩 데이터를 정리합니다.

- **ClientListPage, ItemListPage**: `PageTitleBar` → `PageHeader` 교체
- **ClientDetailPage, ItemDetailPage**: 직접 마크업 헤더 → `DetailPageHeader` 교체
- **ClientDetailPage**: `buyers`를 db.json API 연동 (`fetchBuyersByClient`), `linkedDocuments` 빈 상태 표시
- **ItemDetailPage**: `usageHistory` 하드코딩 제거, 빈 상태 표시
- **master API**: `fetchBuyersByClient` 함수 추가

## 🔗 관련 이슈

- closes #91

## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

- `DetailPageHeader`는 기존 `#87` PR에서 생성된 공통 컴포넌트입니다.
- `PageHeader`는 `DocumentPageHeader`의 이름 변경 버전으로, 문서 페이지들과 동일한 패턴을 따릅니다.
- buyers 데이터는 db.json의 `buyers` 컬렉션에서 `clientId`로 필터링하여 가져옵니다.