### PR TITLE
[refactor] 활동기록 패키지 기간·수주건 필터 개선

### DIFF
--- a/src/components/common/SearchModal.vue
+++ b/src/components/common/SearchModal.vue
@@ -54,6 +54,7 @@ function normalizeColumn(column) {
     @close="$emit('close')"
   >
     <div class="space-y-4">
+      <slot name="filter" />
       <SearchInput
         :model-value="searchKeyword"
         placeholder="검색어를 입력하세요"

--- a/src/views/package/ActivityPackagePage.vue
+++ b/src/views/package/ActivityPackagePage.vue
@@ -42,6 +42,7 @@ const poSearchKeyword = ref('')
 const selectedPoId = ref('')
 
 const filteredPoList = computed(() => {
+  if (!dateFrom.value) return []
   let list = poList.value
   const from = dateFrom.value.replaceAll('-', '/')
   const to   = dateTo.value.replaceAll('-', '/')
@@ -71,7 +72,7 @@ function clearPo() {
 const keyword     = ref('')
 const poDisplay   = ref('')
 const dateFrom    = ref('')
-const dateTo      = ref(new Date().toISOString().slice(0, 10))
+const dateTo      = ref(new Date().toLocaleDateString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit' }).replace(/\. /g, '-').replace('.', ''))
 
 // ── 유효성 검사 ────────────────────────────────────────────
 const errors = ref({})
@@ -345,27 +346,6 @@ function generatePdf() {
               />
             </div>
 
-            <!-- 기간 -->
-            <div class="space-y-1.5">
-              <p class="text-sm font-semibold text-slate-700">
-                기간 <span class="text-red-500">*</span>
-              </p>
-              <div class="grid gap-3 md:grid-cols-[1fr_auto_1fr] md:items-start">
-                <div>
-                  <DateField v-model="dateFrom" />
-                  <p v-if="errors.dateFrom" class="mt-1 text-xs text-red-500">{{ errors.dateFrom }}</p>
-                </div>
-                <span class="hidden pt-2 text-center text-sm text-slate-400 md:block">~</span>
-                <div>
-                  <DateField v-model="dateTo" />
-                  <p v-if="errors.dateTo" class="mt-1 text-xs text-red-500">{{ errors.dateTo }}</p>
-                </div>
-              </div>
-              <div class="flex justify-end">
-                <BaseButton variant="secondary" size="sm" @click="dateFrom = ''; dateTo = ''">기간 초기화</BaseButton>
-              </div>
-            </div>
-
             <!-- 수주건 (PO) -->
             <div class="space-y-1.5">
               <p class="text-sm font-semibold text-slate-700">
@@ -524,11 +504,25 @@ function generatePdf() {
       :columns="poColumns"
       :rows="filteredPoList"
       :search-keyword="poSearchKeyword"
-      empty-text="검색된 PO가 없습니다."
+      :empty-text="dateFrom ? '검색된 PO가 없습니다.' : '기간을 먼저 설정해주세요.'"
       @close="isPoModalOpen = false"
       @update:search-keyword="poSearchKeyword = $event"
       @select="selectPo"
-    />
+    >
+      <template #filter>
+        <div class="space-y-1.5">
+          <p class="text-sm font-semibold text-slate-700">기간</p>
+          <div class="grid grid-cols-[1fr_auto_1fr] items-center gap-2">
+            <DateField v-model="dateFrom" />
+            <span class="text-center text-sm text-slate-400">~</span>
+            <DateField v-model="dateTo" />
+          </div>
+          <div class="flex justify-end">
+            <BaseButton variant="secondary" size="sm" @click="dateFrom = ''; dateTo = ''">기간 초기화</BaseButton>
+          </div>
+        </div>
+      </template>
+    </SearchModal>
 
   </div>
 </template>


### PR DESCRIPTION
## 📋 작업 내용

<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->

  - 패키지 생성 폼에서 기간 항목을 수주건보다 먼저 입력하도록 순서 변경
  - 기간 설정 시 해당 기간 내에 속하는 수주건만 PO 검색 모달에 노출
  - 활동기록 목록 헤더 하단에 독립적인 기간 필터 추가 (종료일 기본값: 오늘 날짜)
  - 기간 필터 변경 시 조회된 목록 자동 전체 선택
  - PO를 선택하지 않은 상태에서 활동기록 목록이 비어있도록 수정


## 🔗 관련 이슈

<!-- 관련 이슈 번호를 적어주세요 (자동으로 이슈가 닫힙니다) -->
- closes #153 

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

<img width="1441" height="770" alt="image" src="https://github.com/user-attachments/assets/80f2d849-1f94-45d1-85c6-c5ec2ada26c0" />



## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

<!-- 리뷰할 때 중점적으로 봐줬으면 하는 부분이 있다면 적어주세요 -->
- 패키지 기간(`dateFrom`/`dateTo`)과 활동기록 목록 기간(`actDateFrom`/`actDateTo`)은 독립적으로 동작합니다.
- PO의 날짜 필드(`YYYY/MM/DD`)와 DateField 입력값(`YYYY-MM-DD`) 간 포맷 변환 처리가 포함되어 있습니다.

