### PR TITLE
refactor: 페이지네이션 디자인 Activity 스타일로 통일

### DIFF
--- a/src/views/master/ClientListPage.vue
+++ b/src/views/master/ClientListPage.vue
@@ -38,8 +38,8 @@ const deleting = ref(false)
 const searchKeyword = ref('')
 const statusFilter = ref('')
 
+const PAGE_SIZE = 10
 const currentPage = ref(1)
-const pageSize = ref(20)
 
 const showFormModal = ref(false)
 const formMode = ref('create')
@@ -116,11 +116,11 @@ const filteredClients = computed(() => {
   return result
 })
 
-const totalPages = computed(() => Math.ceil(filteredClients.value.length / pageSize.value) || 1)
+const totalPages = computed(() => Math.max(1, Math.ceil(filteredClients.value.length / PAGE_SIZE)))
 
 const paginatedClients = computed(() => {
-  const start = (currentPage.value - 1) * pageSize.value
-  return filteredClients.value.slice(start, start + pageSize.value)
+  const start = (currentPage.value - 1) * PAGE_SIZE
+  return filteredClients.value.slice(start, start + PAGE_SIZE)
 })
 
 // Reset to page 1 when filters change
@@ -273,13 +273,16 @@ function goToDetail(row) {
       </template>
     </BaseTable>
 
-    <div class="flex items-center justify-between rounded-xl bg-slate-50 px-4 py-3 text-sm text-slate-600">
-      <span>총 {{ filteredClients.length }}건</span>
-      <BasePagination
-        :current-page="currentPage"
-        :total-pages="totalPages"
-        @update:current-page="currentPage = $event"
-      />
+    <div>
+      <div class="mt-2 px-1 text-xs text-slate-500">
+        <span>총 {{ filteredClients.length }}건</span>
+      </div>
+      <div class="mt-4">
+        <BasePagination
+          v-model:current-page="currentPage"
+          :total-pages="totalPages"
+        />
+      </div>
     </div>
 
     <ClientFormModal

--- a/src/views/master/ItemListPage.vue
+++ b/src/views/master/ItemListPage.vue
@@ -25,8 +25,8 @@ const deleting = ref(false)
 const searchKeyword = ref('')
 const categoryFilter = ref('')
 
+const PAGE_SIZE = 10
 const currentPage = ref(1)
-const pageSize = ref(20)
 
 const showFormModal = ref(false)
 const formMode = ref('create')
@@ -73,11 +73,11 @@ const filteredItems = computed(() => {
   return result
 })
 
-const totalPages = computed(() => Math.ceil(filteredItems.value.length / pageSize.value) || 1)
+const totalPages = computed(() => Math.max(1, Math.ceil(filteredItems.value.length / PAGE_SIZE)))
 
 const paginatedItems = computed(() => {
-  const start = (currentPage.value - 1) * pageSize.value
-  return filteredItems.value.slice(start, start + pageSize.value)
+  const start = (currentPage.value - 1) * PAGE_SIZE
+  return filteredItems.value.slice(start, start + PAGE_SIZE)
 })
 
 // Reset to page 1 when filters change
@@ -211,13 +211,16 @@ function goToDetail(row) {
       </template>
     </BaseTable>
 
-    <div class="flex items-center justify-between rounded-xl bg-slate-50 px-4 py-3 text-sm text-slate-600">
-      <span>총 {{ filteredItems.length }}건</span>
-      <BasePagination
-        :current-page="currentPage"
-        :total-pages="totalPages"
-        @update:current-page="currentPage = $event"
-      />
+    <div>
+      <div class="mt-2 px-1 text-xs text-slate-500">
+        <span>총 {{ filteredItems.length }}건</span>
+      </div>
+      <div class="mt-4">
+        <BasePagination
+          v-model:current-page="currentPage"
+          :total-pages="totalPages"
+        />
+      </div>
     </div>
 
     <ItemFormModal


### PR DESCRIPTION
## 📋 작업 내용

Master 페이지(거래처, 품목)의 페이지네이션을 Activity 페이지와 동일한 디자인으로 통일했습니다.

**변경 사항:**
- 페이지 크기: `ref(20)` → 상수 `PAGE_SIZE = 10`
- UI: `bg-slate-50` 통합 바 → 카운트/페이지네이션 분리 (Activity와 동일)
- 바인딩: `@update:current-page` → `v-model:current-page`

## 🔗 관련 이슈

- closes #123

## 📸 스크린샷 (선택)

| Before | After |
|--------|-------|
| `bg-slate-50` 바 안에 카운트+페이지네이션 합쳐짐, 20건 단위 | 카운트와 페이지네이션 분리, 10건 단위 (Activity와 동일) |

## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

- ClientListPage, ItemListPage 두 파일만 수정했습니다
- BasePagination 공통 컴포넌트는 변경 없음
- Activity 페이지의 페이지네이션 패턴을 그대로 적용했습니다