### PR TITLE
feat: 데모 비밀번호 8자 정책 적용 및 로그인 테스트 계정 자동 입력

### DIFF
--- a/db.json
+++ b/db.json
@@ -247,7 +247,7 @@
       "departmentId": 1,
       "positionId": 1,
       "status": "재직",
-      "pw": "1234"
+      "pw": "test1234"
     },
     {
       "id": "2",
@@ -258,7 +258,7 @@
       "departmentId": 3,
       "positionId": 1,
       "status": "재직",
-      "pw": "1234"
+      "pw": "test1234"
     },
     {
       "id": "3",
@@ -269,7 +269,7 @@
       "departmentId": 4,
       "positionId": 1,
       "status": "재직",
-      "pw": "1234"
+      "pw": "test1234"
     },
     {
       "id": "4",
@@ -280,7 +280,7 @@
       "departmentId": 5,
       "positionId": 1,
       "status": "재직",
-      "pw": "1234"
+      "pw": "test1234"
     },
     {
       "id": "5",
@@ -291,7 +291,7 @@
       "departmentId": 2,
       "positionId": 2,
       "status": "재직",
-      "pw": "1234"
+      "pw": "test1234"
     },
     {
       "id": "6",
@@ -302,7 +302,7 @@
       "departmentId": 1,
       "positionId": 2,
       "status": "퇴직",
-      "pw": "1234"
+      "pw": "test1234"
     },
     {
       "id": "7",
@@ -313,7 +313,7 @@
       "departmentId": 1,
       "positionId": 2,
       "status": "재직",
-      "pw": "1234"
+      "pw": "test1234"
     },
     {
       "id": "8",
@@ -324,7 +324,7 @@
       "departmentId": 3,
       "positionId": 2,
       "status": "재직",
-      "pw": "1234"
+      "pw": "test1234"
     },
     {
       "id": "9",
@@ -335,7 +335,7 @@
       "departmentId": 4,
       "positionId": 2,
       "status": "재직",
-      "pw": "1234"
+      "pw": "test1234"
     },
     {
       "id": "10",
@@ -346,7 +346,7 @@
       "departmentId": 2,
       "positionId": 2,
       "status": "재직",
-      "pw": "1234"
+      "pw": "test1234"
     },
     {
       "id": "11",
@@ -357,7 +357,7 @@
       "departmentId": 3,
       "positionId": 2,
       "status": "재직",
-      "pw": "1234"
+      "pw": "test1234"
     },
     {
       "id": "12",
@@ -368,7 +368,7 @@
       "departmentId": 4,
       "positionId": 2,
       "status": "재직",
-      "pw": "1234"
+      "pw": "test1234"
     },
     {
       "id": "13",
@@ -379,7 +379,7 @@
       "departmentId": 1,
       "positionId": 2,
       "status": "재직",
-      "pw": "1234"
+      "pw": "test1234"
     },
     {
       "id": "14",
@@ -390,7 +390,7 @@
       "departmentId": 5,
       "positionId": 2,
       "status": "재직",
-      "pw": "1234"
+      "pw": "test1234"
     },
     {
       "id": "15",
@@ -401,7 +401,7 @@
       "departmentId": 2,
       "positionId": 2,
       "status": "재직",
-      "pw": "1234"
+      "pw": "test1234"
     },
     {
       "id": "16",
@@ -412,7 +412,7 @@
       "departmentId": 3,
       "positionId": 2,
       "status": "재직",
-      "pw": "1234"
+      "pw": "test1234"
     },
     {
       "id": "17",
@@ -423,7 +423,7 @@
       "departmentId": 4,
       "positionId": 2,
       "status": "재직",
-      "pw": "1234"
+      "pw": "test1234"
     },
     {
       "id": "18",
@@ -434,7 +434,7 @@
       "departmentId": 1,
       "positionId": 2,
       "status": "퇴직",
-      "pw": "1234"
+      "pw": "test1234"
     },
     {
       "id": "19",
@@ -445,7 +445,7 @@
       "departmentId": 2,
       "positionId": 2,
       "status": "재직",
-      "pw": "1234"
+      "pw": "test1234"
     },
     {
       "id": "20",
@@ -456,7 +456,7 @@
       "departmentId": 5,
       "positionId": 2,
       "status": "재직",
-      "pw": "1234"
+      "pw": "test1234"
     }
   ],
   "company": [

--- a/src/components/domain/auth/UserFormModal.vue
+++ b/src/components/domain/auth/UserFormModal.vue
@@ -134,8 +134,8 @@ function confirmResetPassword() {
 async function handleResetPassword() {
   if (!props.user?.id) return
   try {
-    await changePassword(props.user.id, '1234')
-    success('비밀번호가 1234로 초기화되었습니다.')
+    await changePassword(props.user.id, 'test1234')
+    success('비밀번호가 test1234로 초기화되었습니다.')
   } catch (e) {
     error('비밀번호 초기화 중 오류가 발생했습니다.')
   } finally {
@@ -189,7 +189,7 @@ const currentDepartmentName = computed(() => {
           </FormField>
 
           <FormField label="초기 비밀번호">
-            <BaseTextField model-value="1234" type="password" readonly />
+            <BaseTextField model-value="test1234" type="password" readonly />
           </FormField>
         </template>
       </div>
@@ -238,7 +238,7 @@ const currentDepartmentName = computed(() => {
       <div v-if="mode === 'edit'" class="flex items-center justify-between rounded-xl border border-slate-200 bg-slate-50/50 p-4">
         <div>
           <p class="text-sm font-medium text-ink">비밀번호 초기화</p>
-          <p class="text-xs text-slate-500">비밀번호를 초기값(1234)으로 재설정합니다.</p>
+          <p class="text-xs text-slate-500">비밀번호를 초기값(test1234)으로 재설정합니다.</p>
         </div>
         <BaseButton variant="secondary" size="sm" type="button" @click="confirmResetPassword">
           초기화
@@ -250,7 +250,7 @@ const currentDepartmentName = computed(() => {
     <ConfirmModal
       :open="showResetConfirm"
       title="비밀번호 초기화"
-      :message="`${user?.name} 사용자의 비밀번호를 초기값(1234)으로 초기화하시겠습니까?`"
+      :message="`${user?.name} 사용자의 비밀번호를 초기값(test1234)으로 초기화하시겠습니까?`"
       confirm-label="초기화"
       confirm-variant="danger"
       @confirm="handleResetPassword"

--- a/src/components/domain/auth/UserListTab.vue
+++ b/src/components/domain/auth/UserListTab.vue
@@ -175,7 +175,7 @@ async function handleSave(formData) {
       const newUser = {
         ...formData,
         employeeNo,
-        pw: '1234',
+        pw: 'test1234',
         status: formData.status || '재직',
       }
       await createUser(newUser)

--- a/src/views/auth/LoginPage.vue
+++ b/src/views/auth/LoginPage.vue
@@ -20,6 +20,20 @@ const emailError = ref('')
 const passwordError = ref('')
 const loading = ref(false)
 
+const demoAccounts = [
+  { label: '관리자', email: 'admin@salesboost.com', pw: 'test1234' },
+  { label: '영업', email: 'kim@salesboost.com', pw: 'test1234' },
+  { label: '생산', email: 'lee@salesboost.com', pw: 'test1234' },
+  { label: '출하', email: 'park@salesboost.com', pw: 'test1234' },
+]
+
+function fillDemoAccount(account) {
+  email.value = account.email
+  password.value = account.pw
+  emailError.value = ''
+  passwordError.value = ''
+}
+
 function validate() {
   emailError.value = ''
   passwordError.value = ''
@@ -127,12 +141,18 @@ async function handleLogin() {
 
     <!-- Demo 계정 안내 -->
     <div v-if="isDev" class="w-full rounded-2xl bg-white p-4 shadow-panel">
-      <p class="mb-2 text-xs font-semibold text-slate-600">Demo 계정 안내</p>
-      <div class="space-y-1 text-xs text-slate-500">
-        <p>관리자: admin@salesboost.com / 1234</p>
-        <p>영업: kim@salesboost.com / 1234</p>
-        <p>생산: lee@salesboost.com / 1234</p>
-        <p>출하: park@salesboost.com / 1234</p>
+      <p class="mb-2 text-xs font-semibold text-slate-600">Demo 계정 (클릭하면 자동 입력)</p>
+      <div class="grid grid-cols-2 gap-2">
+        <button
+          v-for="account in demoAccounts"
+          :key="account.email"
+          type="button"
+          class="rounded-lg border border-slate-200 px-3 py-2 text-left text-xs text-slate-600 transition hover:border-brand hover:bg-blue-50 hover:text-brand"
+          @click="fillDemoAccount(account)"
+        >
+          <span class="font-semibold">{{ account.label }}</span>
+          <span class="mt-0.5 block truncate text-slate-400">{{ account.email }}</span>
+        </button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## 📋 작업 내용

비밀번호 최소 8자 정책(#138)에 맞춰 데모 데이터를 정비하고, 로그인 화면의 테스트 계정 자동 입력 기능을 추가했습니다.

### 변경 사항

- **db.json**: 전체 사용자(20명) 비밀번호 `1234` → `test1234`로 변경
- **LoginPage.vue**: 데모 계정 안내를 클릭 가능한 버튼 그리드로 개선 — 클릭 시 이메일/비밀번호 자동 입력, 기존 유효성 에러 초기화
- **UserFormModal.vue**: 초기 비밀번호 및 비밀번호 초기화 값 `1234` → `test1234`, 안내 텍스트 업데이트
- **UserListTab.vue**: 사용자 등록 시 기본 비밀번호 `1234` → `test1234`

## 🔗 관련 이슈

- closes #141

## ✅ 체크리스트

- [x] 정상 동작 확인 (빌드 성공)
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

- 데모 계정 자동 입력은 `v-if="isDev"` 가드로 프로덕션에서는 숨겨집니다.
- `demo/db.json`은 `.gitignore`에 포함되어 있어 로컬에서만 별도 관리됩니다.
- 공통 컴포넌트(`src/components/common/`)는 수정하지 않았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)