### PR TITLE
refactor: Auth 도메인 UI/UX + F/E 로직 QA 기반 코드 개선

### DIFF
--- a/src/components/domain/auth/CompanyInfoTab.vue
+++ b/src/components/domain/auth/CompanyInfoTab.vue
@@ -6,10 +6,10 @@ import FileUploadField from '@/components/common/FileUploadField.vue'
 import FormField from '@/components/common/FormField.vue'
 import { useToast } from '@/composables/useToast'
 import { fetchCompany, updateCompany } from '@/api/auth'
+import { isValidEmail } from '@/utils/validators'
 
 const { success, error, warning } = useToast()
 
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
 const form = ref({
   nameEn: '',
@@ -51,7 +51,7 @@ function validate() {
   if (!form.value.nameEn.trim()) {
     e.nameEn = '영문 회사명을 입력해주세요.'
   }
-  if (form.value.email && !EMAIL_REGEX.test(form.value.email.trim())) {
+  if (form.value.email && !isValidEmail(form.value.email)) {
     e.email = '올바른 이메일 형식을 입력해주세요.'
   }
   errors.value = e
@@ -133,6 +133,12 @@ async function handleSave() {
 
       <!-- 회사 도장 이미지 -->
       <div class="space-y-3">
+        <img
+          v-if="form.sealImageUrl && !form.sealImage"
+          :src="form.sealImageUrl"
+          alt="현재 등록된 도장 이미지"
+          class="h-20 w-20 rounded-lg border border-slate-200 object-contain"
+        />
         <FileUploadField
           v-model="form.sealImage"
           label="회사 도장 이미지"

--- a/src/components/domain/auth/DepartmentAccordion.vue
+++ b/src/components/domain/auth/DepartmentAccordion.vue
@@ -66,11 +66,13 @@ function getActiveCount() {
     </button>
 
     <!-- 본문 테이블 -->
-    <div v-show="expanded" :id="`dept-panel-${department}`" class="border-t border-slate-100">
+    <div v-show="expanded" :id="`dept-panel-${department}`" :aria-hidden="!expanded" class="border-t border-slate-100">
       <BaseTable :columns="columns" :rows="users" empty-text="사용자가 없습니다.">
         <template #cell-name="{ row, value }">
           <div class="flex items-center gap-2.5">
             <span
+              role="img"
+              :aria-label="`${value} 프로필`"
               class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs font-bold text-white"
               :class="getAvatarColor(row.id)"
             >

--- a/src/components/domain/auth/PasswordChangeModal.vue
+++ b/src/components/domain/auth/PasswordChangeModal.vue
@@ -52,8 +52,8 @@ function validate() {
   }
   if (!newPassword.value) {
     e.newPassword = '새 비밀번호를 입력해주세요.'
-  } else if (newPassword.value.length < 4) {
-    e.newPassword = '비밀번호는 최소 4자 이상이어야 합니다.'
+  } else if (newPassword.value.length < 8) {
+    e.newPassword = '비밀번호는 최소 8자 이상이어야 합니다.'
   }
   if (!confirmPassword.value) {
     e.confirmPassword = '새 비밀번호 확인을 입력해주세요.'
@@ -105,11 +105,11 @@ async function handleSave() {
   >
     <form class="space-y-4" @submit.prevent="handleSave">
       <FormField label="현재 비밀번호" required :error="errors.currentPassword">
-        <BaseTextField v-model="currentPassword" type="password" placeholder="현재 비밀번호를 입력하세요" />
+        <BaseTextField v-model="currentPassword" type="password" placeholder="현재 비밀번호를 입력하세요" autocomplete="current-password" />
       </FormField>
 
       <FormField label="새 비밀번호" required :error="errors.newPassword">
-        <BaseTextField v-model="newPassword" type="password" placeholder="새 비밀번호를 입력하세요" />
+        <BaseTextField v-model="newPassword" type="password" placeholder="새 비밀번호를 입력하세요" autocomplete="new-password" />
       </FormField>
 
       <FormField
@@ -117,7 +117,7 @@ async function handleSave() {
         required
         :error="errors.confirmPassword"
       >
-        <BaseTextField v-model="confirmPassword" type="password" placeholder="새 비밀번호를 다시 입력하세요" />
+        <BaseTextField v-model="confirmPassword" type="password" placeholder="새 비밀번호를 다시 입력하세요" autocomplete="new-password" />
       </FormField>
     </form>
 

--- a/src/components/domain/auth/UserFormModal.vue
+++ b/src/components/domain/auth/UserFormModal.vue
@@ -4,10 +4,12 @@ import BaseButton from '@/components/common/BaseButton.vue'
 import BaseModal from '@/components/common/BaseModal.vue'
 import BaseSelect from '@/components/common/BaseSelect.vue'
 import BaseTextField from '@/components/common/BaseTextField.vue'
+import ConfirmModal from '@/components/common/ConfirmModal.vue'
 import FileUploadField from '@/components/common/FileUploadField.vue'
 import FormField from '@/components/common/FormField.vue'
 import { useToast } from '@/composables/useToast'
 import { changePassword } from '@/api/auth'
+import { isValidEmail } from '@/utils/validators'
 
 const props = defineProps({
   open: { type: Boolean, default: false },
@@ -24,8 +26,7 @@ const { success, error, warning } = useToast()
 
 const form = ref(getInitialForm())
 const errors = ref({})
-
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+const showResetConfirm = ref(false)
 
 const roleOptions = [
   { label: '영업', value: 'sales' },
@@ -84,7 +85,7 @@ function validate() {
 
   if (!form.value.email.trim()) {
     e.email = '이메일을 입력해주세요.'
-  } else if (!EMAIL_REGEX.test(form.value.email.trim())) {
+  } else if (!isValidEmail(form.value.email)) {
     e.email = '올바른 이메일 형식을 입력해주세요.'
   } else {
     // 중복 이메일 체크
@@ -110,6 +111,10 @@ function validate() {
     e.departmentId = '팀을 선택해주세요.'
   }
 
+  if (form.value.transferDepartmentId && !form.value.transferReason.trim()) {
+    e.transferReason = '이동 사유를 입력해주세요.'
+  }
+
   errors.value = e
   return Object.keys(e).length === 0
 }
@@ -122,6 +127,10 @@ function handleSave() {
   emit('save', { ...form.value })
 }
 
+function confirmResetPassword() {
+  showResetConfirm.value = true
+}
+
 async function handleResetPassword() {
   if (!props.user?.id) return
   try {
@@ -129,6 +138,8 @@ async function handleResetPassword() {
     success('비밀번호가 1234로 초기화되었습니다.')
   } catch (e) {
     error('비밀번호 초기화 중 오류가 발생했습니다.')
+  } finally {
+    showResetConfirm.value = false
   }
 }
 
@@ -178,7 +189,7 @@ const currentDepartmentName = computed(() => {
           </FormField>
 
           <FormField label="초기 비밀번호">
-            <BaseTextField model-value="1234" readonly />
+            <BaseTextField model-value="1234" type="password" readonly />
           </FormField>
         </template>
       </div>
@@ -208,7 +219,7 @@ const currentDepartmentName = computed(() => {
                 :options="[{ label: '변경안함', value: '' }, ...departments.map((d) => ({ label: d.name, value: String(d.id) }))]"
               />
             </FormField>
-            <FormField label="이동 사유">
+            <FormField label="이동 사유" :required="!!form.transferDepartmentId" :error="errors.transferReason">
               <BaseTextField v-model="form.transferReason" placeholder="이동 사유를 입력하세요" />
             </FormField>
           </div>
@@ -229,11 +240,22 @@ const currentDepartmentName = computed(() => {
           <p class="text-sm font-medium text-ink">비밀번호 초기화</p>
           <p class="text-xs text-slate-500">비밀번호를 초기값(1234)으로 재설정합니다.</p>
         </div>
-        <BaseButton variant="secondary" size="sm" type="button" @click="handleResetPassword">
+        <BaseButton variant="secondary" size="sm" type="button" @click="confirmResetPassword">
           초기화
         </BaseButton>
       </div>
     </form>
+
+    <!-- 비밀번호 초기화 확인 모달 -->
+    <ConfirmModal
+      :open="showResetConfirm"
+      title="비밀번호 초기화"
+      :message="`${user?.name} 사용자의 비밀번호를 초기값(1234)으로 초기화하시겠습니까?`"
+      confirm-label="초기화"
+      confirm-variant="danger"
+      @confirm="handleResetPassword"
+      @cancel="showResetConfirm = false"
+    />
 
     <template #footer>
       <BaseButton variant="secondary" @click="emit('close')">취소</BaseButton>

--- a/src/lib/token.js
+++ b/src/lib/token.js
@@ -35,8 +35,8 @@ export function generateTokens(user) {
     exp: now + RT_EXPIRY_DAYS * 24 * 60 * 60 * 1000,
   }
 
-  const accessToken = btoa(unescape(encodeURIComponent(JSON.stringify(accessPayload))))
-  const refreshToken = btoa(unescape(encodeURIComponent(JSON.stringify(refreshPayload))))
+  const accessToken = btoa(encodeURIComponent(JSON.stringify(accessPayload)))
+  const refreshToken = btoa(encodeURIComponent(JSON.stringify(refreshPayload)))
 
   return { accessToken, refreshToken }
 }
@@ -44,7 +44,7 @@ export function generateTokens(user) {
 /** AT 페이로드 디코딩 */
 export function decodeToken(token) {
   try {
-    return JSON.parse(decodeURIComponent(escape(atob(token))))
+    return JSON.parse(decodeURIComponent(atob(token)))
   } catch {
     return null
   }
@@ -60,7 +60,7 @@ export function isTokenExpired(token) {
 /** RT를 쿠키에 저장 */
 export function setRefreshTokenCookie(token) {
   const expires = new Date(Date.now() + RT_EXPIRY_DAYS * 24 * 60 * 60 * 1000).toUTCString()
-  document.cookie = `${RT_COOKIE_NAME}=${token}; expires=${expires}; path=/; SameSite=Strict`
+  document.cookie = `${RT_COOKIE_NAME}=${token}; expires=${expires}; path=/; SameSite=Strict; Secure`
 }
 
 /** RT를 쿠키에서 읽기 */
@@ -71,5 +71,5 @@ export function getRefreshTokenCookie() {
 
 /** RT 쿠키 삭제 */
 export function removeRefreshTokenCookie() {
-  document.cookie = `${RT_COOKIE_NAME}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; SameSite=Strict`
+  document.cookie = `${RT_COOKIE_NAME}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; SameSite=Strict; Secure`
 }

--- a/src/stores/auth.js
+++ b/src/stores/auth.js
@@ -1,4 +1,4 @@
-import { computed, ref } from 'vue'
+import { computed, readonly, ref } from 'vue'
 import { defineStore } from 'pinia'
 import {
   decodeToken,
@@ -100,7 +100,7 @@ export const useAuthStore = defineStore('auth', () => {
   }
 
   return {
-    accessToken,
+    accessToken: readonly(accessToken),
     isLoggedIn,
     currentUser,
     login,

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -1,0 +1,10 @@
+/**
+ * 공통 유효성 검증 유틸리티
+ */
+
+/** 이메일 유효성 검증 정규식 (Auth 도메인 전체 통일) */
+export const EMAIL_REGEX = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/
+
+export function isValidEmail(email) {
+  return EMAIL_REGEX.test(email.trim())
+}

--- a/src/views/auth/ForgotPasswordPage.vue
+++ b/src/views/auth/ForgotPasswordPage.vue
@@ -4,6 +4,7 @@ import BaseButton from '@/components/common/BaseButton.vue'
 import BaseTextField from '@/components/common/BaseTextField.vue'
 import FormField from '@/components/common/FormField.vue'
 import { useToast } from '@/composables/useToast'
+import { isValidEmail } from '@/utils/validators'
 
 const { success, error } = useToast()
 
@@ -12,15 +13,13 @@ const emailError = ref('')
 const loading = ref(false)
 const submitted = ref(false)
 
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
-
 function validate() {
   emailError.value = ''
   if (!email.value.trim()) {
     emailError.value = '이메일을 입력해주세요.'
     return false
   }
-  if (!EMAIL_REGEX.test(email.value.trim())) {
+  if (!isValidEmail(email.value)) {
     emailError.value = '올바른 이메일 형식을 입력해주세요.'
     return false
   }
@@ -35,11 +34,14 @@ async function handleSubmit() {
     // TODO: 백엔드 연동 시 await sendPasswordResetEmail(email.value.trim())
     submitted.value = true
     success('등록된 이메일이라면 재설정 링크가 발송됩니다.')
-  } catch {
-    error('이메일 확인 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.')
   } finally {
     loading.value = false
   }
+}
+
+function handleRetry() {
+  submitted.value = false
+  email.value = ''
 }
 </script>
 
@@ -69,12 +71,19 @@ async function handleSubmit() {
       </div>
 
       <!-- 발송 완료 메시지 -->
-      <div v-if="submitted" class="rounded-xl bg-green-50 px-4 py-4 text-center text-sm text-green-700">
+      <div v-if="submitted" role="alert" aria-live="polite" class="rounded-xl bg-green-50 px-4 py-4 text-center text-sm text-green-700">
         <p class="font-semibold">이메일이 발송되었습니다.</p>
         <p class="mt-1 text-xs text-green-600">
           <strong>{{ email }}</strong> 으로 비밀번호 재설정 링크를 발송했습니다.<br />
           이메일을 확인해 주세요.
         </p>
+        <button
+          type="button"
+          class="mt-3 text-xs font-medium text-green-700 underline transition hover:text-green-900"
+          @click="handleRetry"
+        >
+          다른 이메일로 다시 시도
+        </button>
       </div>
 
       <form v-else class="space-y-5" @submit.prevent="handleSubmit">

--- a/src/views/auth/LoginPage.vue
+++ b/src/views/auth/LoginPage.vue
@@ -6,6 +6,7 @@ import BaseTextField from '@/components/common/BaseTextField.vue'
 import FormField from '@/components/common/FormField.vue'
 import { useToast } from '@/composables/useToast'
 import { useAuthStore } from '@/stores/auth'
+import { isValidEmail } from '@/utils/validators'
 
 const router = useRouter()
 const route = useRoute()
@@ -24,11 +25,10 @@ function validate() {
   passwordError.value = ''
   let valid = true
 
-  const EMAIL_REGEX = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/
   if (!email.value.trim()) {
     emailError.value = '이메일을 입력해주세요.'
     valid = false
-  } else if (!EMAIL_REGEX.test(email.value.trim())) {
+  } else if (!isValidEmail(email.value)) {
     emailError.value = '올바른 이메일 형식을 입력해주세요.'
     valid = false
   }
@@ -112,7 +112,7 @@ async function handleLogin() {
         </FormField>
 
         <!-- 로그인 버튼 -->
-        <BaseButton variant="primary" type="submit" block size="lg" :disabled="loading">
+        <BaseButton variant="primary" type="submit" block size="lg" :disabled="loading" :aria-busy="loading">
           {{ loading ? '로그인 중...' : '로그인' }}
         </BaseButton>
       </form>


### PR DESCRIPTION
## 📋 작업 내용

Auth 도메인 전체에 대한 UI/UX QA와 F/E 로직 QA를 수행하고, 발견된 이슈를 개선했습니다.

### 주요 변경 사항

**보안 개선**
- RT 쿠키에 `Secure` 플래그 추가 (`token.js`)
- `accessToken`을 `readonly`로 래핑하여 외부 변조 차단 (`auth.js`)
- deprecated `escape/unescape` API를 `encodeURIComponent/decodeURIComponent`로 교체 (`token.js`)
- 비밀번호 최소 길이 4자 → 8자로 상향 (`PasswordChangeModal.vue`)

**UI/UX 개선**
- 비밀번호 초기화 시 `ConfirmModal`로 확인 절차 추가 (`UserFormModal.vue`)
- 비밀번호 찾기 페이지에 "다른 이메일로 재시도" 버튼 추가 (`ForgotPasswordPage.vue`)
- 발송 완료 메시지에 `role="alert"` / `aria-live="polite"` 추가 (`ForgotPasswordPage.vue`)
- 아코디언 패널에 `aria-hidden` 속성 추가 (`DepartmentAccordion.vue`)
- 사용자 아바타에 `role="img"` / `aria-label` 추가 (`DepartmentAccordion.vue`)
- 로그인 버튼에 `aria-busy` 추가 (`LoginPage.vue`)
- 초기 비밀번호 필드 `type="password"`로 마스킹 (`UserFormModal.vue`)
- 기존 도장 이미지 미리보기 추가 (`CompanyInfoTab.vue`)
- 비밀번호 변경 폼에 `autocomplete` 속성 추가 (`PasswordChangeModal.vue`)

**로직 개선**
- 이메일 검증 정규식을 `src/utils/validators.js`로 통일 (3파일 불일치 해소)
- 팀 이동 시 이동 사유 필수 검증 추가 (`UserFormModal.vue`)
- ForgotPasswordPage의 도달 불가 catch 블록 제거 (dead code)

## 🔗 관련 이슈

- closes #138

## ✅ 체크리스트

- [x] 정상 동작 확인 (빌드 성공)
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

### 3관점 코드 리뷰 결과 요약

**보안 리뷰**: 토큰 서명 없음(base64 only)과 HttpOnly 누락은 프론트 단독 개발 단계의 의도된 임시 구현이며, 백엔드 연동 시 TODO 주석 기반으로 교체 예정입니다.

**코드 품질 리뷰**: LGTM — 고신뢰도 결함 없음.

**컨벤션 리뷰**: LGTM — CODE_CONVENTION.md 준수 확인 완료.

> 공통 컴포넌트(`src/components/common/`)는 수정하지 않았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)