### PR TITLE
[refactor] 거래처·품목 검색 모달 상세 컬럼과 공통 lookup 구조 정리

### DIFF
--- a/src/components/common/SearchModal.vue
+++ b/src/components/common/SearchModal.vue
@@ -28,19 +28,46 @@ const props = defineProps({
     type: String,
     default: '검색 결과가 없습니다.',
   },
+  width: {
+    type: String,
+    default: 'max-w-6xl',
+  },
 })
 
 const emit = defineEmits(['close', 'update:searchKeyword', 'select'])
 
 function normalizeColumn(column) {
   if (typeof column === 'string') {
-    return { key: column, label: column }
+    return { key: column, label: column, align: 'left', width: '' }
   }
 
   return {
     key: column.key,
     label: column.label ?? column.key,
+    align: column.align ?? 'left',
+    width: column.width ?? '',
+    format: column.format,
   }
+}
+
+function getAlignClass(align) {
+  if (align === 'center') return 'text-center'
+  if (align === 'right') return 'text-right'
+  return 'text-left'
+}
+
+function getColumnStyle(column) {
+  if (!column.width) return {}
+
+  return {
+    width: column.width,
+    minWidth: column.width,
+  }
+}
+
+function getCellValue(row, column) {
+  const value = row[column.key]
+  return column.format ? column.format(value, row) : value
 }
 </script>
 
