### PR TITLE
feat: 메일 이력 발송 규칙 정립 및 첨부파일 연동 개선 (#126, #128)

### DIFF
--- a/db.json
+++ b/db.json
@@ -4067,11 +4067,15 @@
     {
       "id": "1",
       "client": "Global Steel Corp.",
-      "title": "[SalesBoost] PI-2025-001 발송",
+      "title": "[SalesBoost] PI2025001 발송",
       "recipient": "James Carter",
       "email": "james.carter@globalsteel.com",
-      "type": "PI",
-      "hasAttachment": true,
+      "types": [
+        "PI"
+      ],
+      "attachments": [
+        "PI2025001.pdf"
+      ],
       "poId": "PO2025001",
       "status": "발송",
       "sentAt": "2025/03/10",
@@ -4080,249 +4084,335 @@
     {
       "id": "2",
       "client": "Hamburg Metal GmbH",
-      "title": "[SalesBoost] PO2025003 발송",
-      "recipient": "Hans Müller",
-      "email": "hans.muller@hamburgmetal.de",
-      "type": "PO",
-      "hasAttachment": true,
-      "poId": "PO2025003",
+      "title": "[SalesBoost] PI2025002 발송",
+      "recipient": "Anna Schmidt",
+      "email": "anna.schmidt@hamburgmetal.de",
+      "types": [
+        "PI"
+      ],
+      "attachments": [
+        "PI2025002.pdf"
+      ],
+      "poId": null,
       "status": "발송",
-      "sentAt": "2025/03/09",
+      "sentAt": "2025/03/15",
       "sender": "정영업"
     },
     {
       "id": "3",
       "client": "Tokyo Trading Co.",
-      "title": "[SalesBoost] CI-2025-001 발송",
+      "title": "[SalesBoost] PI2025003 발송",
       "recipient": "Tanaka Yuki",
       "email": "yuki.tanaka@tokyotrading.jp",
-      "type": "CI",
-      "hasAttachment": false,
+      "types": [
+        "PI"
+      ],
+      "attachments": [
+        "PI2025003.pdf"
+      ],
       "poId": null,
       "status": "실패",
-      "sentAt": "2025/03/08",
+      "sentAt": "2025/03/20",
       "sender": "김영업"
     },
     {
       "id": "4",
-      "client": "Global Steel Corp.",
-      "title": "[SalesBoost] PL-2025-001 발송",
-      "recipient": "Sarah Johnson",
-      "email": "sarah.johnson@globalsteel.com",
-      "type": "PL",
-      "hasAttachment": true,
-      "poId": "PO2025002",
+      "client": "Shanghai Import Ltd.",
+      "title": "[SalesBoost] PI2025004 발송",
+      "recipient": "Wang Lei",
+      "email": "wang.lei@shanghaiimport.cn",
+      "types": [
+        "PI"
+      ],
+      "attachments": [
+        "PI2025004.pdf"
+      ],
+      "poId": "PO2025004",
       "status": "발송",
-      "sentAt": "2025/03/07",
+      "sentAt": "2025/04/02",
       "sender": "정영업"
     },
     {
       "id": "5",
-      "client": "Hamburg Metal GmbH",
-      "title": "[SalesBoost] PI-2025-002 발송",
-      "recipient": "Anna Schmidt",
-      "email": "anna.schmidt@hamburgmetal.de",
-      "type": "PI",
-      "hasAttachment": false,
-      "poId": null,
+      "client": "London Metals Plc",
+      "title": "[SalesBoost] PI2025005 발송",
+      "recipient": "James Brown",
+      "email": "james.brown@londonmetals.co.uk",
+      "types": [
+        "PI"
+      ],
+      "attachments": [
+        "PI2025005.pdf"
+      ],
+      "poId": "PO2025005",
       "status": "발송",
-      "sentAt": "2025/03/06",
+      "sentAt": "2025/04/08",
       "sender": "김영업"
     },
     {
       "id": "6",
-      "client": "Tokyo Trading Co.",
-      "title": "[SalesBoost] PO2025004 발송",
-      "recipient": "Kenji Sato",
-      "email": "kenji.sato@tokyotrading.jp",
-      "type": "PO",
-      "hasAttachment": true,
-      "poId": "PO2025004",
-      "status": "발송",
-      "sentAt": "2025/03/05",
-      "sender": "정영업"
-    },
-    {
-      "id": "7",
       "client": "Global Steel Corp.",
-      "title": "[SalesBoost] CI-2025-002 발송",
-      "recipient": "Michael Brown",
-      "email": "michael.brown@globalsteel.com",
-      "type": "CI",
-      "hasAttachment": false,
-      "poId": null,
+      "title": "[SalesBoost] CI2025001·PL2025001 발송",
+      "recipient": "James Carter",
+      "email": "james.carter@globalsteel.com",
+      "types": [
+        "CI",
+        "PL"
+      ],
+      "attachments": [
+        "CI2025001.pdf",
+        "PL2025001.pdf"
+      ],
+      "poId": "PO2025001",
       "status": "발송",
-      "sentAt": "2025/03/04",
+      "sentAt": "2025/03/25",
       "sender": "김영업"
     },
     {
-      "id": "8",
+      "id": "7",
       "client": "Hamburg Metal GmbH",
-      "title": "[SalesBoost] PL-2025-002 발송",
+      "title": "[SalesBoost] CI2025002·PL2025002 발송",
       "recipient": "Hans Müller",
       "email": "hans.muller@hamburgmetal.de",
-      "type": "PL",
-      "hasAttachment": true,
+      "types": [
+        "CI",
+        "PL"
+      ],
+      "attachments": [
+        "CI2025002.pdf",
+        "PL2025002.pdf"
+      ],
+      "poId": "PO2025002",
+      "status": "발송",
+      "sentAt": "2025/04/12",
+      "sender": "정영업"
+    },
+    {
+      "id": "8",
+      "client": "Tokyo Trading Co.",
+      "title": "[SalesBoost] CI2025003·PL2025003 발송",
+      "recipient": "Kenji Sato",
+      "email": "kenji.sato@tokyotrading.jp",
+      "types": [
+        "CI",
+        "PL"
+      ],
+      "attachments": [
+        "CI2025003.pdf",
+        "PL2025003.pdf"
+      ],
       "poId": "PO2025003",
       "status": "실패",
-      "sentAt": "2025/03/03",
-      "sender": "정영업"
+      "sentAt": "2025/04/18",
+      "sender": "김영업"
     },
     {
       "id": "9",
       "client": "Shanghai Import Ltd.",
-      "title": "[SalesBoost] PI-2025-003 발송",
+      "title": "[SalesBoost] CI2025004·PL2025004 발송",
       "recipient": "Wang Lei",
       "email": "wang.lei@shanghaiimport.cn",
-      "type": "PI",
-      "hasAttachment": true,
-      "poId": "PO2025007",
+      "types": [
+        "CI",
+        "PL"
+      ],
+      "attachments": [
+        "CI2025004.pdf",
+        "PL2025004.pdf"
+      ],
+      "poId": "PO2025004",
       "status": "발송",
-      "sentAt": "2025/04/03",
-      "sender": "김영업"
-    },
-    {
-      "id": "10",
-      "client": "London Metals Plc",
-      "title": "[SalesBoost] PO2025008 발송",
-      "recipient": "James Brown",
-      "email": "james.brown@londonmetals.co.uk",
-      "type": "PO",
-      "hasAttachment": true,
-      "poId": "PO2025008",
-      "status": "실패",
-      "sentAt": "2025/04/07",
+      "sentAt": "2025/05/05",
       "sender": "정영업"
     },
     {
-      "id": "11",
+      "id": "10",
       "client": "Paris Acier SA",
-      "title": "[SalesBoost] CI-2025-003 발송",
+      "title": "[SalesBoost] CI2025006·PL2025006 발송",
       "recipient": "Pierre Dupont",
       "email": "pierre.dupont@parisacier.fr",
-      "type": "CI",
-      "hasAttachment": false,
-      "poId": null,
+      "types": [
+        "CI",
+        "PL"
+      ],
+      "attachments": [
+        "CI2025006.pdf",
+        "PL2025006.pdf"
+      ],
+      "poId": "PO2025006",
       "status": "발송",
-      "sentAt": "2025/04/12",
+      "sentAt": "2025/05/14",
+      "sender": "김영업"
+    },
+    {
+      "id": "11",
+      "client": "Global Steel Corp.",
+      "title": "[SalesBoost] MO2025001 생산지시서 발송",
+      "recipient": "이생산",
+      "email": "lee@salesboost.com",
+      "types": [
+        "생산지시서"
+      ],
+      "attachments": [
+        "MO2025001.pdf"
+      ],
+      "poId": "PO2025001",
+      "status": "발송",
+      "sentAt": "2025/03/12",
       "sender": "김영업"
     },
     {
       "id": "12",
-      "client": "Mumbai Steel Works",
-      "title": "[SalesBoost] PL-2025-003 발송",
-      "recipient": "Raj Patel",
-      "email": "raj.patel@mumbaisteel.in",
-      "type": "PL",
-      "hasAttachment": true,
-      "poId": "PO2025010",
+      "client": "Hamburg Metal GmbH",
+      "title": "[SalesBoost] MO2025002 생산지시서 발송",
+      "recipient": "이생산",
+      "email": "lee@salesboost.com",
+      "types": [
+        "생산지시서"
+      ],
+      "attachments": [
+        "MO2025002.pdf"
+      ],
+      "poId": "PO2025002",
       "status": "발송",
-      "sentAt": "2025/04/17",
+      "sentAt": "2025/04/05",
       "sender": "정영업"
     },
     {
       "id": "13",
-      "client": "São Paulo Metals",
-      "title": "[SalesBoost] PI-2025-004 발송",
-      "recipient": "Carlos Silva",
-      "email": "carlos.silva@spmetals.br",
-      "type": "PI",
-      "hasAttachment": true,
-      "poId": "PO2025011",
+      "client": "Tokyo Trading Co.",
+      "title": "[SalesBoost] MO2025003 생산지시서 발송",
+      "recipient": "이생산",
+      "email": "lee@salesboost.com",
+      "types": [
+        "생산지시서"
+      ],
+      "attachments": [
+        "MO2025003.pdf"
+      ],
+      "poId": "PO2025003",
       "status": "발송",
-      "sentAt": "2025/04/22",
+      "sentAt": "2025/04/10",
       "sender": "김영업"
     },
     {
       "id": "14",
-      "client": "Dtech Electronics Inc.",
-      "title": "[SalesBoost] PO2025014 발송",
-      "recipient": "David Kim",
-      "email": "info@dtech.com",
-      "type": "PO",
-      "hasAttachment": true,
-      "poId": "PO2025014",
+      "client": "Shanghai Import Ltd.",
+      "title": "[SalesBoost] MO2025004 생산지시서 발송",
+      "recipient": "이생산",
+      "email": "lee@salesboost.com",
+      "types": [
+        "생산지시서"
+      ],
+      "attachments": [
+        "MO2025004.pdf"
+      ],
+      "poId": "PO2025004",
       "status": "발송",
-      "sentAt": "2025/05/06",
+      "sentAt": "2025/05/02",
       "sender": "정영업"
     },
     {
       "id": "15",
-      "client": "Berlin Digital AG",
-      "title": "[SalesBoost] CI-2025-004 발송",
-      "recipient": "Lukas Weber",
-      "email": "info@berlindgital.de",
-      "type": "CI",
-      "hasAttachment": false,
-      "poId": null,
-      "status": "발송",
-      "sentAt": "2025/05/12",
+      "client": "Paris Acier SA",
+      "title": "[SalesBoost] MO2025006 생산지시서 발송",
+      "recipient": "이생산",
+      "email": "lee@salesboost.com",
+      "types": [
+        "생산지시서"
+      ],
+      "attachments": [
+        "MO2025006.pdf"
+      ],
+      "poId": "PO2025006",
+      "status": "실패",
+      "sentAt": "2025/05/20",
       "sender": "김영업"
     },
     {
       "id": "16",
-      "client": "Osaka Tech Corp.",
-      "title": "[SalesBoost] PL-2025-004 발송",
-      "recipient": "Suzuki Ichiro",
-      "email": "contact@osaktech.jp",
-      "type": "PL",
-      "hasAttachment": true,
-      "poId": "PO2025016",
-      "status": "실패",
-      "sentAt": "2025/05/17",
-      "sender": "정영업"
+      "client": "Global Steel Corp.",
+      "title": "[SalesBoost] SO2025001 출하지시서 발송",
+      "recipient": "박출하",
+      "email": "park@salesboost.com",
+      "types": [
+        "출하지시서"
+      ],
+      "attachments": [
+        "SO2025001.pdf"
+      ],
+      "poId": "PO2025001",
+      "status": "발송",
+      "sentAt": "2025/03/28",
+      "sender": "김영업"
     },
     {
       "id": "17",
-      "client": "Shenzhen Gadgets Co.",
-      "title": "[SalesBoost] PI-2025-005 발송",
-      "recipient": "Li Fang",
-      "email": "sales@szgadgets.cn",
-      "type": "PI",
-      "hasAttachment": true,
-      "poId": "PO2025017",
+      "client": "Hamburg Metal GmbH",
+      "title": "[SalesBoost] SO2025002 출하지시서 발송",
+      "recipient": "박출하",
+      "email": "park@salesboost.com",
+      "types": [
+        "출하지시서"
+      ],
+      "attachments": [
+        "SO2025002.pdf"
+      ],
+      "poId": "PO2025002",
       "status": "발송",
-      "sentAt": "2025/05/22",
-      "sender": "김영업"
+      "sentAt": "2025/04/15",
+      "sender": "정영업"
     },
     {
       "id": "18",
-      "client": "London Tech Ltd",
-      "title": "[SalesBoost] PO2025018 발송",
-      "recipient": "Emma Wilson",
-      "email": "hello@londontech.co.uk",
-      "type": "PO",
-      "hasAttachment": true,
-      "poId": "PO2025018",
+      "client": "Tokyo Trading Co.",
+      "title": "[SalesBoost] SO2025003 출하지시서 발송",
+      "recipient": "박출하",
+      "email": "park@salesboost.com",
+      "types": [
+        "출하지시서"
+      ],
+      "attachments": [
+        "SO2025003.pdf"
+      ],
+      "poId": "PO2025003",
       "status": "발송",
-      "sentAt": "2025/05/27",
-      "sender": "정영업"
-    },
-    {
-      "id": "19",
-      "client": "Paris Digital SAS",
-      "title": "[SalesBoost] CI-2025-005 발송",
-      "recipient": "Sophie Martin",
-      "email": "contact@parisdigital.fr",
-      "type": "CI",
-      "hasAttachment": false,
-      "poId": null,
-      "status": "발송",
-      "sentAt": "2025/06/02",
+      "sentAt": "2025/04/20",
       "sender": "김영업"
     },
     {
-      "id": "20",
-      "client": "Singapore Electronics Pte",
-      "title": "[SalesBoost] PO2025020 발송",
-      "recipient": "Tan Ah Kow",
-      "email": "info@sgelec.sg",
-      "type": "PO",
-      "hasAttachment": true,
-      "poId": "PO2025020",
+      "id": "19",
+      "client": "Shanghai Import Ltd.",
+      "title": "[SalesBoost] SO2025004 출하지시서 발송",
+      "recipient": "박출하",
+      "email": "park@salesboost.com",
+      "types": [
+        "출하지시서"
+      ],
+      "attachments": [
+        "SO2025004.pdf"
+      ],
+      "poId": "PO2025004",
       "status": "발송",
-      "sentAt": "2025/06/06",
+      "sentAt": "2025/05/08",
       "sender": "정영업"
+    },
+    {
+      "id": "20",
+      "client": "Paris Acier SA",
+      "title": "[SalesBoost] SO2025006 출하지시서 발송",
+      "recipient": "박출하",
+      "email": "park@salesboost.com",
+      "types": [
+        "출하지시서"
+      ],
+      "attachments": [
+        "SO2025006.pdf"
+      ],
+      "poId": "PO2025006",
+      "status": "실패",
+      "sentAt": "2025/06/01",
+      "sender": "김영업"
     }
   ],
   "pi": [

--- a/src/views/emails/EmailListPage.vue
+++ b/src/views/emails/EmailListPage.vue
@@ -1,6 +1,14 @@
 <script setup>
 import { computed, onMounted, ref } from 'vue'
 import { fetchActivityEmails } from '@/api/emails'
+import { api } from '@/lib/api'
+import {
+  buildPIOutputHtml,
+  buildCIOutputHtml,
+  buildPLOutputHtml,
+  buildProductionOrderOutputHtml,
+  buildShipmentOrderOutputHtml,
+} from '@/utils/documentOutput'
 import { useToast } from '@/composables/useToast'
 import BaseButton from '@/components/common/BaseButton.vue'
 import BaseModal from '@/components/common/BaseModal.vue'
@@ -40,9 +48,10 @@ const filterDateTo    = ref('')
 
 const typeOptions = [
   { label: 'PI', value: 'PI' },
-  { label: 'PO', value: 'PO' },
   { label: 'CI', value: 'CI' },
   { label: 'PL', value: 'PL' },
+  { label: '생산지시서', value: '생산지시서' },
+  { label: '출하지시서', value: '출하지시서' },
 ]
 
 const statusOptions = [
@@ -92,7 +101,7 @@ const filteredEmails = computed(() => {
   return emails.value.filter((e) => {
     const q = applied.value.keyword.trim().toLowerCase()
     const matchKeyword   = !q || e.title.toLowerCase().includes(q) || e.client.toLowerCase().includes(q)
-    const matchType      = !applied.value.type      || e.type === applied.value.type
+    const matchType      = !applied.value.type      || (e.types ?? []).includes(applied.value.type)
     const matchStatus    = !applied.value.status    || e.status === applied.value.status
     const matchSender    = !applied.value.sender    || e.sender === applied.value.sender
     const matchRecipient = !applied.value.recipient || e.recipient === applied.value.recipient
@@ -103,6 +112,39 @@ const filteredEmails = computed(() => {
     return matchKeyword && matchType && matchStatus && matchSender && matchRecipient && matchFrom && matchTo
   })
 })
+
+// ── 첨부파일 열기 ───────────────────────────────────────────
+const ATTACHMENT_CONFIG = {
+  PI: { endpoint: 'pi',               builder: buildPIOutputHtml               },
+  CI: { endpoint: 'ci',               builder: buildCIOutputHtml               },
+  PL: { endpoint: 'pl',               builder: buildPLOutputHtml               },
+  MO: { endpoint: 'productionOrders', builder: buildProductionOrderOutputHtml  },
+  SO: { endpoint: 'shipmentOrders',   builder: buildShipmentOrderOutputHtml    },
+}
+
+const attachmentHtml = ref('')
+const isAttachmentOpen = ref(false)
+
+async function openAttachment(filename) {
+  const id = filename.replace('.pdf', '')
+  const prefix = id.match(/^[A-Z]+/)?.[0] ?? ''
+  const config = ATTACHMENT_CONFIG[prefix]
+  if (!config) return
+  try {
+    const { data } = await api.get(`/${config.endpoint}/${id}`)
+    if (!Array.isArray(data.items)) {
+      data.items = data.itemName
+        ? [{ name: data.itemName, quantity: '-', unitPrice: '-', amount: data.amount ?? '-' }]
+        : []
+    }
+    if (!data.totalAmount && data.amount != null) data.totalAmount = String(data.amount)
+    attachmentHtml.value = config.builder(data)
+    isAttachmentOpen.value = true
+  } catch (e) {
+    console.error('문서 로드 실패', e)
+    error('문서를 불러오지 못했습니다.')
+  }
+}
 
 // ── 상세 모달 ──────────────────────────────────────────────
 const selectedEmail = ref(null)
@@ -125,7 +167,7 @@ const columns = [
   { key: 'title',     label: '제목'                                      },
   { key: 'recipient', label: '수신자',  width: '110px'                  },
   { key: 'email',     label: '이메일',  width: '210px'                  },
-  { key: 'type',      label: '유형',   width: '100px'                  },
+  { key: 'types',      label: '유형',   width: '120px'                  },
   { key: 'attachment', label: '첨부',  width: '60px',  align: 'center' },
   { key: 'status',    label: '상태',   width: '80px',  align: 'center' },
   { key: 'sentAt',    label: '발송일',  width: '110px', align: 'center' },
@@ -238,21 +280,29 @@ const columns = [
         <span class="break-all text-slate-600">{{ row.email }}</span>
       </template>
 
+      <!-- 유형 배지 -->
+      <template #cell-types="{ row }">
+        <span class="text-sm text-slate-700">{{ (row.types ?? []).join(' · ') }}</span>
+      </template>
+
       <!-- 첨부 -->
       <template #cell-attachment="{ row }">
-        <div v-if="row.hasAttachment" class="group relative mx-auto flex items-center justify-center" @click.stop>
+        <div v-if="row.attachments?.length" class="group relative mx-auto flex items-center justify-center" @click.stop>
           <svg class="h-4 w-4 text-slate-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
             <path d="M9.25 13.25a.75.75 0 0 0 1.5 0V4.636l2.955 3.129a.75.75 0 0 0 1.09-1.03l-4.25-4.5a.75.75 0 0 0-1.09 0l-4.25 4.5a.75.75 0 1 0 1.09 1.03L9.25 4.636v8.614Z" />
             <path d="M3.5 12.75a.75.75 0 0 0-1.5 0v2.5A2.75 2.75 0 0 0 4.75 18h10.5A2.75 2.75 0 0 0 18 15.25v-2.5a.75.75 0 0 0-1.5 0v2.5c0 .69-.56 1.25-1.25 1.25H4.75c-.69 0-1.25-.56-1.25-1.25v-2.5Z" />
           </svg>
-          <a
-            v-if="row.poId"
-            href="/Purchase Order.pdf"
-            target="_blank"
-            class="absolute bottom-full left-1/2 z-10 mb-1.5 -translate-x-1/2 whitespace-nowrap rounded bg-slate-800 px-2 py-1 text-xs text-white opacity-0 transition-opacity group-hover:opacity-100 hover:underline"
-          >
-            {{ row.poId }}
-          </a>
+          <div class="absolute bottom-full left-1/2 z-10 mb-1.5 -translate-x-1/2 whitespace-nowrap rounded bg-slate-800 px-2 py-1 text-xs text-white opacity-0 transition-opacity group-hover:opacity-100">
+            <button
+              v-for="file in row.attachments"
+              :key="file"
+              type="button"
+              class="block hover:underline"
+              @click="openAttachment(file)"
+            >
+              {{ file }}
+            </button>
+          </div>
         </div>
         <span v-else class="text-slate-300">—</span>
       </template>
@@ -269,6 +319,23 @@ const columns = [
       총 {{ filteredEmails.length }}건
     </div>
 
+    <!-- 첨부파일 문서 미리보기 모달 -->
+    <BaseModal
+      :open="isAttachmentOpen"
+      title="문서 미리보기"
+      width="max-w-4xl"
+      @close="isAttachmentOpen = false"
+    >
+      <iframe
+        :srcdoc="attachmentHtml"
+        class="w-full rounded"
+        style="height: 70vh; border: none;"
+      />
+      <template #footer>
+        <BaseButton variant="secondary" @click="isAttachmentOpen = false">닫기</BaseButton>
+      </template>
+    </BaseModal>
+
     <!-- 메일 상세 모달 -->
     <BaseModal
       :open="isDetailOpen"
@@ -282,21 +349,24 @@ const columns = [
         <InfoField label="수신자"  :value="selectedEmail?.recipient || '-'" />
         <InfoField label="발송일시" :value="selectedEmail?.sentAt" />
         <InfoField label="제목"    :value="selectedEmail?.title" />
-        <InfoField label="유형"    :value="selectedEmail?.type" />
+        <InfoField label="유형"    :value="(selectedEmail?.types ?? []).join(' · ')" />
         <InfoField label="연결 PO" :value="selectedEmail?.poId || '-'" />
         <InfoField label="첨부파일">
-          <a
-            v-if="selectedEmail?.hasAttachment"
-            href="/Purchase Order.pdf"
-            target="_blank"
-            class="flex items-center gap-1.5 text-sm text-brand-600 hover:underline"
-          >
-            <svg class="h-4 w-4 shrink-0" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-              <path d="M9.25 13.25a.75.75 0 0 0 1.5 0V4.636l2.955 3.129a.75.75 0 0 0 1.09-1.03l-4.25-4.5a.75.75 0 0 0-1.09 0l-4.25 4.5a.75.75 0 1 0 1.09 1.03L9.25 4.636v8.614Z" />
-              <path d="M3.5 12.75a.75.75 0 0 0-1.5 0v2.5A2.75 2.75 0 0 0 4.75 18h10.5A2.75 2.75 0 0 0 18 15.25v-2.5a.75.75 0 0 0-1.5 0v2.5c0 .69-.56 1.25-1.25 1.25H4.75c-.69 0-1.25-.56-1.25-1.25v-2.5Z" />
-            </svg>
-            <span>{{ selectedEmail?.title?.replace('[SalesBoost] ', '').replace(' 발송', '').replace(/-/g, '') }}.pdf</span>
-          </a>
+          <div v-if="selectedEmail?.attachments?.length" class="flex flex-col gap-1">
+            <button
+              v-for="file in selectedEmail.attachments"
+              :key="file"
+              type="button"
+              class="flex items-center gap-1.5 text-sm text-brand-600 hover:underline"
+              @click="openAttachment(file)"
+            >
+              <svg class="h-4 w-4 shrink-0" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                <path d="M9.25 13.25a.75.75 0 0 0 1.5 0V4.636l2.955 3.129a.75.75 0 0 0 1.09-1.03l-4.25-4.5a.75.75 0 0 0-1.09 0l-4.25 4.5a.75.75 0 1 0 1.09 1.03L9.25 4.636v8.614Z" />
+                <path d="M3.5 12.75a.75.75 0 0 0-1.5 0v2.5A2.75 2.75 0 0 0 4.75 18h10.5A2.75 2.75 0 0 0 18 15.25v-2.5a.75.75 0 0 0-1.5 0v2.5c0 .69-.56 1.25-1.25 1.25H4.75c-.69 0-1.25-.56-1.25-1.25v-2.5Z" />
+              </svg>
+              <span>{{ file }}</span>
+            </button>
+          </div>
           <span v-else class="text-sm text-slate-400">없음</span>
         </InfoField>
       </div>


### PR DESCRIPTION
## 📋 작업 내용

<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- 메일 이력 발송 규칙을 실제 비즈니스 흐름에 맞게 정립 (#126)
- 첨부파일 필드를 boolean에서 파일명 배열로 교체하고 문서 미리보기 연동 (#128)
- 상세검색에 수신자 필터 추가 및 날짜 필터 레이아웃 개선

- `db.json`: 메일 이력 데이터 재구성 (PO 제거, CI+PL 묶음 발송, 생산·출하 지시서 내부 수신자 수정)
- `EmailListPage.vue`
- `type` → `types[]`, `hasAttachment` → `attachments[]` 구조 반영
- 첨부파일 클릭 시 API 조회 후 문서 HTML 미리보기 모달 오픈
- 수신자 필터(`recipient`) 추가 및 필터 초기화 처리
- `DateRangeField` → `DateField` 두 개로 분리

## 🔗 관련 이슈

<!-- 관련 이슈 번호를 적어주세요 (자동으로 이슈가 닫힙니다) -->
- closes #126 
- closes #128 

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

<img width="1420" height="746" alt="image" src="https://github.com/user-attachments/assets/ce3957e5-47d1-4144-832f-ed5e9842889e" />

<img width="1414" height="111" alt="image" src="https://github.com/user-attachments/assets/f20279ed-b2d5-4376-9b96-611bc5375255" />


## ✅ 체크리스트

  - [x] 메일 이력 목록 정상 렌더링 확인
  - [x] 유형·수신자·날짜 필터 검색 동작 확인
  - [x] 첨부파일 아이콘 클릭 시 문서 미리보기 모달 오픈 확인 (PI, CI, PL, 생산지시서, 출하지시서)
  - [x] 필터 초기화 후 전체 목록 복원 확인

## 💬 리뷰어에게

<!-- 리뷰할 때 중점적으로 봐줬으면 하는 부분이 있다면 적어주세요 -->
- 메일 상세보기, 파일첨부 이모지 HOVER 시 메일 이력 파일과 일치하는지 체크 봐주시면 됩니다.


