### PR TITLE
hotfix: 품목 목록 관세코드 → HS Code 라벨 수정

### DIFF
--- a/src/views/master/ItemListPage.vue
+++ b/src/views/master/ItemListPage.vue
@@ -48,7 +48,7 @@ const columns = [
   { key: 'unit', label: '단위', width: '80px', align: 'center' },
   { key: 'unitPrice', label: '단가 (KRW)', width: '140px', align: 'right' },
   { key: 'weight', label: '중량 (kg)', width: '110px', align: 'right' },
-  { key: 'hsCode', label: '관세코드', width: '100px', align: 'center' },
+  { key: 'hsCode', label: 'HS Code', width: '100px', align: 'center' },
   { key: 'status', label: '상태', width: '80px', align: 'center' },
   { key: 'actions', label: '액션', width: '120px', align: 'center' },
 ]


### PR DESCRIPTION
## 📋 작업 내용

품목 관리 목록(ItemListPage)의 테이블 컬럼 라벨을 국제 무역 표준 용어에 맞게 `관세코드` → `HS Code`로 변경했습니다.

- 다른 화면(ItemDetailPage, ItemFormModal)은 이미 `HS Code`로 표기되어 있어 변경 불필요
- DB/API 필드명(`hsCode`)은 그대로 유지

## 🔗 관련 이슈

- closes #122

## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

- `ItemListPage.vue` 1줄 변경입니다 (컬럼 label만 수정)
- ItemDetailPage, ItemFormModal은 이미 `HS Code`로 되어 있어 수정하지 않았습니다