### PR TITLE
refactor: 메일 이력 상세검색 수신자 필터 추가 및 레이아웃 개선

### DIFF
--- a/db.json
+++ b/db.json
@@ -1164,7 +1164,7 @@
       "unit": "EA",
       "packUnit": "BOX",
       "unitPrice": 1200000,
-      "weight": 22.0,
+      "weight": 22,
       "hsCode": "8443.32",
       "category": "Electronics",
       "status": "활성",
@@ -1224,7 +1224,7 @@
       "unit": "EA",
       "packUnit": "LOOSE",
       "unitPrice": 3500000,
-      "weight": 38.0,
+      "weight": 38,
       "hsCode": "8528.52",
       "category": "Electronics",
       "status": "활성",
@@ -5039,7 +5039,7 @@
       "clientName": "Global Steel Corp.",
       "country": "USA",
       "itemName": "Business Laptop 15\"",
-      "grossWeight": 90.0
+      "grossWeight": 90
     },
     {
       "id": "PL2025002",
@@ -5048,7 +5048,7 @@
       "clientName": "Hamburg Metal GmbH",
       "country": "Germany",
       "itemName": "LED Monitor 27\"",
-      "grossWeight": 126.0
+      "grossWeight": 126
     },
     {
       "id": "PL2025003",
@@ -5057,7 +5057,7 @@
       "clientName": "Tokyo Trading Co.",
       "country": "Japan",
       "itemName": "Laser Printer A4",
-      "grossWeight": 156.0
+      "grossWeight": 156
     },
     {
       "id": "PL2025004",
@@ -5084,7 +5084,7 @@
       "clientName": "Paris Acier SA",
       "country": "France",
       "itemName": "Smart Projector FHD",
-      "grossWeight": 70.0
+      "grossWeight": 70
     },
     {
       "id": "PL2025007",
@@ -5093,7 +5093,7 @@
       "clientName": "Mumbai Steel Works",
       "country": "India",
       "itemName": "UPS 1000VA",
-      "grossWeight": 380.0
+      "grossWeight": 380
     },
     {
       "id": "PL2025008",
@@ -5111,7 +5111,7 @@
       "clientName": "Singapore Pipe Pte",
       "country": "Singapore",
       "itemName": "Mechanical Keyboard",
-      "grossWeight": 85.0
+      "grossWeight": 85
     },
     {
       "id": "PL2025010",
@@ -5120,7 +5120,7 @@
       "clientName": "Hanoi Industries",
       "country": "Vietnam",
       "itemName": "Wireless Mouse",
-      "grossWeight": 18.0
+      "grossWeight": 18
     },
     {
       "id": "PL2025011",
@@ -5129,7 +5129,7 @@
       "clientName": "Dtech Electronics Inc.",
       "country": "USA",
       "itemName": "All-in-One PC 24\"",
-      "grossWeight": 126.0
+      "grossWeight": 126
     },
     {
       "id": "PL2025012",
@@ -5138,7 +5138,7 @@
       "clientName": "Berlin Digital AG",
       "country": "Germany",
       "itemName": "Multifunction Printer A3",
-      "grossWeight": 330.0
+      "grossWeight": 330
     },
     {
       "id": "PL2025013",
@@ -5147,7 +5147,7 @@
       "clientName": "Osaka Tech Corp.",
       "country": "Japan",
       "itemName": "NAS Storage 4-Bay",
-      "grossWeight": 21.0
+      "grossWeight": 21
     },
     {
       "id": "PL2025014",
@@ -5156,7 +5156,7 @@
       "clientName": "Shenzhen Gadgets Co.",
       "country": "China",
       "itemName": "USB-C Hub 7-in-1",
-      "grossWeight": 60.0
+      "grossWeight": 60
     },
     {
       "id": "PL2025015",
@@ -5174,7 +5174,7 @@
       "clientName": "Paris Digital SAS",
       "country": "France",
       "itemName": "Smart Whiteboard 65\"",
-      "grossWeight": 190.0
+      "grossWeight": 190
     },
     {
       "id": "PL2025017",
@@ -5183,7 +5183,7 @@
       "clientName": "Singapore Electronics Pte",
       "country": "Singapore",
       "itemName": "Network Switch 24Port",
-      "grossWeight": 105.0
+      "grossWeight": 105
     },
     {
       "id": "PL2025018",
@@ -5192,7 +5192,7 @@
       "clientName": "Sydney Tech Pty",
       "country": "Australia",
       "itemName": "Wireless Presenter",
-      "grossWeight": 9.0
+      "grossWeight": 9
     },
     {
       "id": "PL2025019",
@@ -5210,7 +5210,7 @@
       "clientName": "Hanoi Digital JSC",
       "country": "Vietnam",
       "itemName": "External SSD 1TB",
-      "grossWeight": 15.0
+      "grossWeight": 15
     }
   ],
   "productionOrders": [

--- a/src/views/emails/EmailListPage.vue
+++ b/src/views/emails/EmailListPage.vue
@@ -4,10 +4,9 @@ import { fetchActivityEmails } from '@/api/emails'
 import { useToast } from '@/composables/useToast'
 import BaseButton from '@/components/common/BaseButton.vue'
 import BaseModal from '@/components/common/BaseModal.vue'
-import BaseSelect from '@/components/common/BaseSelect.vue'
 import BaseTable from '@/components/common/BaseTable.vue'
 import CollapsibleFilterCard from '@/components/common/CollapsibleFilterCard.vue'
-import DateRangeField from '@/components/common/DateRangeField.vue'
+import DateField from '@/components/common/DateField.vue'
 import FilterToolbarCard from '@/components/common/FilterToolbarCard.vue'
 import FormField from '@/components/common/FormField.vue'
 import InfoField from '@/components/common/InfoField.vue'
@@ -34,9 +33,10 @@ const isFilterOpen = ref(false)
 const filterKeyword = ref('')
 const filterType    = ref('')
 const filterStatus  = ref('')
-const filterSender  = ref('')
-const filterDateFrom = ref('')
-const filterDateTo   = ref('')
+const filterSender    = ref('')
+const filterRecipient = ref('')
+const filterDateFrom  = ref('')
+const filterDateTo    = ref('')
 
 const typeOptions = [
   { label: 'PI', value: 'PI' },
@@ -51,44 +51,56 @@ const statusOptions = [
 ]
 
 const senderOptions = computed(() => {
-  const unique = [...new Set(emails.value.map((e) => e.sender))]
+  const unique = [...new Set(emails.value.map((e) => e.sender).filter(Boolean))]
   return unique.map((s) => ({ label: s, value: s }))
 })
 
+const recipientOptions = computed(() => {
+  const unique = [...new Set(emails.value.map((e) => e.recipient).filter(Boolean))]
+  return unique.map((r) => ({ label: r, value: r }))
+})
+
 // 실제 적용된 필터 (검색 버튼 클릭 시에만 반영)
-const applied = ref({ keyword: '', type: '', status: '', sender: '', dateFrom: '', dateTo: '' })
+const applied = ref({ keyword: '', type: '', status: '', sender: '', recipient: '', dateFrom: '', dateTo: '' })
+const recipientKey = ref(0)
 
 function applySearch() {
   applied.value = {
-    keyword:  filterKeyword.value,
-    type:     filterType.value,
-    status:   filterStatus.value,
-    sender:   filterSender.value,
-    dateFrom: filterDateFrom.value,
-    dateTo:   filterDateTo.value,
+    keyword:   filterKeyword.value,
+    type:      filterType.value,
+    status:    filterStatus.value,
+    sender:    filterSender.value,
+    recipient: filterRecipient.value,
+    dateFrom:  filterDateFrom.value,
+    dateTo:    filterDateTo.value,
   }
 }
 
 function resetFilters() {
-  filterKeyword.value  = ''
-  filterType.value     = ''
-  filterStatus.value   = ''
-  filterSender.value   = ''
-  filterDateFrom.value = ''
-  filterDateTo.value   = ''
-  applied.value = { keyword: '', type: '', status: '', sender: '', dateFrom: '', dateTo: '' }
+  filterKeyword.value   = ''
+  filterType.value      = ''
+  filterStatus.value    = ''
+  filterSender.value    = ''
+  filterRecipient.value = ''
+  filterDateFrom.value  = ''
+  filterDateTo.value    = ''
+  applied.value = { keyword: '', type: '', status: '', sender: '', recipient: '', dateFrom: '', dateTo: '' }
+  recipientKey.value++
 }
 
 const filteredEmails = computed(() => {
   return emails.value.filter((e) => {
     const q = applied.value.keyword.trim().toLowerCase()
-    const matchKeyword = !q || e.title.toLowerCase().includes(q) || e.client.toLowerCase().includes(q)
-    const matchType    = !applied.value.type   || e.type === applied.value.type
-    const matchStatus  = !applied.value.status || e.status === applied.value.status
-    const matchSender  = !applied.value.sender || e.sender === applied.value.sender
-    const matchFrom    = !applied.value.dateFrom || e.sentAt >= applied.value.dateFrom
-    const matchTo      = !applied.value.dateTo   || e.sentAt <= applied.value.dateTo
-    return matchKeyword && matchType && matchStatus && matchSender && matchFrom && matchTo
+    const matchKeyword   = !q || e.title.toLowerCase().includes(q) || e.client.toLowerCase().includes(q)
+    const matchType      = !applied.value.type      || e.type === applied.value.type
+    const matchStatus    = !applied.value.status    || e.status === applied.value.status
+    const matchSender    = !applied.value.sender    || e.sender === applied.value.sender
+    const matchRecipient = !applied.value.recipient || e.recipient === applied.value.recipient
+    const dateFrom = applied.value.dateFrom.replaceAll('-', '/')
+    const dateTo   = applied.value.dateTo.replaceAll('-', '/')
+    const matchFrom = !dateFrom || e.sentAt >= dateFrom
+    const matchTo   = !dateTo   || e.sentAt <= dateTo
+    return matchKeyword && matchType && matchStatus && matchSender && matchRecipient && matchFrom && matchTo
   })
 })
 
@@ -136,35 +148,31 @@ const columns = [
 
     <!-- 상세검색 패널 -->
     <CollapsibleFilterCard :open="isFilterOpen" @toggle="isFilterOpen = !isFilterOpen">
-      <div class="grid grid-cols-2 gap-x-4 gap-y-4 md:grid-cols-4">
+      <div class="grid grid-cols-2 gap-3 text-sm md:grid-cols-3 lg:grid-cols-4">
         <!-- 기간 -->
-        <div class="col-span-2">
-          <FormField label="발송일 기간">
-            <DateRangeField
-              :start="filterDateFrom"
-              :end="filterDateTo"
-              @update:start="filterDateFrom = $event"
-              @update:end="filterDateTo = $event"
-              @reset="filterDateFrom = ''; filterDateTo = ''"
-            />
-          </FormField>
-        </div>
+        <FormField label="발송일 기간" class="col-span-2">
+          <div class="grid gap-2 sm:grid-cols-[1fr_auto_1fr] sm:items-end">
+            <DateField v-model="filterDateFrom" />
+            <span class="text-center text-sm text-slate-400 sm:pb-2">~</span>
+            <DateField v-model="filterDateTo" />
+          </div>
+        </FormField>
 
         <!-- 유형 -->
         <FormField label="유형">
-          <BaseSelect
+          <SearchableCombobox
             v-model="filterType"
             :options="typeOptions"
-            placeholder="유형 선택"
+            placeholder="유형 선택..."
           />
         </FormField>
 
         <!-- 상태 -->
         <FormField label="상태">
-          <BaseSelect
+          <SearchableCombobox
             v-model="filterStatus"
             :options="statusOptions"
-            placeholder="상태 선택"
+            placeholder="상태 선택..."
           />
         </FormField>
 
@@ -176,11 +184,31 @@ const columns = [
             placeholder="발송자 검색..."
           />
         </FormField>
+
+        <!-- 수신자 -->
+        <FormField label="수신자">
+          <SearchableCombobox
+            :key="recipientKey"
+            v-model="filterRecipient"
+            :options="recipientOptions"
+            placeholder="수신자 검색..."
+          />
+        </FormField>
       </div>
 
-      <div class="mt-4 flex justify-end gap-2 border-t border-slate-100 pt-3">
-        <BaseButton variant="secondary" size="sm" @click="resetFilters">초기화</BaseButton>
-        <BaseButton size="sm" @click="applySearch">검색</BaseButton>
+      <div class="mt-2 flex items-center justify-end gap-2 border-t border-slate-100 pt-3">
+        <BaseButton variant="secondary" size="sm" @click="resetFilters">
+          <template #leading>
+            <i class="fas fa-undo text-xs" aria-hidden="true"></i>
+          </template>
+          초기화
+        </BaseButton>
+        <BaseButton size="sm" @click="applySearch">
+          <template #leading>
+            <i class="fas fa-search text-xs" aria-hidden="true"></i>
+          </template>
+          검색
+        </BaseButton>
       </div>
     </CollapsibleFilterCard>
 


### PR DESCRIPTION
## 📋 작업 내용

<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->

- 메일 이력 상세검색에 수신자 필터 추가 (SearchableCombobox)
- 상세검색 레이아웃을 기록관리 페이지와 통일 (그리드, DateField×2 + ~ 구분자, 버튼 아이콘)
- BaseSelect → SearchableCombobox로 교체 (유형, 상태)
- 날짜 필터 비교 버그 수정 (DateField 출력 `yyyy-mm-dd` ↔ db.json `yyyy/mm/dd` 정규화)


## 🔗 관련 이슈

<!-- 관련 이슈 번호를 적어주세요 (자동으로 이슈가 닫힙니다) -->
- closes #112 

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->
<img width="1433" height="456" alt="image" src="https://github.com/user-attachments/assets/90bd45fe-9c07-4094-99ab-8f01af9917b4" />



## ✅ 체크리스트

- [ ] 메일 이력 → 상세검색 → 수신자 선택 후 검색 동작 확인
- [ ] 초기화 버튼 클릭 시 수신자 포함 모든 필터 초기화 확인
- [ ] 발송일 기간 필터로 날짜 범위 검색 정상 동작 확인
- [ ] 유형/상태 콤보박스 검색 및 선택 동작 확인

## 💬 리뷰어에게

<!-- 리뷰할 때 중점적으로 봐줬으면 하는 부분이 있다면 적어주세요 -->
메일 레이아웃 수정, 수신자 항목 추가했습니다.

