### PR TITLE
refactor: Auth F/E 로직 QA — 역할 가드, 타입 정규화, pw 노출, 데드코드 수정

### DIFF
--- a/src/components/domain/auth/UserFormModal.vue
+++ b/src/components/domain/auth/UserFormModal.vue
@@ -61,9 +61,9 @@ watch(
       form.value = {
         name: props.user.name ?? '',
         email: props.user.email ?? '',
-        positionId: props.user.positionId ?? '',
+        positionId: String(props.user.positionId ?? ''),
         role: props.user.role ?? '',
-        departmentId: props.user.departmentId ?? '',
+        departmentId: String(props.user.departmentId ?? ''),
         status: props.user.status ?? '재직',
         transferDepartmentId: '',
         transferReason: '',
@@ -159,7 +159,7 @@ const currentDepartmentName = computed(() => {
         <FormField label="직급" required :error="errors.positionId">
           <BaseSelect
             v-model="form.positionId"
-            :options="positions.map((p) => ({ label: p.name, value: p.id }))"
+            :options="positions.map((p) => ({ label: p.name, value: String(p.id) }))"
             placeholder="직급을 선택하세요"
           />
         </FormField>
@@ -172,7 +172,7 @@ const currentDepartmentName = computed(() => {
           <FormField label="팀" required :error="errors.departmentId">
             <BaseSelect
               v-model="form.departmentId"
-              :options="departments.map((d) => ({ label: d.name, value: d.id }))"
+              :options="departments.map((d) => ({ label: d.name, value: String(d.id) }))"
               placeholder="팀을 선택하세요"
             />
           </FormField>
@@ -205,7 +205,7 @@ const currentDepartmentName = computed(() => {
             <FormField label="이동할 팀">
               <BaseSelect
                 v-model="form.transferDepartmentId"
-                :options="[{ label: '변경안함', value: '' }, ...departments.map((d) => ({ label: d.name, value: d.id }))]"
+                :options="[{ label: '변경안함', value: '' }, ...departments.map((d) => ({ label: d.name, value: String(d.id) }))]"
               />
             </FormField>
             <FormField label="이동 사유">

--- a/src/components/domain/auth/UserListTab.vue
+++ b/src/components/domain/auth/UserListTab.vue
@@ -203,7 +203,8 @@ async function handleDelete() {
   deleting.value = true
   try {
     // 물리 삭제(deleteUser) 대신 소프트 삭제: status를 '퇴직'으로 변경
-    await updateUser(userToDelete.value.id, { ...userToDelete.value, status: '퇴직' })
+    const { pw: _, ...safeUser } = userToDelete.value
+    await updateUser(safeUser.id, { ...safeUser, status: '퇴직' })
     success(`${userToDelete.value.name} 사용자가 퇴직 처리되었습니다.`)
     await loadData()
   } catch (e) {

--- a/src/main.js
+++ b/src/main.js
@@ -36,7 +36,12 @@ router.beforeEach(async (to) => {
 
   // AT 없으면 RT로 세션 복구 시도
   const restored = await authStore.restoreSession()
-  if (restored) return true
+  if (restored) {
+    if (to.meta.requiredRole && authStore.currentUser?.role !== to.meta.requiredRole) {
+      return { name: 'dashboard' }
+    }
+    return true
+  }
 
   // 복구 실패 → 로그인 페이지
   return { name: 'login', query: { redirect: to.fullPath } }

--- a/src/views/auth/ForgotPasswordPage.vue
+++ b/src/views/auth/ForgotPasswordPage.vue
@@ -33,9 +33,10 @@ async function handleSubmit() {
 
   loading.value = true
   try {
+    // TODO: 백엔드 연동 시 await sendPasswordResetEmail(email.value.trim())
     submitted.value = true
     success('등록된 이메일이라면 재설정 링크가 발송됩니다.')
-  } catch (e) {
+  } catch {
     error('이메일 확인 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.')
   } finally {
     loading.value = false


### PR DESCRIPTION
## 📋 작업 내용

Auth 서비스의 프론트엔드 로직 오류 4건을 검증하고 수정했습니다.

- `main.js` — `restoreSession()` 후 `requiredRole` 가드 우회 방지
- `UserFormModal` — positionId/departmentId String 정규화 (select DOM 타입 불일치 해결)
- `UserListTab` — 소프트 삭제 시 pw 필드 API 페이로드에서 제거
- `ForgotPasswordPage` — try/catch 데드코드 정리 + TODO 주석

## 🔗 관련 이슈

- closes #114

## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

`main.js` 가드 수정은 보안 관련입니다 — 비관리자의 `/users` 직접 접근이 차단되는지 확인 부탁드립니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)