### PR TITLE
refactor: 사용자 관리 페이지 헤더를 공통 PageHeader로 통일

### DIFF
--- a/src/views/auth/UserManagementPage.vue
+++ b/src/views/auth/UserManagementPage.vue
@@ -2,7 +2,7 @@
 import { ref } from 'vue'
 import BaseButton from '@/components/common/BaseButton.vue'
 import BaseTabs from '@/components/common/BaseTabs.vue'
-import PageTitleBar from '@/components/layout/PageTitleBar.vue'
+import PageHeader from '@/components/common/PageHeader.vue'
 import CompanyInfoTab from '@/components/domain/auth/CompanyInfoTab.vue'
 import UserListTab from '@/components/domain/auth/UserListTab.vue'
 
@@ -23,7 +23,7 @@ function handleCreateUser() {
 <template>
   <div class="space-y-6">
     <!-- 페이지 헤더 -->
-    <PageTitleBar title="사용자 관리">
+    <PageHeader title="사용자 관리" icon-class="fas fa-users-gear">
       <template #actions>
         <BaseButton v-if="activeTab === 'users'" variant="primary" @click="handleCreateUser">
           <template #leading>
@@ -34,7 +34,7 @@ function handleCreateUser() {
           사용자 등록
         </BaseButton>
       </template>
-    </PageTitleBar>
+    </PageHeader>
 
     <BaseTabs v-model="activeTab" :tabs="tabs" />
 


### PR DESCRIPTION
## 📋 작업 내용

사용자 관리 페이지(UserManagementPage)의 헤더를 `PageTitleBar`(layout 전용)에서 `PageHeader`(공통 컴포넌트)로 교체하여 다른 리스트 페이지와 UI를 통일했습니다.

### 변경 전/후

| | 변경 전 | 변경 후 |
|---|---|---|
| 컴포넌트 | `PageTitleBar` (layout) | `PageHeader` (common) |
| 스타일 | 카드형 (border, shadow, bg-white) | 심플 바형 (아이콘 + 타이틀) |
| 일관성 | 이 페이지만 유일하게 다른 패턴 | 거래처/품목/문서 등 모든 리스트 페이지와 동일 |

## 🔗 관련 이슈

- closes #143

## ✅ 체크리스트

- [x] 정상 동작 확인 (빌드 성공)
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

- 변경 범위가 단일 파일(`UserManagementPage.vue`)의 import 1줄 + 템플릿 컴포넌트명 교체로 매우 작습니다.
- `#actions` 슬롯 내용(사용자 등록 버튼, activeTab 조건부 렌더링)은 그대로 유지됩니다.
- `PageTitleBar`는 컴포넌트 쇼케이스 페이지에서 참조되므로 삭제하지 않았습니다.
- 공통 컴포넌트(`src/components/common/`)는 수정하지 않았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)