### PR TITLE
refactor: 활동기록 화면 UI 개선 및 코드 정리

### DIFF
--- a/src/components/domain/activity/ActivityEditModal.vue
+++ b/src/components/domain/activity/ActivityEditModal.vue
@@ -35,6 +35,7 @@ watch(
     formDate.value    = val?.date    ?? ''
     formTitle.value   = val?.title   ?? ''
     formContent.value = val?.content ?? ''
+    errors.value      = {}
   },
   { immediate: true },
 )

--- a/src/views/activity/ActivityCreatePage.vue
+++ b/src/views/activity/ActivityCreatePage.vue
@@ -19,6 +19,7 @@ const authStore = useAuthStore()
 const { warning, error } = useToast()
 
 // ── state ──────────────────────────────────────────────────
+const isSubmitting = ref(false)
 const formClient = ref('')
 const formType = ref('')
 const formPoDisplay = ref('')
@@ -121,6 +122,7 @@ async function handleSubmit() {
     warning('입력 내용을 확인해주세요.')
     return
   }
+  isSubmitting.value = true
   try {
     await createActivity({
       clientId: formClient.value,
@@ -136,6 +138,8 @@ async function handleSubmit() {
   } catch (e) {
     console.error('기록 등록 실패', e)
     error('기록 등록에 실패했습니다. 다시 시도해주세요.')
+  } finally {
+    isSubmitting.value = false
   }
 }
 </script>
@@ -262,7 +266,7 @@ async function handleSubmit() {
 
         <!-- 저장 버튼 -->
         <div class="pt-2">
-          <BaseButton @click="handleSubmit">
+          <BaseButton :disabled="isSubmitting" @click="handleSubmit">
             <template #leading>
               <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                 <path fill-rule="evenodd" d="M16.704 4.153a.75.75 0 0 1 .143 1.052l-8 10.5a.75.75 0 0 1-1.127.075l-4.5-4.5a.75.75 0 0 1 1.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 0 1 1.05-.143Z" clip-rule="evenodd" />

--- a/src/views/activity/ActivityListPage.vue
+++ b/src/views/activity/ActivityListPage.vue
@@ -86,6 +86,7 @@ onMounted(async () => {
     clients.value = clientData
   } catch (e) {
     console.error('데이터 로드 실패', e)
+    error('데이터를 불러오지 못했습니다. 페이지를 새로고침해주세요.')
   }
 })
 
@@ -175,9 +176,11 @@ function closeDelete() {
 }
 
 async function handleDelete() {
+  const targetId = deleteTarget.value?.id
+  if (!targetId) return
   try {
-    await deleteActivity(deleteTarget.value.id)
-    activities.value = activities.value.filter((a) => a.id !== deleteTarget.value.id)
+    await deleteActivity(targetId)
+    activities.value = activities.value.filter((a) => a.id !== targetId)
     closeDelete()
   } catch (e) {
     console.error('기록 삭제 실패', e)

--- a/src/views/contacts/ContactListPage.vue
+++ b/src/views/contacts/ContactListPage.vue
@@ -27,6 +27,7 @@ onMounted(async () => {
     contacts.value = buyerData
   } catch (e) {
     console.error('데이터 로드 실패', e)
+    error('데이터를 불러오지 못했습니다. 페이지를 새로고침해주세요.')
   }
 })
 
@@ -111,6 +112,7 @@ function openEdit(contact) {
   formPosition.value = contact.position
   formEmail.value = contact.email
   formTel.value = contact.tel
+  formErrors.value = {}
   isDetailOpen.value = false
   isFormOpen.value = true
 }

--- a/src/views/emails/EmailListPage.vue
+++ b/src/views/emails/EmailListPage.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { computed, onMounted, ref } from 'vue'
 import { fetchActivityEmails } from '@/api/emails'
+import { useToast } from '@/composables/useToast'
 import BaseButton from '@/components/common/BaseButton.vue'
 import BaseModal from '@/components/common/BaseModal.vue'
 import BaseSelect from '@/components/common/BaseSelect.vue'
@@ -14,6 +15,8 @@ import PageHeader from '@/components/common/PageHeader.vue'
 import SearchableCombobox from '@/components/common/SearchableCombobox.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
 
+const { error } = useToast()
+
 // ── 데이터 ─────────────────────────────────────────────────
 const emails = ref([])
 
@@ -22,6 +25,7 @@ onMounted(async () => {
     emails.value = await fetchActivityEmails()
   } catch (e) {
     console.error('메일 이력 로드 실패', e)
+    error('데이터를 불러오지 못했습니다. 페이지를 새로고침해주세요.')
   }
 })
 
@@ -186,7 +190,7 @@ const columns = [
       <!-- 항목 번호 -->
       <template #cell-index="{ row }">
         <span class="text-xs font-medium text-slate-500">
-          {{ emails.findIndex((e) => e.id === row.id) + 1 }}
+          {{ filteredEmails.findIndex((e) => e.id === row.id) + 1 }}
         </span>
       </template>
 

--- a/src/views/package/ActivityPackagePage.vue
+++ b/src/views/package/ActivityPackagePage.vue
@@ -61,8 +61,8 @@ function clearPo() {
 // ── 패키지 생성 폼 상태 ────────────────────────────────────
 const keyword     = ref('')
 const poDisplay   = ref('')
-const dateFrom    = ref('2025-01-01')
-const dateTo      = ref('2025-03-19')
+const dateFrom    = ref(`${new Date().getFullYear()}-01-01`)
+const dateTo      = ref(new Date().toISOString().slice(0, 10))
 
 const includes = ref({
   meetings:    true,


### PR DESCRIPTION
## 📋 작업 내용

- 활동기록 4개 화면(`기록관리`, `기록등록`, `컨텍리스트`, `메일이력`, `활동기록패키지`) `PageTitleBar` → `DocumentPageHeader`(아이콘 포함)로 교체
- `ActivityListPage`: 체크박스 제거, 행 클릭 시 상세 모달 오픈, 컬럼 너비/정렬 조정
- `ActivityCreatePage`: PO 검색 UI를 `ActivityPackagePage`와 동일한 버튼 스타일로 통일
- `ActivityEditModal`: 필수값(날짜, 제목) 유효성 검사 및 인라인 에러 메시지 추가
- 메일 이력 -> 첨부 (hover 시 po넘버 보여짐) -> po넘버에 hover시 pdf 파일 링크 추가
- 전체 화면 `alert()` / `confirm()` → `useToast` (`error`, `warning`)로 교체

## 🔗 관련 이슈

- 

## 📸 스크린샷 (선택)

<img width="218" height="170" alt="image" src="https://github.com/user-attachments/assets/19888366-c768-4c59-a008-56b20254a0c3" />

<img width="198" height="110" alt="image" src="https://github.com/user-attachments/assets/5db07c75-672f-45b9-ac73-e18915579cf6" />

<img width="1442" height="638" alt="image" src="https://github.com/user-attachments/assets/291c349a-5c77-49d0-9e8b-02df0f333f02" />

<img width="1433" height="819" alt="image" src="https://github.com/user-attachments/assets/8369f05d-9d78-413a-86d0-7de3e09f2e8e" />


## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

- `alert()`/`confirm()` 제거 후 `useToast`로 통일한 부분 위주로 확인 부탁드립니다.