@@ -49,7 +76,7 @@ function normalizeColumn(column) {
     :open="open"
     :title="title"
     description="목록에서 원하는 항목을 검색해 선택하는 공통 모달"
-    width="max-w-4xl"
+    :width="width"
     :z-index="70"
     @close="$emit('close')"
   >
@@ -69,7 +96,9 @@ function normalizeColumn(column) {
               <th
                 v-for="column in columns"
                 :key="normalizeColumn(column).key"
-                class="px-4 py-3 text-left text-sm font-semibold text-slate-600"
+                class="px-4 py-3 text-sm font-semibold text-slate-600"
+                :class="getAlignClass(normalizeColumn(column).align)"
+                :style="getColumnStyle(normalizeColumn(column))"
               >
                 {{ normalizeColumn(column).label }}
               </th>
@@ -92,13 +121,15 @@ function normalizeColumn(column) {
                 v-for="column in columns"
                 :key="normalizeColumn(column).key"
                 class="px-4 py-3 text-slate-700"
+                :class="getAlignClass(normalizeColumn(column).align)"
+                :style="getColumnStyle(normalizeColumn(column))"
               >
                 <slot
                   :name="`cell-${normalizeColumn(column).key}`"
                   :row="row"
                   :value="row[normalizeColumn(column).key]"
                 >
-                  {{ row[normalizeColumn(column).key] ?? '-' }}
+                  {{ getCellValue(row, normalizeColumn(column)) ?? '-' }}
                 </slot>
               </td>
             </tr>

--- a/src/composables/useSearchModalLookups.js
+++ b/src/composables/useSearchModalLookups.js
@@ -1,0 +1,168 @@
+import { computed, onMounted, ref } from 'vue'
+
+import { fetchClients, fetchCountries, fetchCurrencies, fetchItems } from '@/api/master'
+
+const fallbackClientRows = [
+  {
+    id: '1',
+    code: 'CLI001',
+    name: 'Global Steel Corp.',
+    country: '미국',
+    city: 'Houston',
+    currency: 'USD',
+    manager: 'John Smith',
+    tel: '+1-713-555-0101',
+    status: '활성',
+  },
+  {
+    id: '2',
+    code: 'CLI003',
+    name: 'Tokyo Trading Co.',
+    country: '일본',
+    city: 'Tokyo',
+    currency: 'JPY',
+    manager: 'Tanaka Yuki',
+    tel: '+81-3-555-0303',
+    status: '활성',
+  },
+  {
+    id: '3',
+    code: 'CLI020',
+    name: 'Hanoi Digital JSC',
+    country: '베트남',
+    city: 'Hanoi',
+    currency: 'USD',
+    manager: 'Pham Thi Lan',
+    tel: '+84-24-555-2010',
+    status: '활성',
+  },
+]
+
+const fallbackProductRows = [
+  {
+    id: '1',
+    code: 'ITM001',
+    name: 'Wireless Presenter',
+    nameKr: '무선 프레젠터',
+    spec: '2.4GHz / 100m / USB Receiver / Laser Pointer',
+    unit: 'EA',
+    unitPrice: 55000,
+    hsCode: '8471.60',
+    category: 'Electronics',
+    status: '활성',
+  },
+  {
+    id: '2',
+    code: 'ITM003',
+    name: 'Smart Projector FHD',
+    nameKr: '스마트 프로젝터 FHD',
+    spec: 'FHD 1920×1080 / 3500lm / HDMI / WiFi / BT',
+    unit: 'EA',
+    unitPrice: 780000,
+    hsCode: '8528.62',
+    category: 'Electronics',
+    status: '활성',
+  },
+  {
+    id: '3',
+    code: 'ITM010',
+    name: 'Smart Whiteboard 65"',
+    nameKr: '스마트 화이트보드 65형',
+    spec: '65" 4K Touch / Android / WiFi / HDMI / 20pt',
+    unit: 'EA',
+    unitPrice: 3500000,
+    hsCode: '8528.52',
+    category: 'Electronics',
+    status: '활성',
+  },
+]
+
+function includesKeyword(row, fields, keyword) {
+  if (!keyword) return true
+
+  return fields.some((field) => String(row[field] ?? '').toLowerCase().includes(keyword))
+}
+
+export function useSearchModalLookups() {
+  const clientRowsSource = ref([...fallbackClientRows])
+  const productRowsSource = ref([...fallbackProductRows])
+
+  async function loadSearchModalLookups() {
+    try {
+      const [clientsData, countriesData, currenciesData, itemsData] = await Promise.all([
+        fetchClients(),
+        fetchCountries(),
+        fetchCurrencies(),
+        fetchItems(),
+      ])
+
+      const countryMap = new Map(
+        countriesData.map((country) => [String(country.id), country.nameKr ?? country.name ?? '-']),
+      )
+
+      const currencyMap = new Map(
+        currenciesData.map((currency) => [String(currency.id), currency.code ?? '-']),
+      )
+
+      clientRowsSource.value = clientsData.map((client) => ({
+        id: String(client.id),
+        code: client.code ?? '-',
+        name: client.name ?? '-',
+        country: countryMap.get(String(client.countryId)) ?? '-',
+        city: client.city ?? '-',
+        currency: currencyMap.get(String(client.currencyId)) ?? '-',
+        manager: client.manager ?? '-',
+        tel: client.tel ?? '-',
+        status: client.status ?? '-',
+      }))
+
+      productRowsSource.value = itemsData.map((item) => ({
+        id: String(item.id),
+        code: item.code ?? '-',
+        name: item.name ?? '-',
+        nameKr: item.nameKr ?? '-',
+        spec: item.spec ?? '-',
+        unit: item.unit ?? '-',
+        unitPrice: item.unitPrice ?? 0,
+        hsCode: item.hsCode ?? '-',
+        category: item.category ?? '-',
+        status: item.status ?? '-',
+      }))
+    } catch {
+      clientRowsSource.value = [...fallbackClientRows]
+      productRowsSource.value = [...fallbackProductRows]
+    }
+  }
+
+  onMounted(loadSearchModalLookups)
+
+  function createClientRows(keywordRef) {
+    return computed(() => {
+      const keyword = keywordRef.value.trim().toLowerCase()
+      return clientRowsSource.value.filter((row) => includesKeyword(
+        row,
+        ['code', 'name', 'country', 'city', 'currency', 'manager', 'tel', 'status'],
+        keyword,
+      ))
+    })
+  }
+
+  function createProductRows(keywordRef) {
+    return computed(() => {
+      const keyword = keywordRef.value.trim().toLowerCase()
+      return productRowsSource.value.filter((row) => includesKeyword(
+        row,
+        ['code', 'name', 'nameKr', 'spec', 'unit', 'hsCode', 'category', 'status'],
+        keyword,
+      ))
+    })
+  }
+
+  return {
+    clientRowsSource,
+    productRowsSource,
+    createClientRows,
+    createProductRows,
+    reloadSearchModalLookups: loadSearchModalLookups,
+  }
+}

--- a/src/utils/searchModalColumns.js
+++ b/src/utils/searchModalColumns.js
@@ -1,0 +1,25 @@
+function formatUnitPrice(value) {
+  return `₩${Number(value || 0).toLocaleString()}`
+}
+
+export const clientSearchColumns = [
+  { key: 'code', label: '코드', align: 'center', width: '110px' },
+  { key: 'name', label: '거래처명', align: 'left', width: '220px' },
+  { key: 'country', label: '국가', align: 'center', width: '110px' },
+  { key: 'city', label: '도시', align: 'center', width: '120px' },
+  { key: 'currency', label: '통화', align: 'center', width: '90px' },
+  { key: 'manager', label: '담당자', align: 'center', width: '120px' },
+  { key: 'tel', label: '연락처', align: 'left', width: '170px' },
+  { key: 'status', label: '상태', align: 'center', width: '90px' },
+]
+
+export const productSearchColumns = [
+  { key: 'code', label: '코드', align: 'center', width: '110px' },
+  { key: 'name', label: '품목명', align: 'left', width: '210px' },
+  { key: 'nameKr', label: '국문명', align: 'left', width: '180px' },
+  { key: 'spec', label: '규격', align: 'left', width: '280px' },
+  { key: 'unit', label: '단위', align: 'center', width: '80px' },
+  { key: 'unitPrice', label: '기준단가', align: 'right', width: '120px', format: formatUnitPrice },
+  { key: 'hsCode', label: 'HS Code', align: 'center', width: '110px' },
+  { key: 'status', label: '상태', align: 'center', width: '90px' },
+]

--- a/src/views/documents/CIPage.vue
+++ b/src/views/documents/CIPage.vue
@@ -16,7 +16,9 @@ import SearchTriggerField from '@/components/common/SearchTriggerField.vue'
 import SearchableCombobox from '@/components/common/SearchableCombobox.vue'
 import { useDocumentFilter } from '@/composables/useDocumentFilter'
 import { usePagination } from '@/composables/usePagination'
+import { useSearchModalLookups } from '@/composables/useSearchModalLookups'
 import { openDocumentOutputByType } from '@/utils/documentOutput'
+import { clientSearchColumns, productSearchColumns } from '@/utils/searchModalColumns'
 
 const isAdvancedOpen = ref(false)
 const previewTarget = ref(null)
@@ -77,13 +79,9 @@ const { filters, filteredRows, resetFilters, applyFilters } = useDocumentFilter(
   issueDateField: 'invoiceDate',
 })
 const { currentPage, totalPages, paginatedRows } = usePagination(filteredRows)
+const { createClientRows, createProductRows } = useSearchModalLookups()
 
-const clientRows = computed(() => {
-  const keyword = clientSearchKeyword.value.trim().toLowerCase()
-  const source = [...new Map(rowsData.value.map((row) => [row.clientName, { id: row.id, name: row.clientName, country: row.country }])).values()]
-  if (!keyword) return source
-  return source.filter((row) => [row.id, row.name, row.country].some((value) => String(value).toLowerCase().includes(keyword)))
-})
+const clientRows = createClientRows(clientSearchKeyword)
 
 const codeRows = computed(() => {
   const keyword = codeSearchKeyword.value.trim().toLowerCase()
@@ -92,12 +90,7 @@ const codeRows = computed(() => {
   return source.filter((row) => [row.id, row.invoiceDate, row.clientName].some((value) => String(value).toLowerCase().includes(keyword)))
 })
 
-const productRows = computed(() => {
-  const keyword = productSearchKeyword.value.trim().toLowerCase()
-  const source = [...new Map(rowsData.value.map((row) => [row.itemName, { name: row.itemName, country: row.country, clientName: row.clientName }])).values()]
-  if (!keyword) return source
-  return source.filter((row) => [row.name, row.country, row.clientName].some((value) => String(value).toLowerCase().includes(keyword)))
-})
+const productRows = createProductRows(productSearchKeyword)
 
 /**
  * 목록 row 데이터를 CI 문서 템플릿이 필요로 하는 구조로 변환합니다.
@@ -314,11 +307,7 @@ function handleProductSelect(row) {
     <SearchModal
       :open="clientSearchOpen"
       title="거래처 검색"
-      :columns="[
-        { key: 'id', label: '코드' },
-        { key: 'name', label: '거래처명' },
-        { key: 'country', label: '국가' },
-      ]"
+      :columns="clientSearchColumns"
       :rows="clientRows"
       :search-keyword="clientSearchKeyword"
       @update:search-keyword="clientSearchKeyword = $event"
@@ -344,11 +333,7 @@ function handleProductSelect(row) {
     <SearchModal
       :open="productSearchOpen"
       title="품목명 검색"
-      :columns="[
-        { key: 'name', label: '품목명' },
-        { key: 'country', label: '국가' },
-        { key: 'clientName', label: '거래처명' },
-      ]"
+      :columns="productSearchColumns"
       :rows="productRows"
       :search-keyword="productSearchKeyword"
       @update:search-keyword="productSearchKeyword = $event"

--- a/src/views/documents/CollectionsPage.vue
+++ b/src/views/documents/CollectionsPage.vue
@@ -14,7 +14,9 @@ import SearchTriggerField from '@/components/common/SearchTriggerField.vue'
 import SearchableCombobox from '@/components/common/SearchableCombobox.vue'
 import { useDocumentFilter } from '@/composables/useDocumentFilter'
 import { usePagination } from '@/composables/usePagination'
+import { useSearchModalLookups } from '@/composables/useSearchModalLookups'
 import { convertCurrencyAmountToKrw } from '@/utils/exchangeRate'
+import { clientSearchColumns } from '@/utils/searchModalColumns'
 
 const isAdvancedOpen = ref(false)
 const clientSearchOpen = ref(false)
@@ -128,12 +130,7 @@ const rowsData = ref([
   },
 ].map(normalizeCollectionRow))
 
-const clientRowsSource = [
-  { id: 'CL001', name: 'COOLSAY SDN BHD', country: '말레이시아' },
-  { id: 'CL002', name: 'Sakura Electronics Co., Ltd.', country: '일본' },
-  { id: 'CL003', name: 'Viet Steel JSC', country: '베트남' },
-  { id: 'CL004', name: 'Al Baraka Trading LLC', country: 'UAE' },
-]
+const { createClientRows } = useSearchModalLookups()
 
 const {
   filters,
@@ -229,11 +226,7 @@ const tableRows = computed(() => {
 
 const totalKrwAmount = computed(() => sortedRows.value.reduce((sum, row) => sum + row.salesAmountKrw, 0))
 
-const clientRows = computed(() => {
-  const keyword = clientSearchKeyword.value.trim().toLowerCase()
-  if (!keyword) return clientRowsSource
-  return clientRowsSource.filter((row) => [row.id, row.name, row.country].some((value) => String(value).toLowerCase().includes(keyword)))
-})
+const clientRows = createClientRows(clientSearchKeyword)
 
 const poRows = computed(() => {
   const keyword = poSearchKeyword.value.trim().toLowerCase()
@@ -607,11 +600,7 @@ function cancelStatusChange() {
     <SearchModal
       :open="clientSearchOpen"
       title="거래처 검색"
-      :columns="[
-        { key: 'id', label: '코드' },
-        { key: 'name', label: '거래처명' },
-        { key: 'country', label: '국가' },
-      ]"
+      :columns="clientSearchColumns"
       :rows="clientRows"
       :search-keyword="clientSearchKeyword"
       @update:search-keyword="clientSearchKeyword = $event"

--- a/src/views/documents/PIDetailPage.vue
+++ b/src/views/documents/PIDetailPage.vue
@@ -17,6 +17,7 @@ import { usePoDocuments } from '@/stores/poDocuments'
 import { buildApprovalInfoRows } from '@/utils/documentApproval'
 import { openDocumentOutputByType } from '@/utils/documentOutput'
 import { formatIncotermsLabel, resolveIncotermState } from '@/utils/incoterms'
+import { clientSearchColumns } from '@/utils/searchModalColumns'
 
 const route = useRoute()
 const router = useRouter()
@@ -32,16 +33,25 @@ const piDocuments = usePiDocuments()
 const poDocuments = usePoDocuments()
 
 const fallbackClientRowsSource = [
-  { id: 'CL001', name: 'COOLSAY SDN BHD', country: '말레이시아', buyers: ['Mr. Ahmad Razak (Purchasing Manager)', 'Ms. Siti Nurhaliza (Director)'] },
-  { id: 'CL002', name: 'TechBridge GmbH', country: '독일', buyers: ['Ms. Hanna Schneider (Procurement Lead)'] },
-  { id: 'CL003', name: 'Pacific Trading Inc.', country: '미국', buyers: ['Mr. Jacob Miller (Import Manager)'] },
+  { id: 'CL001', code: 'CL001', name: 'COOLSAY SDN BHD', country: '말레이시아', city: 'Port Klang', currency: 'USD', manager: 'Ahmad Razak', tel: '+60-3-555-0101', status: '활성', buyers: ['Mr. Ahmad Razak (Purchasing Manager)', 'Ms. Siti Nurhaliza (Director)'] },
+  { id: 'CL002', code: 'CL002', name: 'TechBridge GmbH', country: '독일', city: 'Hamburg', currency: 'EUR', manager: 'Hanna Schneider', tel: '+49-40-555-0202', status: '활성', buyers: ['Ms. Hanna Schneider (Procurement Lead)'] },
+  { id: 'CL003', code: 'CL003', name: 'Pacific Trading Inc.', country: '미국', city: 'Seattle', currency: 'USD', manager: 'Jacob Miller', tel: '+1-206-555-0303', status: '활성', buyers: ['Mr. Jacob Miller (Import Manager)'] },
 ]
 const clientRowsSource = ref([...fallbackClientRowsSource])
 
 const clientRows = computed(() => {
   const keyword = clientSearchKeyword.value.trim().toLowerCase()
   if (!keyword) return clientRowsSource.value
-  return clientRowsSource.value.filter((client) => [client.id, client.name, client.country].some((value) => value.toLowerCase().includes(keyword)))
+  return clientRowsSource.value.filter((client) => [
+    client.code,
+    client.name,
+    client.country,
+    client.city,
+    client.currency,
+    client.manager,
+    client.tel,
+    client.status,
+  ].some((value) => String(value ?? '').toLowerCase().includes(keyword)))
 })
 
 const incotermsLabel = computed(() => (
@@ -166,6 +176,11 @@ async function loadClientRows() {
       code: client.code,
       name: client.name,
       country: countryMap.get(String(client.countryId)) ?? '-',
+      city: client.city ?? '-',
+      currency: '-',
+      manager: client.manager ?? '-',
+      tel: client.tel ?? '-',
+      status: client.status ?? '-',
       buyers: buyersByClientId.get(String(client.id)) ?? [],
     }))
   } catch {
@@ -499,11 +514,7 @@ function confirmDelete() {
     <SearchModal
       :open="clientSearchOpen"
       title="거래처 검색"
-      :columns="[
-        { key: 'id', label: '코드' },
-        { key: 'name', label: '거래처명' },
-        { key: 'country', label: '국가' },
-      ]"
+      :columns="clientSearchColumns"
       :rows="clientRows"
       :search-keyword="clientSearchKeyword"
       @update:search-keyword="clientSearchKeyword = $event"

--- a/src/views/documents/PIPage.vue
+++ b/src/views/documents/PIPage.vue
@@ -20,6 +20,7 @@ import PIFormModal from '@/components/domain/document/PIFormModal.vue'
 import { fetchBuyers, fetchClients, fetchCountries, fetchCurrencies } from '@/api/master'
 import { useDocumentFilter } from '@/composables/useDocumentFilter'
 import { usePagination } from '@/composables/usePagination'
+import { useSearchModalLookups } from '@/composables/useSearchModalLookups'
 import { useAuthStore } from '@/stores/auth'
 import { usePiDocuments } from '@/stores/piDocuments'
 import { useToast } from '@/composables/useToast'
@@ -36,6 +37,7 @@ import {
   REGISTRATION_REQUEST_STATUS,
 } from '@/utils/documentApproval'
 import { formatIncotermsLabel, resolveIncotermState } from '@/utils/incoterms'
+import { clientSearchColumns, productSearchColumns } from '@/utils/searchModalColumns'
 
 const router = useRouter()
 const authStore = useAuthStore()
@@ -87,7 +89,10 @@ const fallbackClientRowsSource = [
     code: 'CL001',
     name: 'COOLSAY SDN BHD',
     country: '말레이시아',
+    city: 'Port Klang',
     currency: 'USD',
+    manager: 'Ahmad Razak',
+    status: '활성',
     address: 'Lot 18, Jalan Pelabuhan Utara 27, 42000 Port Klang, Selangor, Malaysia',
     tel: '+60-3-555-0101',
     email: 'contact@coolsay.com',
@@ -98,7 +103,10 @@ const fallbackClientRowsSource = [
     code: 'CL002',
     name: 'TechBridge GmbH',
     country: '독일',
+    city: 'Hamburg',
     currency: 'EUR',
+    manager: 'Hanna Schneider',
+    status: '활성',
     address: 'Am Sandtorkai 35, 20457 Hamburg, Germany',
     tel: '+49-40-555-0202',
     email: 'info@techbridge.de',
@@ -109,7 +117,10 @@ const fallbackClientRowsSource = [
     code: 'CL003',
     name: 'Pacific Trading Inc.',
     country: '미국',
+    city: 'Seattle',
     currency: 'USD',
+    manager: 'Jacob Miller',
+    status: '활성',
     address: '1201 Harbor Avenue SW, Seattle, WA 98134, USA',
     tel: '+1-206-555-0303',
     email: 'contact@pacifictrading.com',
@@ -117,6 +128,7 @@ const fallbackClientRowsSource = [
   },
 ]
 const clientRowsSource = ref([...fallbackClientRowsSource])
+const { createProductRows } = useSearchModalLookups()
 const rowsData = usePiDocuments()
 
 const columns = [
@@ -157,7 +169,16 @@ const { currentPage, totalPages, paginatedRows } = usePagination(filteredRows)
 const clientRows = computed(() => {
   const keyword = clientSearchKeyword.value.trim().toLowerCase()
   if (!keyword) return clientRowsSource.value
-  return clientRowsSource.value.filter((client) => [client.id, client.name, client.country].some((value) => value.toLowerCase().includes(keyword)))
+  return clientRowsSource.value.filter((client) => [
+    client.code,
+    client.name,
+    client.country,
+    client.city,
+    client.currency,
+    client.manager,
+    client.tel,
+    client.status,
+  ].some((value) => String(value ?? '').toLowerCase().includes(keyword)))
 })
 
 const codeRows = computed(() => {
@@ -167,12 +188,7 @@ const codeRows = computed(() => {
   return rows.filter((row) => [row.id, row.issueDate, row.clientName].some((value) => String(value).toLowerCase().includes(keyword)))
 })
 
-const productRows = computed(() => {
-  const keyword = productSearchKeyword.value.trim().toLowerCase()
-  const rows = [...new Map(rowsData.value.map((row) => [row.itemName, { name: row.itemName, country: row.country, manager: row.manager }])).values()]
-  if (!keyword) return rows
-  return rows.filter((row) => [row.name, row.country, row.manager].some((value) => String(value).toLowerCase().includes(keyword)))
-})
+const productRows = createProductRows(productSearchKeyword)
 
 const currencySymbolMap = {
   USD: '$',
@@ -225,7 +241,10 @@ async function loadClientRows() {
       code: client.code,
       name: client.name,
       country: countryMap.get(String(client.countryId)) ?? '-',
+      city: client.city ?? '-',
       currency: currencyMap.get(String(client.currencyId)) ?? 'USD',
+      manager: client.manager ?? '-',
+      status: client.status ?? '-',
       address: client.address ?? '',
       tel: client.tel ?? '',
       email: client.email ?? '',
@@ -974,11 +993,7 @@ function handleProductSelect(product) {
     <SearchModal
       :open="clientSearchOpen"
       title="거래처 검색"
-      :columns="[
-        { key: 'id', label: '코드' },
-        { key: 'name', label: '거래처명' },
-        { key: 'country', label: '국가' },
-      ]"
+      :columns="clientSearchColumns"
       :rows="clientRows"
       :search-keyword="clientSearchKeyword"
       @update:search-keyword="clientSearchKeyword = $event"
@@ -1004,11 +1019,7 @@ function handleProductSelect(product) {
     <SearchModal
       :open="productSearchOpen"
       title="품목명 검색"
-      :columns="[
-        { key: 'name', label: '품목명' },
-        { key: 'country', label: '국가' },
-        { key: 'manager', label: '영업담당자' },
-      ]"
+      :columns="productSearchColumns"
       :rows="productRows"
       :search-keyword="productSearchKeyword"
       @update:search-keyword="productSearchKeyword = $event"

--- a/src/views/documents/PLPage.vue
+++ b/src/views/documents/PLPage.vue
@@ -16,7 +16,9 @@ import SearchTriggerField from '@/components/common/SearchTriggerField.vue'
 import SearchableCombobox from '@/components/common/SearchableCombobox.vue'
 import { useDocumentFilter } from '@/composables/useDocumentFilter'
 import { usePagination } from '@/composables/usePagination'
+import { useSearchModalLookups } from '@/composables/useSearchModalLookups'
 import { openDocumentOutputByType } from '@/utils/documentOutput'
+import { clientSearchColumns, productSearchColumns } from '@/utils/searchModalColumns'
 
 const isAdvancedOpen = ref(false)
 const previewTarget = ref(null)
@@ -77,13 +79,9 @@ const { filters, filteredRows, resetFilters, applyFilters } = useDocumentFilter(
   issueDateField: 'invoiceDate',
 })
 const { currentPage, totalPages, paginatedRows } = usePagination(filteredRows)
+const { createClientRows, createProductRows } = useSearchModalLookups()
 
-const clientRows = computed(() => {
-  const keyword = clientSearchKeyword.value.trim().toLowerCase()
-  const source = [...new Map(rowsData.value.map((row) => [row.clientName, { id: row.id, name: row.clientName, country: row.country }])).values()]
-  if (!keyword) return source
-  return source.filter((row) => [row.id, row.name, row.country].some((value) => String(value).toLowerCase().includes(keyword)))
-})
+const clientRows = createClientRows(clientSearchKeyword)
 
 const codeRows = computed(() => {
   const keyword = codeSearchKeyword.value.trim().toLowerCase()
@@ -92,12 +90,7 @@ const codeRows = computed(() => {
   return source.filter((row) => [row.id, row.invoiceDate, row.clientName].some((value) => String(value).toLowerCase().includes(keyword)))
 })
 
-const productRows = computed(() => {
-  const keyword = productSearchKeyword.value.trim().toLowerCase()
-  const source = [...new Map(rowsData.value.map((row) => [row.itemName, { name: row.itemName, country: row.country, clientName: row.clientName }])).values()]
-  if (!keyword) return source
-  return source.filter((row) => [row.name, row.country, row.clientName].some((value) => String(value).toLowerCase().includes(keyword)))
-})
+const productRows = createProductRows(productSearchKeyword)
 
 /**
  * 목록 row 데이터를 PL 문서 템플릿이 필요로 하는 구조로 변환합니다.
@@ -316,11 +309,7 @@ function handleProductSelect(row) {
     <SearchModal
       :open="clientSearchOpen"
       title="거래처 검색"
-      :columns="[
-        { key: 'id', label: '코드' },
-        { key: 'name', label: '거래처명' },
-        { key: 'country', label: '국가' },
-      ]"
+      :columns="clientSearchColumns"
       :rows="clientRows"
       :search-keyword="clientSearchKeyword"
       @update:search-keyword="clientSearchKeyword = $event"
@@ -346,11 +335,7 @@ function handleProductSelect(row) {
     <SearchModal
       :open="productSearchOpen"
       title="품목명 검색"
-      :columns="[
-        { key: 'name', label: '품목명' },
-        { key: 'country', label: '국가' },
-        { key: 'clientName', label: '거래처명' },
-      ]"
+      :columns="productSearchColumns"
       :rows="productRows"
       :search-keyword="productSearchKeyword"
       @update:search-keyword="productSearchKeyword = $event"

--- a/src/views/documents/PODetailPage.vue
+++ b/src/views/documents/PODetailPage.vue
@@ -10,11 +10,13 @@ import StatusBadge from '@/components/common/StatusBadge.vue'
 import DocumentPreviewModal from '@/components/domain/document/DocumentPreviewModal.vue'
 import PODocumentTemplate from '@/components/domain/document/PODocumentTemplate.vue'
 import POFormModal from '@/components/domain/document/POFormModal.vue'
+import { useSearchModalLookups } from '@/composables/useSearchModalLookups'
 import { useToast } from '@/composables/useToast'
 import { usePiDocuments } from '@/stores/piDocuments'
 import { usePoDocuments } from '@/stores/poDocuments'
 import { buildApprovalInfoRows } from '@/utils/documentApproval'
 import { openDocumentOutputByType } from '@/utils/documentOutput'
+import { clientSearchColumns } from '@/utils/searchModalColumns'
 
 const route = useRoute()
 const router = useRouter()
@@ -32,11 +34,7 @@ const selectedClient = ref(null)
 const piDocuments = usePiDocuments()
 const poDocuments = usePoDocuments()
 
-const clientRowsSource = [
-  { id: 'CL001', name: 'COOLSAY SDN BHD', country: '말레이시아' },
-  { id: 'CL002', name: 'TechBridge GmbH', country: '독일' },
-  { id: 'CL003', name: 'Pacific Trading Inc.', country: '미국' },
-]
+const { createClientRows } = useSearchModalLookups()
 
 const piRows = computed(() => {
   const keyword = piSearchKeyword.value.trim().toLowerCase()
@@ -44,11 +42,7 @@ const piRows = computed(() => {
   return piDocuments.value.filter((row) => [row.id, row.clientName, row.currency, row.deliveryDate].some((value) => String(value ?? '').toLowerCase().includes(keyword)))
 })
 
-const clientRows = computed(() => {
-  const keyword = clientSearchKeyword.value.trim().toLowerCase()
-  if (!keyword) return clientRowsSource
-  return clientRowsSource.filter((row) => [row.id, row.name, row.country].some((value) => String(value).toLowerCase().includes(keyword)))
-})
+const clientRows = createClientRows(clientSearchKeyword)
 
 function parseNumericValue(value) {
   const numeric = Number.parseFloat(String(value ?? '').replace(/[^0-9.]/g, ''))
@@ -456,11 +450,7 @@ function confirmDelete() {
     <SearchModal
       :open="clientSearchOpen"
       title="거래처 검색"
-      :columns="[
-        { key: 'id', label: '코드' },
-        { key: 'name', label: '거래처명' },
-        { key: 'country', label: '국가' },
-      ]"
+      :columns="clientSearchColumns"
       :rows="clientRows"
       :search-keyword="clientSearchKeyword"
       @update:search-keyword="clientSearchKeyword = $event"

--- a/src/views/documents/POPage.vue
+++ b/src/views/documents/POPage.vue
@@ -19,6 +19,7 @@ import TableActions from '@/components/common/TableActions.vue'
 import POFormModal from '@/components/domain/document/POFormModal.vue'
 import { useDocumentFilter } from '@/composables/useDocumentFilter'
 import { usePagination } from '@/composables/usePagination'
+import { useSearchModalLookups } from '@/composables/useSearchModalLookups'
 import { useAuthStore } from '@/stores/auth'
 import { usePiDocuments } from '@/stores/piDocuments'
 import { usePoDocuments } from '@/stores/poDocuments'
@@ -35,6 +36,7 @@ import {
   REGISTRATION_DOCUMENT_STATUS,
   REGISTRATION_REQUEST_STATUS,
 } from '@/utils/documentApproval'
+import { clientSearchColumns, productSearchColumns } from '@/utils/searchModalColumns'
 
 const router = useRouter()
 const authStore = useAuthStore()
@@ -84,11 +86,7 @@ const statusOptions = [
   { value: '취소', label: '취소' },
 ]
 const piRowsSource = usePiDocuments()
-const clientRowsSource = [
-  { id: 'CL001', name: 'COOLSAY SDN BHD', country: '말레이시아' },
-  { id: 'CL002', name: 'TechBridge GmbH', country: '독일' },
-  { id: 'CL003', name: 'Pacific Trading Inc.', country: '미국' },
-]
+const { clientRowsSource, createClientRows, createProductRows } = useSearchModalLookups()
 
 const columns = [
   { key: 'id', label: 'PO번호', align: 'center', width: '140px' },
@@ -132,11 +130,7 @@ const piRows = computed(() => {
   return piRowsSource.value.filter((row) => [row.id, row.clientName, row.currency, row.deliveryDate].some((value) => value.toLowerCase().includes(keyword)))
 })
 
-const clientRows = computed(() => {
-  const keyword = clientSearchKeyword.value.trim().toLowerCase()
-  if (!keyword) return clientRowsSource
-  return clientRowsSource.filter((row) => [row.id, row.name, row.country].some((value) => value.toLowerCase().includes(keyword)))
-})
+const clientRows = createClientRows(clientSearchKeyword)
 
 const codeRows = computed(() => {
   const keyword = codeSearchKeyword.value.trim().toLowerCase()
@@ -145,12 +139,7 @@ const codeRows = computed(() => {
   return rows.filter((row) => [row.id, row.issueDate, row.clientName].some((value) => String(value).toLowerCase().includes(keyword)))
 })
 
-const productRows = computed(() => {
-  const keyword = productSearchKeyword.value.trim().toLowerCase()
-  const rows = [...new Map(rowsData.value.map((row) => [row.itemName, { name: row.itemName, country: row.country, manager: row.manager }])).values()]
-  if (!keyword) return rows
-  return rows.filter((row) => [row.name, row.country, row.manager].some((value) => String(value).toLowerCase().includes(keyword)))
-})
+const productRows = createProductRows(productSearchKeyword)
 
 function openClientSearch(context = 'filter') {
   clientSearchContext.value = context
@@ -189,7 +178,7 @@ function closeForm() {
 
 function openEditForm(row) {
   selectedPi.value = piRowsSource.value.find((pi) => pi.id === (row.piId || row.linkedPiId || '')) ?? null
-  selectedClient.value = clientRowsSource.find((client) => client.name === row.clientName) ?? null
+  selectedClient.value = clientRowsSource.value.find((client) => client.name === row.clientName) ?? null
   formMode.value = 'edit'
   selectedRow.value = {
     id: row.id,
@@ -311,7 +300,7 @@ function getLinkedPiItems(linkedPi) {
 }
 
 function buildRowPayload(formValue) {
-  const matchedClient = clientRowsSource.find((client) => client.name === formValue.clientName)
+  const matchedClient = clientRowsSource.value.find((client) => client.name === formValue.clientName)
   const linkedPi = piRowsSource.value.find((pi) => pi.id === formValue.linkedPiId)
   const linkedItems = getLinkedPiItems(linkedPi)
   const totalAmount = linkedItems.reduce((sum, item) => sum + parseAmount(item.amount), 0)
@@ -980,11 +969,7 @@ function handleProductSelect(product) {
     <SearchModal
       :open="clientSearchOpen"
       title="거래처 검색"
-      :columns="[
-        { key: 'id', label: '코드' },
-        { key: 'name', label: '거래처명' },
-        { key: 'country', label: '국가' },
-      ]"
+      :columns="clientSearchColumns"
       :rows="clientRows"
       :search-keyword="clientSearchKeyword"
       @update:search-keyword="clientSearchKeyword = $event"
@@ -1010,11 +995,7 @@ function handleProductSelect(product) {
     <SearchModal
       :open="productSearchOpen"
       title="품목명 검색"
-      :columns="[
-        { key: 'name', label: '품목명' },
-        { key: 'country', label: '국가' },
-        { key: 'manager', label: '영업담당자' },
-      ]"
+      :columns="productSearchColumns"
       :rows="productRows"
       :search-keyword="productSearchKeyword"
       @update:search-keyword="productSearchKeyword = $event"

--- a/src/views/documents/ProductionOrderPage.vue
+++ b/src/views/documents/ProductionOrderPage.vue
@@ -18,8 +18,10 @@ import SearchableCombobox from '@/components/common/SearchableCombobox.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
 import { useDocumentFilter } from '@/composables/useDocumentFilter'
 import { usePagination } from '@/composables/usePagination'
+import { useSearchModalLookups } from '@/composables/useSearchModalLookups'
 import { useToast } from '@/composables/useToast'
 import { openDocumentOutputByType } from '@/utils/documentOutput'
+import { clientSearchColumns, productSearchColumns } from '@/utils/searchModalColumns'
 
 const router = useRouter()
 const isAdvancedOpen = ref(false)
@@ -102,18 +104,13 @@ const rowsData = ref([
   },
 ])
 
-const clientRowsSource = [
-  { id: 'CL001', name: 'COOLSAY SDN BHD', country: '말레이시아' },
-  { id: 'CL002', name: 'TechBridge GmbH', country: '독일' },
-  { id: 'CL003', name: 'Pacific Trading Inc.', country: '미국' },
-]
-
 const { filters, filteredRows, resetFilters, applyFilters } = useDocumentFilter(rowsData, {
   keywordFields: ['id', 'issueDate', 'poId', 'country', 'clientName', 'itemName', 'manager', 'status', 'dueDate'],
   issueDateField: 'issueDate',
   deliveryDateField: 'dueDate',
 })
 const { currentPage, totalPages, paginatedRows } = usePagination(filteredRows)
+const { createClientRows, createProductRows } = useSearchModalLookups()
 
 const previewFields = computed(() => {
   if (!previewTarget.value) {
@@ -132,11 +129,7 @@ const previewFields = computed(() => {
   ]
 })
 
-const clientRows = computed(() => {
-  const keyword = clientSearchKeyword.value.trim().toLowerCase()
-  if (!keyword) return clientRowsSource
-  return clientRowsSource.filter((row) => [row.id, row.name, row.country].some((value) => String(value).toLowerCase().includes(keyword)))
-})
+const clientRows = createClientRows(clientSearchKeyword)
 
 const codeRows = computed(() => {
   const keyword = codeSearchKeyword.value.trim().toLowerCase()
@@ -145,12 +138,7 @@ const codeRows = computed(() => {
   return source.filter((row) => [row.id, row.issueDate, row.clientName].some((value) => String(value).toLowerCase().includes(keyword)))
 })
 
-const productRows = computed(() => {
-  const keyword = productSearchKeyword.value.trim().toLowerCase()
-  const source = [...new Map(rowsData.value.map((row) => [row.itemName, { name: row.itemName, country: row.country, manager: row.manager }])).values()]
-  if (!keyword) return source
-  return source.filter((row) => [row.name, row.country, row.manager].some((value) => String(value).toLowerCase().includes(keyword)))
-})
+const productRows = createProductRows(productSearchKeyword)
 
 const currentOutputTarget = computed(() => previewTarget.value ?? paginatedRows.value[0] ?? null)
 
@@ -379,11 +367,7 @@ function downloadPdf(row) {
     <SearchModal
       :open="clientSearchOpen"
       title="거래처 검색"
-      :columns="[
-        { key: 'id', label: '코드' },
-        { key: 'name', label: '거래처명' },
-        { key: 'country', label: '국가' },
-      ]"
+      :columns="clientSearchColumns"
       :rows="clientRows"
       :search-keyword="clientSearchKeyword"
       @update:search-keyword="clientSearchKeyword = $event"
@@ -409,11 +393,7 @@ function downloadPdf(row) {
     <SearchModal
       :open="productSearchOpen"
       title="품목명 검색"
-      :columns="[
-        { key: 'name', label: '품목명' },
-        { key: 'country', label: '국가' },
-        { key: 'manager', label: '영업담당자' },
-      ]"
+      :columns="productSearchColumns"
       :rows="productRows"
       :search-keyword="productSearchKeyword"
       @update:search-keyword="productSearchKeyword = $event"

--- a/src/views/documents/ShipmentOrderPage.vue
+++ b/src/views/documents/ShipmentOrderPage.vue
@@ -18,8 +18,10 @@ import SearchableCombobox from '@/components/common/SearchableCombobox.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
 import { useDocumentFilter } from '@/composables/useDocumentFilter'
 import { usePagination } from '@/composables/usePagination'
+import { useSearchModalLookups } from '@/composables/useSearchModalLookups'
 import { useToast } from '@/composables/useToast'
 import { openDocumentOutputByType } from '@/utils/documentOutput'
+import { clientSearchColumns, productSearchColumns } from '@/utils/searchModalColumns'
 
 const router = useRouter()
 const isAdvancedOpen = ref(false)
@@ -101,18 +103,13 @@ const rowsData = ref([
   },
 ])
 
-const clientRowsSource = [
-  { id: 'CL001', name: 'COOLSAY SDN BHD', country: '말레이시아' },
-  { id: 'CL002', name: 'TechBridge GmbH', country: '독일' },
-  { id: 'CL003', name: 'Pacific Trading Inc.', country: '미국' },
-]
-
 const { filters, filteredRows, resetFilters, applyFilters } = useDocumentFilter(rowsData, {
   keywordFields: ['id', 'issueDate', 'poId', 'clientName', 'country', 'itemName', 'manager', 'status', 'dueDate'],
   issueDateField: 'issueDate',
   deliveryDateField: 'dueDate',
 })
 const { currentPage, totalPages, paginatedRows } = usePagination(filteredRows)
+const { createClientRows, createProductRows } = useSearchModalLookups()
 
 const previewFields = computed(() => {
   if (!previewTarget.value) {
@@ -131,11 +128,7 @@ const previewFields = computed(() => {
   ]
 })
 
-const clientRows = computed(() => {
-  const keyword = clientSearchKeyword.value.trim().toLowerCase()
-  if (!keyword) return clientRowsSource
-  return clientRowsSource.filter((row) => [row.id, row.name, row.country].some((value) => String(value).toLowerCase().includes(keyword)))
-})
+const clientRows = createClientRows(clientSearchKeyword)
 
 const codeRows = computed(() => {
   const keyword = codeSearchKeyword.value.trim().toLowerCase()
@@ -144,12 +137,7 @@ const codeRows = computed(() => {
   return source.filter((row) => [row.id, row.issueDate, row.clientName].some((value) => String(value).toLowerCase().includes(keyword)))
 })
 
-const productRows = computed(() => {
-  const keyword = productSearchKeyword.value.trim().toLowerCase()
-  const source = [...new Map(rowsData.value.map((row) => [row.itemName, { name: row.itemName, country: row.country, manager: row.manager }])).values()]
-  if (!keyword) return source
-  return source.filter((row) => [row.name, row.country, row.manager].some((value) => String(value).toLowerCase().includes(keyword)))
-})
+const productRows = createProductRows(productSearchKeyword)
 
 const currentOutputTarget = computed(() => previewTarget.value ?? paginatedRows.value[0] ?? null)
 
@@ -393,11 +381,7 @@ function downloadPdf(row) {
     <SearchModal
       :open="clientSearchOpen"
       title="거래처 검색"
-      :columns="[
-        { key: 'id', label: '코드' },
-        { key: 'name', label: '거래처명' },
-        { key: 'country', label: '국가' },
-      ]"
+      :columns="clientSearchColumns"
       :rows="clientRows"
       :search-keyword="clientSearchKeyword"
       @update:search-keyword="clientSearchKeyword = $event"
@@ -423,11 +407,7 @@ function downloadPdf(row) {
     <SearchModal
       :open="productSearchOpen"
       title="품목명 검색"
-      :columns="[
-        { key: 'name', label: '품목명' },
-        { key: 'country', label: '국가' },
-        { key: 'manager', label: '영업담당자' },
-      ]"
+      :columns="productSearchColumns"
       :rows="productRows"
       :search-keyword="productSearchKeyword"
       @update:search-keyword="productSearchKeyword = $event"

--- a/src/views/documents/ShipmentsPage.vue
+++ b/src/views/documents/ShipmentsPage.vue
@@ -17,6 +17,8 @@ import SearchableCombobox from '@/components/common/SearchableCombobox.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
 import { useDocumentFilter } from '@/composables/useDocumentFilter'
 import { usePagination } from '@/composables/usePagination'
+import { useSearchModalLookups } from '@/composables/useSearchModalLookups'
+import { clientSearchColumns } from '@/utils/searchModalColumns'
 
 const router = useRouter()
 const isAdvancedOpen = ref(false)
@@ -77,12 +79,6 @@ const rowsData = ref([
   },
 ])
 
-const clientRowsSource = [
-  { id: 'CL001', name: 'COOLSAY SDN BHD', country: '말레이시아' },
-  { id: 'CL002', name: 'Viet Steel JSC', country: '베트남' },
-  { id: 'CL003', name: 'Pacific Trading Inc.', country: '미국' },
-]
-
 const { filters, filteredRows, resetFilters, applyFilters } = useDocumentFilter(rowsData, {
   keywordFields: ['id', 'clientName', 'country', 'poId', 'requestDate', 'dueDate', 'status'],
   issueDateField: 'requestDate',
@@ -90,14 +86,11 @@ const { filters, filteredRows, resetFilters, applyFilters } = useDocumentFilter(
   codeField: 'id',
 })
 const { currentPage, totalPages, paginatedRows } = usePagination(filteredRows)
+const { createClientRows } = useSearchModalLookups()
 
 const preparingCount = computed(() => filteredRows.value.filter((row) => row.status === '출하준비').length)
 const completedCount = computed(() => filteredRows.value.filter((row) => row.status === '출하완료').length)
-const clientRows = computed(() => {
-  const keyword = clientSearchKeyword.value.trim().toLowerCase()
-  if (!keyword) return clientRowsSource
-  return clientRowsSource.filter((row) => [row.id, row.name, row.country].some((value) => String(value).toLowerCase().includes(keyword)))
-})
+const clientRows = createClientRows(clientSearchKeyword)
 
 const shipmentRows = computed(() => {
   const keyword = shipmentSearchKeyword.value.trim().toLowerCase()
@@ -271,11 +264,7 @@ function searchRows() {
     <SearchModal
       :open="clientSearchOpen"
       title="거래처 검색"
-      :columns="[
-        { key: 'id', label: '코드' },
-        { key: 'name', label: '거래처명' },
-        { key: 'country', label: '국가' },
-      ]"
+      :columns="clientSearchColumns"
       :rows="clientRows"
       :search-keyword="clientSearchKeyword"
       @update:search-keyword="clientSearchKeyword = $event"


### PR DESCRIPTION
## 📋 작업 내용

<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
  - 거래처 검색 모달과 품목 검색 모달의 표시 컬럼을 확장했습니다.
  - 공통 `SearchModal`이 컬럼별 폭, 정렬, 포맷을 받을 수 있도록 확장했습니다.
  - 거래처/품목 검색용 lookup 데이터를 공통 composable로 정리했습니다.
  - 문서 페이지 전반에서 같은 검색 모달 구조와 컬럼 정의를 재사용하도록 맞췄습니다.

## 🔗 관련 이슈

<!-- 관련 이슈 번호를 적어주세요 (자동으로 이슈가 닫힙니다) -->
- closes #135 

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->
# 품목명 검색 확장
<img width="2300" height="1554" alt="image" src="https://github.com/user-attachments/assets/d5a5b574-7535-4f09-8053-1e38163fc58e" />

# 거래처 검색 확장
<img width="2276" height="1546" alt="image" src="https://github.com/user-attachments/assets/25c36a8d-ff4c-4083-b28f-fd572c968e8f" />


## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

<!-- 리뷰할 때 중점적으로 봐줬으면 하는 부분이 있다면 적어주세요 -->
  - 이번 작업은 검색 모달의 선택 정확도를 높이는 데 초점을 맞췄습니다.
  - 기존에는 식별 정보만 보여주던 모달을 `db.json` 기준 상세 정보까지 함께 보이도록 확장했습니다.
  - 거래처/품목 검색 데이터와 컬럼 정의를 공통화해서 문서 페이지 간 표시 방식 차이를 줄였습니다.

