### PR TITLE
refactor: Master F/E 로직 QA — 코드 중복검증, 404 처리, 타입 통일, 가드 수정

### DIFF
--- a/src/components/domain/master/ClientFormModal.vue
+++ b/src/components/domain/master/ClientFormModal.vue
@@ -43,9 +43,9 @@ const paymentTermsOptions = computed(() =>
 
 const currencyOptions = computed(() => {
   if (!form.value.countryId) return []
-  const cid = Number(form.value.countryId)
+  const cid = String(form.value.countryId)
   return props.currencies
-    .filter((c) => c.countryIds?.includes(cid))
+    .filter((c) => c.countryIds?.map(String).includes(cid))
     .map((c) => ({ label: `${c.code} (${c.symbol})`, value: c.id }))
 })
 
@@ -119,8 +119,7 @@ watch(
     const cid = String(newId)
     const portBelongs = props.ports.some((p) => String(p.countryId) === cid && String(p.id) === String(form.value.portId))
     if (!portBelongs) form.value.portId = null
-    const numId = Number(newId)
-    const currBelongs = props.currencies.some((c) => c.countryIds?.includes(numId) && String(c.id) === String(form.value.currencyId))
+    const currBelongs = props.currencies.some((c) => c.countryIds?.map(String).includes(cid) && String(c.id) === String(form.value.currencyId))
     if (!currBelongs) form.value.currencyId = null
   },
 )
@@ -130,11 +129,12 @@ function validate() {
 
   if (!form.value.code?.trim()) {
     e.code = '코드를 입력하세요.'
-  } else if (props.mode === 'create') {
-    const duplicate = props.allClients.some(
-      (c) => c.code.toLowerCase() === form.value.code.trim().toLowerCase(),
+  } else if (
+    props.allClients.some(
+      (c) => c.code.toLowerCase() === form.value.code.trim().toLowerCase() && c.id !== props.client?.id,
     )
-    if (duplicate) e.code = '이미 사용 중인 코드입니다.'
+  ) {
+    e.code = '이미 사용 중인 코드입니다.'
   }
 
   if (!form.value.name?.trim()) {
@@ -163,6 +163,7 @@ function validate() {
 function handleSave() {
   if (!validate()) return
   const payload = { ...form.value }
+  // TODO: 백엔드 파일 업로드 API 연동 시 sealImage 전송 활성화
   delete payload.sealImage
   emit('save', payload)
 }

--- a/src/components/domain/master/ItemFormModal.vue
+++ b/src/components/domain/master/ItemFormModal.vue
@@ -116,11 +116,12 @@ function validate() {
 
   if (!form.value.code?.trim()) {
     e.code = '코드를 입력하세요.'
-  } else if (props.mode === 'create') {
-    const duplicate = props.allItems.some(
-      (i) => i.code.toLowerCase() === form.value.code.trim().toLowerCase(),
+  } else if (
+    props.allItems.some(
+      (i) => i.code.toLowerCase() === form.value.code.trim().toLowerCase() && i.id !== props.item?.id,
     )
-    if (duplicate) e.code = '이미 사용 중인 코드입니다.'
+  ) {
+    e.code = '이미 사용 중인 코드입니다.'
   }
 
   if (!form.value.name?.trim()) {

--- a/src/views/master/ClientDetailPage.vue
+++ b/src/views/master/ClientDetailPage.vue
@@ -94,6 +94,11 @@ async function loadData() {
         fetchPaymentTerms(),
         fetchBuyersByClient(route.params.id),
       ])
+    if (!clientData) {
+      error('거래처를 찾을 수 없습니다.')
+      router.push({ name: 'client-list' })
+      return
+    }
     client.value = clientData
     countries.value = countriesData
     ports.value = portsData
@@ -152,7 +157,7 @@ async function handleDelete() {
 }
 
 function goBack() {
-  if (window.history.length > 1) router.back()
+  if (router.options.history.state?.back) router.back()
   else router.push({ name: 'client-list' })
 }
 

--- a/src/views/master/ItemDetailPage.vue
+++ b/src/views/master/ItemDetailPage.vue
@@ -38,7 +38,7 @@ const infoFields = computed(() => {
   ]
 })
 
-const usageHistory = []
+const usageHistory = ref([])
 
 async function loadData() {
   const rawId = route.params.id
@@ -53,6 +53,11 @@ async function loadData() {
       fetchItem(route.params.id),
       fetchItems(),
     ])
+    if (!itemData) {
+      error('품목을 찾을 수 없습니다.')
+      router.push({ name: 'item-list' })
+      return
+    }
     item.value = itemData
     allItems.value = itemsData
   } catch {
@@ -102,7 +107,7 @@ async function handleDelete() {
 }
 
 function goBack() {
-  if (window.history.length > 1) router.back()
+  if (router.options.history.state?.back) router.back()
   else router.push({ name: 'item-list' })
 }
 </script>


### PR DESCRIPTION
## 📋 작업 내용

Master 서비스의 프론트엔드 로직 오류 7건을 검증하고 수정했습니다.

- `ClientFormModal` / `ItemFormModal` — edit 모드에서도 코드 중복 검증 (자기 자신 제외)
- `ClientDetailPage` / `ItemDetailPage` — fetch 404 시 에러 토스트 + 목록 리다이렉트
- `ClientFormModal` — countryId 필터링 타입을 String으로 일관화
- `ClientFormModal` — sealImage 삭제에 TODO 주석 추가 (의도적 strip 명시)
- `ItemDetailPage` — `usageHistory`를 `ref([])`로 반응형 전환
- 양쪽 DetailPage — `goBack()` 가드를 `router.options.history.state?.back`으로 수정

## 🔗 관련 이슈

- closes #116

## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

코드 중복 검증 로직이 create/edit 모두에서 동작하도록 변경되었습니다. 거래처/품목 수정 시 코드 변경 테스트 확인 부탁드립니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)