### PR TITLE
refactor: 활동기록 상세조회 모달 레이아웃 개선 (#110)

### DIFF
--- a/src/components/domain/activity/ActivityDetailModal.vue
+++ b/src/components/domain/activity/ActivityDetailModal.vue
@@ -24,16 +24,37 @@ defineEmits(['close'])
     description="활동 기록 상세 내용을 확인하는 공통 모달"
     @close="$emit('close')"
   >
-    <div class="space-y-4">
-      <InfoField label="유형">
-        <div class="flex justify-end">
-          <ActivityTypeBadge :value="activity.type || '메모/노트'" />
+    <div class="space-y-5">
+      <!-- 기본 정보 -->
+      <div>
+        <p class="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">기본 정보</p>
+        <div class="rounded-lg border border-slate-100 bg-slate-50 px-4">
+          <InfoField label="유형">
+            <div class="flex justify-end">
+              <ActivityTypeBadge :value="activity.type || '메모/노트'" />
+            </div>
+          </InfoField>
+          <InfoField label="거래처" :value="activity.client" />
+          <InfoField label="PO" :value="activity.poId || '-'" />
         </div>
-      </InfoField>
-      <InfoField label="거래처" :value="activity.client" />
-      <InfoField label="작성일" :value="activity.date" />
-      <InfoField label="작성자" :value="activity.author" />
-      <InfoField label="내용" :value="activity.content || '-'" />
+      </div>
+
+      <!-- 작성 정보 -->
+      <div>
+        <p class="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">작성 정보</p>
+        <div class="rounded-lg border border-slate-100 bg-slate-50 px-4">
+          <InfoField label="작성자" :value="activity.author" />
+          <InfoField label="작성일" :value="activity.date" />
+        </div>
+      </div>
+
+      <!-- 내용 -->
+      <div>
+        <p class="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">내용</p>
+        <div class="rounded-lg border border-slate-100 bg-slate-50 px-4 py-3">
+          <p class="whitespace-pre-wrap text-sm text-slate-700">{{ activity.content || '-' }}</p>
+        </div>
+      </div>
     </div>
   </BaseModal>
 </template>


### PR DESCRIPTION
## 📋 작업 내용

ActivityDetailModal.vue 상세조회 모달의 레이아웃을 팀 피드백에 따라 개선합니다.

- **정보 그룹핑**: 기본 정보 / 작성 정보 / 내용 3개 섹션으로 분리
- **PO 필드 추가**: 기존 모달에 누락된 poId 필드 표시
- **내용 영역 개선**: `whitespace-pre-wrap` 적용으로 줄바꿈 처리 및 가독성 향상
- **시각적 구분**: 섹션 헤더 + 배경색 카드로 정보 구분 명확화

## 🔗 관련 이슈

- closes #110

## 수정한 화면

<img width="1433" height="456" alt="image" src="https://github.com/user-attachments/assets/14f53d76-b73b-452a-916b-fc0351acf3c0" />


## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

ActivityDetailModal.vue만 수정되었습니다. 기존 props 구조는 그대로 유지하여 상위 컴포넌트(ActivityListPage.vue) 변경 없이 적용됩니다.