### PR TITLE
hotfix: PI 환율 유틸 중복 선언 및 매출수금 현황 충돌

### DIFF
--- a/src/components/domain/document/PIFormModal.vue
+++ b/src/components/domain/document/PIFormModal.vue
@@ -72,34 +72,6 @@ const fallbackProductCatalog = [
   { id: '19', code: 'ITM019', name: 'UPS 1000VA', spec: '1000VA / 600W / 8 Outlet / LCD Display', unit: 'EA', unitPrice: 185000 },
   { id: '20', code: 'ITM020', name: 'Video Conference Camera', spec: '4K / 120° FOV / Built-in Mic / USB-C', unit: 'EA', unitPrice: 320000 },
 ]
-const defaultProductCatalog = defaultProductOptions.map((name, index) => ({
-  id: `default-${index + 1}`,
-  code: `DEF${String(index + 1).padStart(3, '0')}`,
-  name,
-  spec: '',
-  unit: 'EA',
-  unitPrice: 0,
-}))
-const exchangeRateRangeMap = {
-  USD: { unitLabel: '1 USD', quoteAmount: 1, min: 1430, max: 1490 },
-  EUR: { unitLabel: '1 EUR', quoteAmount: 1, min: 1560, max: 1640 },
-  JPY: { unitLabel: '100 JPY', quoteAmount: 100, min: 900, max: 950 },
-  GBP: { unitLabel: '1 GBP', quoteAmount: 1, min: 1830, max: 1910 },
-  AUD: { unitLabel: '1 AUD', quoteAmount: 1, min: 930, max: 980 },
-  CAD: { unitLabel: '1 CAD', quoteAmount: 1, min: 1030, max: 1080 },
-  SGD: { unitLabel: '1 SGD', quoteAmount: 1, min: 1070, max: 1130 },
-  AED: { unitLabel: '1 AED', quoteAmount: 1, min: 390, max: 410 },
-  CNY: { unitLabel: '1 CNY', quoteAmount: 1, min: 197, max: 208 },
-  MYR: { unitLabel: '1 MYR', quoteAmount: 1, min: 300, max: 340 },
-  THB: { unitLabel: '1 THB', quoteAmount: 1, min: 41, max: 45 },
-  VND: { unitLabel: '1000 VND', quoteAmount: 1000, min: 56, max: 62 },
-  IDR: { unitLabel: '100 IDR', quoteAmount: 100, min: 8, max: 10 },
-  INR: { unitLabel: '1 INR', quoteAmount: 1, min: 16, max: 18 },
-  SAR: { unitLabel: '1 SAR', quoteAmount: 1, min: 381, max: 398 },
-  BRL: { unitLabel: '1 BRL', quoteAmount: 1, min: 255, max: 290 },
-  SEK: { unitLabel: '1 SEK', quoteAmount: 1, min: 136, max: 145 },
-  CHF: { unitLabel: '1 CHF', quoteAmount: 1, min: 1620, max: 1690 },
-}
 const currencySymbolMap = {
   KRW: '₩',
   USD: '$',

--- a/src/utils/exchangeRate.js
+++ b/src/utils/exchangeRate.js
@@ -1,4 +1,4 @@
-const exchangeRateRangeMap = {
+export const exchangeRateRangeMap = {
   USD: { unitLabel: '1 USD', quoteAmount: 1, min: 1430, max: 1490 },
   EUR: { unitLabel: '1 EUR', quoteAmount: 1, min: 1560, max: 1640 },
   JPY: { unitLabel: '100 JPY', quoteAmount: 100, min: 900, max: 950 },
@@ -19,15 +19,7 @@ const exchangeRateRangeMap = {
   CHF: { unitLabel: '1 CHF', quoteAmount: 1, min: 1620, max: 1690 },
 }
 
-function getTodayDateInput() {
-  const today = new Date()
-  const year = today.getFullYear()
-  const month = String(today.getMonth() + 1).padStart(2, '0')
-  const day = String(today.getDate()).padStart(2, '0')
-  return `${year}-${month}-${day}`
-}
-
-function getDeterministicRate(seedText, min, max) {
+export function getDeterministicRate(seedText, min, max) {
   let hash = 0
 
   for (let index = 0; index < seedText.length; index += 1) {
@@ -37,7 +29,15 @@ function getDeterministicRate(seedText, min, max) {
   return min + (hash % (max - min + 1))
 }
 
-function resolveExchangeRateValue(currency, issueDate) {
+function getTodayDateInput() {
+  const today = new Date()
+  const year = today.getFullYear()
+  const month = String(today.getMonth() + 1).padStart(2, '0')
+  const day = String(today.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+export function resolveExchangeRateValue(currency, issueDate) {
   const range = exchangeRateRangeMap[currency]
 
   if (!range) {
@@ -48,7 +48,7 @@ function resolveExchangeRateValue(currency, issueDate) {
   return getDeterministicRate(seed, range.min, range.max)
 }
 
-function createExchangeRateHint(currency, issueDate) {
+export function createExchangeRateHint(currency, issueDate) {
   const range = exchangeRateRangeMap[currency]
 
   if (!range) {
@@ -59,7 +59,7 @@ function createExchangeRateHint(currency, issueDate) {
   return `참고 환율 ${range.unitLabel} = ${rate.toLocaleString('ko-KR')} KRW`
 }
 
-function convertCurrencyAmountToKrw(amount, currency, issueDate) {
+export function convertCurrencyAmountToKrw(amount, currency, issueDate) {
   const numericAmount = Number(amount)
 
   if (!Number.isFinite(numericAmount)) {
@@ -71,19 +71,11 @@ function convertCurrencyAmountToKrw(amount, currency, issueDate) {
   }
 
   const range = exchangeRateRangeMap[currency]
-  const exchangeRate = resolveExchangeRateValue(currency, issueDate)
+  const rate = resolveExchangeRateValue(currency, issueDate)
 
-  if (!range || !exchangeRate) {
+  if (!range || !rate) {
     return Math.round(numericAmount)
   }
 
-  return Math.round((numericAmount / range.quoteAmount) * exchangeRate)
-}
-
-export {
-  createExchangeRateHint,
-  convertCurrencyAmountToKrw,
-  exchangeRateRangeMap,
-  getDeterministicRate,
-  resolveExchangeRateValue,
+  return Math.round((numericAmount / range.quoteAmount) * rate)
 }

--- a/src/views/documents/CollectionsPage.vue
+++ b/src/views/documents/CollectionsPage.vue
@@ -51,15 +51,24 @@ const statusOptions = [
 ]
 
 const columns = [
-  { key: 'poId', label: 'PO 번호', align: 'center', width: '140px' },
-  { key: 'clientName', label: '거래처', align: 'center', width: '220px' },
-  { key: 'currency', label: '통화', align: 'center', width: '90px' },
-  { key: 'salesAmount', label: '원문매출액', align: 'right', width: '150px' },
-  { key: 'salesAmountKrw', label: '환산매출액(KRW)', align: 'right', width: '170px' },
-  { key: 'issueDate', label: '발행일', align: 'center', width: '130px' },
-  { key: 'collectionDate', label: '수금일', align: 'center', width: '130px' },
-  { key: 'status', label: '상태', align: 'center', width: '120px' },
+  { key: 'poId', label: 'PO 번호', width: '140px' },
+  { key: 'clientName', label: '거래처', width: '220px' },
+  { key: 'country', label: '국가', width: '110px' },
+  { key: 'manager', label: '영업담당자', width: '120px' },
+  { key: 'currency', label: '통화', width: '90px' },
+  { key: 'salesAmount', label: '원문매출액', width: '150px' },
+  { key: 'salesAmountKrw', label: '환산매출액(KRW)', width: '170px' },
+  { key: 'issueDate', label: '발행일', width: '130px' },
+  { key: 'collectionDate', label: '수금일', width: '130px' },
+  { key: 'status', label: '상태', width: '120px' },
 ]
+
+function normalizeCollectionRow(row) {
+  return {
+    ...row,
+    collectionDate: row.status === '수금완료' ? row.collectionDate || null : null,
+  }
+}
 
 const rowsData = ref([
   {
@@ -126,10 +135,6 @@ const clientRowsSource = [
   { id: 'CL004', name: 'Al Baraka Trading LLC', country: 'UAE' },
 ]
 
-function openClientSearch() {
-  clientSearchOpen.value = true
-}
-
 const {
   filters,
   filteredRows: baseFilteredRows,
@@ -154,12 +159,10 @@ const filteredRows = computed(() => {
   return rows.filter((row) => !appliedCurrencyFilter.value || row.currency === appliedCurrencyFilter.value)
 })
 
-const enrichedRows = computed(() => {
-  return filteredRows.value.map((row) => ({
-    ...row,
-    salesAmountKrw: convertCurrencyAmountToKrw(row.salesAmount, row.currency, row.issueDate?.replaceAll('/', '-')),
-  }))
-})
+const enrichedRows = computed(() => filteredRows.value.map((row) => ({
+  ...row,
+  salesAmountKrw: convertCurrencyAmountToKrw(row.salesAmount, row.currency, row.issueDate?.replaceAll('/', '-')),
+})))
 
 const sortedRows = computed(() => {
   return [...enrichedRows.value].sort((left, right) => {
@@ -174,7 +177,7 @@ const sortedRows = computed(() => {
 })
 
 const { currentPage, totalPages, paginatedRows } = usePagination(sortedRows)
-const totalKrwAmount = computed(() => sortedRows.value.reduce((sum, row) => sum + row.salesAmountKrw, 0))
+
 const tableRows = computed(() => {
   const rows = []
   let currentCurrency = ''
@@ -224,6 +227,8 @@ const tableRows = computed(() => {
   return rows
 })
 
+const totalKrwAmount = computed(() => sortedRows.value.reduce((sum, row) => sum + row.salesAmountKrw, 0))
+
 const clientRows = computed(() => {
   const keyword = clientSearchKeyword.value.trim().toLowerCase()
   if (!keyword) return clientRowsSource
@@ -239,27 +244,6 @@ const poRows = computed(() => {
   }))
   if (!keyword) return source
   return source.filter((row) => [row.poId, row.clientName, row.issueDate].some((value) => String(value).toLowerCase().includes(keyword)))
-})
-
-const summaryRows = computed(() => {
-  const currencyMap = {}
-
-  filteredRows.value.forEach((row) => {
-    if (!currencyMap[row.currency]) {
-      currencyMap[row.currency] = { count: 0, total: 0 }
-    }
-    currencyMap[row.currency].count += 1
-    currencyMap[row.currency].total += row.salesAmount
-  })
-
-  return Object.entries(currencyMap)
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([currency, data]) => ({
-      currency,
-      count: data.count,
-      total: data.total,
-      totalFormatted: data.total.toLocaleString(),
-    }))
 })
 
 const statusConfirmRows = computed(() => {
@@ -284,7 +268,9 @@ const currencySymbols = {
 
 function formatAmount(value, currency) {
   const symbol = currencySymbols[currency] || ''
-  if (typeof value === 'number') return `${symbol}${value.toLocaleString()}`
+  if (typeof value === 'number') {
+    return `${symbol}${value.toLocaleString()}`
+  }
   return `${symbol}${value}`
 }
 
@@ -308,13 +294,6 @@ function resolveNextCollectionDate(row, nextStatusValue) {
   return null
 }
 
-function normalizeCollectionRow(row) {
-  return {
-    ...row,
-    collectionDate: row.status === '수금완료' ? row.collectionDate || null : null,
-  }
-}
-
 function resetFilters() {
   resetBaseFilters()
   currencyFilter.value = ''
@@ -324,6 +303,10 @@ function resetFilters() {
 function searchRows() {
   appliedCurrencyFilter.value = currencyFilter.value
   applyFilters()
+}
+
+function openClientSearch() {
+  clientSearchOpen.value = true
 }
 
 function handleClientSelect(client) {
@@ -398,62 +381,62 @@ function cancelStatusChange() {
 
     <CollapsibleFilterCard :open="isAdvancedOpen">
       <div class="grid grid-cols-2 gap-3 text-sm md:grid-cols-3 lg:grid-cols-4">
-          <FormField label="발행일" class="col-span-2">
-            <div class="grid gap-2 sm:grid-cols-[1fr_auto_1fr] sm:items-end">
-              <DateField v-model="filters.registeredFrom" />
-              <span class="text-center text-sm text-slate-400 sm:pb-2">~</span>
-              <DateField v-model="filters.registeredTo" />
-            </div>
-          </FormField>
+        <FormField label="발행일" class="col-span-2">
+          <div class="grid gap-2 sm:grid-cols-[1fr_auto_1fr] sm:items-end">
+            <DateField v-model="filters.registeredFrom" />
+            <span class="text-center text-sm text-slate-400 sm:pb-2">~</span>
+            <DateField v-model="filters.registeredTo" />
+          </div>
+        </FormField>
 
-          <FormField label="수금일" class="col-span-2">
-            <div class="grid gap-2 sm:grid-cols-[1fr_auto_1fr] sm:items-end">
-              <DateField v-model="filters.deliveryFrom" />
-              <span class="text-center text-sm text-slate-400 sm:pb-2">~</span>
-              <DateField v-model="filters.deliveryTo" />
-            </div>
-          </FormField>
+        <FormField label="수금일" class="col-span-2">
+          <div class="grid gap-2 sm:grid-cols-[1fr_auto_1fr] sm:items-end">
+            <DateField v-model="filters.deliveryFrom" />
+            <span class="text-center text-sm text-slate-400 sm:pb-2">~</span>
+            <DateField v-model="filters.deliveryTo" />
+          </div>
+        </FormField>
 
-          <FormField label="거래처">
-            <SearchTriggerField
-              v-model="filters.clientName"
-              placeholder="거래처 검색..."
-              title="거래처 검색"
-              @trigger="openClientSearch"
-            />
-          </FormField>
+        <FormField label="거래처">
+          <SearchTriggerField
+            v-model="filters.clientName"
+            placeholder="거래처 검색..."
+            title="거래처 검색"
+            @trigger="openClientSearch"
+          />
+        </FormField>
 
-          <FormField label="국가">
-            <SearchableCombobox
-              v-model="filters.country"
-              :options="countryOptions"
-              placeholder="국가 검색..."
-            />
-          </FormField>
+        <FormField label="국가">
+          <SearchableCombobox
+            v-model="filters.country"
+            :options="countryOptions"
+            placeholder="국가 검색..."
+          />
+        </FormField>
 
-          <FormField label="통화">
-            <SearchableCombobox
-              v-model="currencyFilter"
-              :options="currencyOptions"
-              placeholder="통화 선택..."
-            />
-          </FormField>
+        <FormField label="통화">
+          <SearchableCombobox
+            v-model="currencyFilter"
+            :options="currencyOptions"
+            placeholder="통화 선택..."
+          />
+        </FormField>
 
-          <FormField label="영업담당자">
-            <SearchableCombobox
-              v-model="filters.manager"
-              :options="managerOptions"
-              placeholder="담당자 검색..."
-            />
-          </FormField>
+        <FormField label="영업담당자">
+          <SearchableCombobox
+            v-model="filters.manager"
+            :options="managerOptions"
+            placeholder="담당자 검색..."
+          />
+        </FormField>
 
-          <FormField label="상태">
-            <SearchableCombobox
-              v-model="filters.status"
-              :options="statusOptions"
-              placeholder="상태 선택..."
-            />
-          </FormField>
+        <FormField label="상태">
+          <SearchableCombobox
+            v-model="filters.status"
+            :options="statusOptions"
+            placeholder="상태 선택..."
+          />
+        </FormField>
       </div>
 
       <div class="mt-2 flex items-center justify-end gap-2 border-t border-slate-100 pt-3">
@@ -466,90 +449,6 @@ function cancelStatusChange() {
         <BaseButton size="sm" @click="searchRows">
           <template #leading>
             <i class="fas fa-search text-xs" aria-hidden="true"></i>
-        <div class="mt-2 flex items-center justify-end gap-2 border-t border-slate-100 pt-3">
-          <BaseButton variant="secondary" size="sm" @click="resetFilters">
-            <template #leading>
-              <i class="fas fa-undo text-xs" aria-hidden="true"></i>
-            </template>
-            초기화
-          </BaseButton>
-          <BaseButton size="sm" @click="searchRows">
-            <template #leading>
-              <i class="fas fa-search text-xs" aria-hidden="true"></i>
-            </template>
-            검색
-          </BaseButton>
-        </div>
-    </CollapsibleFilterCard>
-    <BaseTable
-      :columns="columns"
-      :rows="filteredRows"
-      empty-text="데이터가 없습니다."
-    >
-      <template #cell-poId="{ value }">
-        <span class="font-mono text-xs font-semibold text-brand-600">{{ value }}</span>
-      </template>
-
-      <template #cell-clientName="{ value }">
-        <span>{{ value }}</span>
-      </template>
-
-      <template #cell-country="{ value }">
-        <span class="text-xs text-slate-600">{{ value }}</span>
-      </template>
-
-      <template #cell-manager="{ value }">
-        <span class="text-xs text-slate-600">{{ value }}</span>
-      </template>
-
-      <template #cell-currency="{ value }">
-        <span class="text-xs font-semibold text-slate-700">{{ value }}</span>
-      </template>
-
-      <template #cell-salesAmount="{ value, row }">
-        <span class="text-sm font-semibold text-slate-800">{{ formatAmount(value, row.currency) }}</span>
-      </template>
-
-      <template #cell-issueDate="{ value }">
-        <span class="text-xs">{{ value }}</span>
-      </template>
-
-      <template #cell-collectionDate="{ value }">
-        <span class="text-xs">{{ formatCollectionDate(value) }}</span>
-      </template>
-
-      <template #cell-status="{ row }">
-        <select
-          :key="`${row.poId}-${row.status}`"
-          class="cursor-pointer rounded-md border border-slate-200 bg-white px-2 py-1 text-xs focus:border-brand-400 focus:outline-none"
-          :value="row.status === '수금완료' ? 'PAID' : 'UNPAID'"
-          @change="openStatusConfirm(row, $event.target.value)"
-        >
-          <option value="UNPAID">미수금</option>
-          <option value="PAID">수금완료</option>
-        </select>
-      </template>
-
-      <template #footer>
-        <tr
-          v-for="(summary, index) in summaryRows"
-          :key="summary.currency"
-          class="bg-slate-100/80"
-        >
-          <template v-if="index === 0">
-            <td
-              class="border-t-2 border-t-slate-300 border-r border-slate-200 px-4 py-3 text-center align-middle text-xs font-semibold text-slate-500"
-              :rowspan="summaryRows.length"
-            >
-              {{ filteredRows.length }}건
-            </td>
-            <td
-              class="border-t-2 border-t-slate-300 border-r border-slate-200 px-4 py-3 text-center align-middle text-base font-extrabold text-slate-800"
-              :rowspan="summaryRows.length"
-              colspan="3"
-            >
-              합계
-            </td>
           </template>
           검색
         </BaseButton>
@@ -586,8 +485,9 @@ function cancelStatusChange() {
           </button>
         </div>
       </div>
+
       <div class="text-xs text-slate-500">
-        통화별로 정렬된 행 뒤에 소계를 표시하고, 맨 아래에서 전체 환산 총액을 확인합니다.
+        통화별 소계와 맨 아래 KRW 총액을 한 테이블에서 확인합니다.
       </div>
     </section>
 
@@ -607,6 +507,7 @@ function cancelStatusChange() {
               </th>
             </tr>
           </thead>
+
           <tbody v-if="tableRows.length > 0" class="bg-white">
             <tr
               v-for="row in tableRows"
@@ -614,7 +515,7 @@ function cancelStatusChange() {
               :class="row.rowType === 'subtotal' ? 'bg-slate-50' : 'transition hover:bg-slate-50/70'"
             >
               <template v-if="row.rowType === 'subtotal'">
-                <td colspan="3" class="border-b border-r border-slate-200 px-4 py-3 text-left text-sm font-semibold text-slate-800">
+                <td colspan="5" class="border-b border-r border-slate-200 px-4 py-3 text-left text-sm font-semibold text-slate-800">
                   {{ row.currency }} 소계 ({{ row.rowCount }}건)
                 </td>
                 <td class="border-b border-r border-slate-200 px-4 py-3 text-right text-sm font-semibold text-slate-800">
@@ -635,10 +536,14 @@ function cancelStatusChange() {
                 <td class="border-b border-r border-slate-200 px-4 py-3 text-left text-sm">
                   <span class="font-medium text-slate-900">{{ row.clientName }}</span>
                 </td>
+                <td class="border-b border-r border-slate-200 px-4 py-3 text-center text-sm text-slate-700">
+                  {{ row.country }}
+                </td>
+                <td class="border-b border-r border-slate-200 px-4 py-3 text-center text-sm text-slate-700">
+                  {{ row.manager }}
+                </td>
                 <td class="border-b border-r border-slate-200 px-4 py-3 text-center text-sm">
-                  <span class="text-xs font-semibold text-slate-700">
-                    {{ row.currency }}
-                  </span>
+                  <span class="text-xs font-semibold text-slate-700">{{ row.currency }}</span>
                 </td>
                 <td class="border-b border-r border-slate-200 px-4 py-3 text-right text-sm">
                   <span class="font-semibold text-slate-800">
@@ -654,13 +559,13 @@ function cancelStatusChange() {
                   {{ row.issueDate }}
                 </td>
                 <td class="border-b border-r border-slate-200 px-4 py-3 text-center text-xs text-slate-700">
-                  {{ row.collectionDate }}
+                  {{ formatCollectionDate(row.collectionDate) }}
                 </td>
                 <td class="border-b border-slate-200 px-4 py-3 text-center text-sm">
                   <select
                     class="cursor-pointer rounded-md border border-slate-200 bg-white px-2 py-1 text-xs focus:border-brand-400 focus:outline-none"
                     :value="row.status === '수금완료' ? 'PAID' : 'UNPAID'"
-                    @change="updateStatus(row.poId, $event.target.value)"
+                    @change="openStatusConfirm(row, $event.target.value)"
                   >
                     <option value="UNPAID">미수금</option>
                     <option value="PAID">수금완료</option>
@@ -669,9 +574,10 @@ function cancelStatusChange() {
               </template>
             </tr>
           </tbody>
+
           <tfoot v-if="tableRows.length > 0" class="bg-slate-50">
             <tr>
-              <td colspan="4" class="border-t border-r border-slate-200 px-4 py-3 text-left text-sm font-bold text-slate-900">
+              <td colspan="6" class="border-t border-r border-slate-200 px-4 py-3 text-left text-sm font-bold text-slate-900">
                 전체 환산 총액
               </td>
               <td class="border-t border-r border-slate-200 px-4 py-3 text-right text-sm font-extrabold text-slate-900">
@@ -684,6 +590,7 @@ function cancelStatusChange() {
           </tfoot>
         </table>
       </div>
+
       <div
         v-if="tableRows.length === 0"
         class="flex min-h-[160px] items-center justify-center border-t border-slate-200 bg-white px-4 py-12 text-center text-sm text-slate-400"


### PR DESCRIPTION
## 📋 작업 내용

<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
  - 병합 충돌로 인해 깨진 `PIFormModal`과 `CollectionsPage`를 정리했습니다.
  - `PIFormModal`의 환율 관련 중복 선언을 제거하고 공통 `exchangeRate` 유틸 기준으로 통일했습니다.
  - `CollectionsPage`에 섞여 있던 충돌 코드를 제거하고, 최신 요구사항 기준의 테이블 구조로 다시 정리했습니다.
  - 빌드가 다시 정상 통과하도록 복구했습니다.


## 🔗 관련 이슈

<!-- 관련 이슈 번호를 적어주세요 (자동으로 이슈가 닫힙니다) -->
- closes #164 

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->



## ✅ 체크리스트

  - [x] 정상 동작 확인
  - [x] 불필요한 코드/주석 제거
  - [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

<!-- 리뷰할 때 중점적으로 봐줬으면 하는 부분이 있다면 적어주세요 -->

- 이번 PR은 기능 추가가 아니라 병합 충돌 후 남은 중복 선언과 깨진 템플릿을 복구하는 hotfix 성격입니다.
- `PIFormModal`은 공통 환율 유틸을 사용하도록 정리했고, `CollectionsPage`는 통화별 소계와 KRW 총액 구조 기준으로 다시 맞췄습니다.

