### PR TITLE
[refactor] 문서 상세 화면 레이아웃과 참조 문서 구조를 ERP식으로 개선

### DIFF
--- a/src/stores/shipmentOrderDocuments.js
+++ b/src/stores/shipmentOrderDocuments.js
@@ -1,0 +1,66 @@
+import { ref } from 'vue'
+
+function createInitialShipmentOrderDocuments() {
+  return [
+    {
+      id: 'SO2026001',
+      status: '출하완료',
+      issueDate: '2026/02/24',
+      poId: 'PO26001',
+      clientName: 'COOLSAY SDN BHD',
+      country: '말레이시아',
+      clientAddress: 'Lot 18, Jalan Pelabuhan Utara 27, 42000 Port Klang, Selangor, Malaysia',
+      itemName: 'H-Beam 482x300x11x15',
+      manager: '김영업',
+      dueDate: '2026/04/20',
+      requestedBy: '김영업',
+      plannedShipDate: '2026/04/18',
+      remarks: '포장 완료 후 부산항 반입 예정',
+      items: [
+        { name: 'H-Beam 482x300x11x15', quantity: '30', unit: 'EA', unitPrice: '$850', amount: '$25,500', remark: '포장 완료' },
+      ],
+    },
+    {
+      id: 'SO2026002',
+      status: '준비완료',
+      issueDate: '2026/03/03',
+      poId: 'PO26002',
+      clientName: 'TechBridge GmbH',
+      country: '독일',
+      clientAddress: 'Am Sandtorkai 35, 20457 Hamburg, Germany',
+      itemName: 'H-Beam 482x300x11x15',
+      manager: '김영업',
+      dueDate: '2026/05/25',
+      requestedBy: '김영업',
+      plannedShipDate: '2026/05/23',
+      remarks: '독일향 선적 서류 사전 점검 필요',
+      items: [
+        { name: 'H-Beam 482x300x11x15', quantity: '80', unit: 'EA', unitPrice: '€855', amount: '€68,400', remark: '서류 검토 대기' },
+      ],
+    },
+    {
+      id: 'SO2026003',
+      status: '준비완료',
+      issueDate: '2026/03/14',
+      poId: 'PO26003',
+      clientName: 'Pacific Trading Inc.',
+      country: '미국',
+      clientAddress: '1201 Harbor Avenue SW, Seattle, WA 98134, USA',
+      itemName: 'Lubricant Oil SAE 10W-40',
+      manager: '정영업',
+      dueDate: '2026/06/05',
+      requestedBy: '정영업',
+      plannedShipDate: '2026/06/02',
+      remarks: '수입국 라벨 부착 여부 최종 확인 필요',
+      items: [
+        { name: 'Lubricant Oil SAE 10W-40', quantity: '520', unit: 'EA', unitPrice: '$30', amount: '$15,600', remark: '라벨링 확인 필요' },
+      ],
+    },
+  ]
+}
+
+const shipmentOrderDocuments = ref(createInitialShipmentOrderDocuments())
+
+export function useShipmentOrderDocuments() {
+  return shipmentOrderDocuments
+}

--- a/src/stores/shipmentStatusDocuments.js
+++ b/src/stores/shipmentStatusDocuments.js
@@ -1,0 +1,60 @@
+import { ref } from 'vue'
+
+function createInitialShipmentStatusDocuments() {
+  return [
+    {
+      id: 'SH26001',
+      status: '출하준비',
+      clientName: 'COOLSAY SDN BHD',
+      poId: 'PO26001',
+      shipmentOrderId: 'SO2026001',
+      requestDate: '2026/03/26',
+      dueDate: '2026/04/05',
+      updatedAt: '2026/03/28 14:30',
+      manager: '김영업',
+      remarks: '출하 서류 검토 후 출하완료 처리 예정',
+      items: [
+        { name: 'H-Beam 482x300x11x15', quantity: '30 EA' },
+        { name: 'Lubricant Oil SAE 10W-40', quantity: '200 EA' },
+        { name: 'Industrial Grease EP-2', quantity: '100 EA' },
+        { name: 'Hydraulic Oil ISO VG 46', quantity: '32 EA' },
+      ],
+    },
+    {
+      id: 'SH26004',
+      status: '출하준비',
+      clientName: 'Viet Steel JSC',
+      poId: 'PO26004',
+      shipmentOrderId: 'SO2026002',
+      requestDate: '2026/03/29',
+      dueDate: '2026/04/30',
+      updatedAt: '2026/03/30 09:40',
+      manager: '정영업',
+      remarks: '독일향 선적 일정 확정 대기',
+      items: [
+        { name: 'H-Beam 482x300x11x15', quantity: '40 EA' },
+      ],
+    },
+    {
+      id: 'SH26005',
+      status: '출하완료',
+      clientName: 'Pacific Trading Inc.',
+      poId: 'PO26003',
+      shipmentOrderId: 'SO2026003',
+      requestDate: '2026/03/18',
+      dueDate: '2026/06/05',
+      updatedAt: '2026/03/31 18:10',
+      manager: '정영업',
+      remarks: '출하완료 및 후속 수출서류 전달 완료',
+      items: [
+        { name: 'Lubricant Oil SAE 10W-40', quantity: '520 EA' },
+      ],
+    },
+  ]
+}
+
+const shipmentStatusDocuments = ref(createInitialShipmentStatusDocuments())
+
+export function useShipmentStatusDocuments() {
+  return shipmentStatusDocuments
+}

--- a/src/views/documents/PIDetailPage.vue
+++ b/src/views/documents/PIDetailPage.vue
@@ -71,6 +71,22 @@ const previewFields = computed(() => {
   ]
 })
 
+const summaryRows = computed(() => {
+  if (!detail.value) return []
+
+  return [
+    { label: '거래처', value: detail.value.clientName },
+    { label: '영업담당자', value: detail.value.manager || '-' },
+    { label: '통화 / 총액', value: `${detail.value.currency} / ${detail.value.totalAmount}` },
+    { label: '납기일', value: detail.value.deliveryDate || '-' },
+  ]
+})
+
+const documentNote = computed(() => {
+  if (!detail.value) return '-'
+  return detail.value.remarks || '-'
+})
+
 const currencySymbolMap = {
   KRW: '₩',
   USD: '$',
@@ -334,10 +350,21 @@ function confirmDelete() {
       </DetailPageHeader>
     </div>
 
+    <div class="mb-6 grid grid-cols-1 overflow-hidden rounded-xl border border-slate-200 bg-white lg:grid-cols-4">
+      <div
+        v-for="row in summaryRows"
+        :key="row.label"
+        class="border-b border-slate-200 px-5 py-4 last:border-b-0 lg:border-b-0 lg:border-r lg:last:border-r-0"
+      >
+        <div class="text-xs font-semibold uppercase tracking-wider text-slate-500">{{ row.label }}</div>
+        <div class="mt-1 text-sm font-semibold text-slate-900">{{ row.value }}</div>
+      </div>
+    </div>
+
     <div class="grid grid-cols-1 gap-6 lg:grid-cols-3">
       <div class="space-y-4 lg:col-span-2">
         <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
-          <h3 class="mb-4 font-bold text-slate-800">기본 정보</h3>
+          <h3 class="mb-4 font-bold text-slate-800">문서 기본정보</h3>
           <div class="grid grid-cols-1 gap-4 text-sm sm:grid-cols-2">
             <div>
               <span class="text-slate-500">거래처</span>
@@ -348,8 +375,34 @@ function confirmDelete() {
               <div class="mt-0.5 break-words font-medium">{{ detail.buyer }}</div>
             </div>
             <div>
+              <span class="text-slate-500">영문주소</span>
+              <div class="mt-0.5 break-words">{{ detail.clientAddress || '-' }}</div>
+            </div>
+            <div>
+              <span class="text-slate-500">국가</span>
+              <div class="mt-0.5">{{ detail.country || '-' }}</div>
+            </div>
+            <div>
+              <span class="text-slate-500">발행일</span>
+              <div class="mt-0.5">{{ detail.issueDate }}</div>
+            </div>
+            <div>
+              <span class="text-slate-500">PI 번호</span>
+              <div class="mt-0.5 font-medium">{{ detail.id }}</div>
+            </div>
+          </div>
+        </div>
+
+        <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+          <h3 class="mb-4 font-bold text-slate-800">거래 조건 정보</h3>
+          <div class="grid grid-cols-1 gap-4 text-sm sm:grid-cols-2">
+            <div>
               <span class="text-slate-500">통화</span>
               <div class="mt-0.5">{{ detail.currency }}</div>
+            </div>
+            <div>
+              <span class="text-slate-500">총액</span>
+              <div class="mt-0.5 font-semibold text-slate-900">{{ detail.totalAmount }}</div>
             </div>
             <div>
               <span class="text-slate-500">인코텀즈</span>
@@ -359,49 +412,59 @@ function confirmDelete() {
               <span class="text-slate-500">납기일</span>
               <div class="mt-0.5">{{ detail.deliveryDate }}</div>
             </div>
-            <div>
-              <span class="text-slate-500">발행일</span>
-              <div class="mt-0.5">{{ detail.issueDate }}</div>
+            <div class="sm:col-span-2">
+              <span class="text-slate-500">Named Place</span>
+              <div class="mt-0.5">{{ detail.namedPlace || '-' }}</div>
             </div>
           </div>
         </div>
 
         <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
-          <h3 class="mb-4 font-bold text-slate-800">품목 목록</h3>
+          <h3 class="mb-4 font-bold text-slate-800">품목 내역</h3>
           <div class="overflow-x-auto">
-            <table class="w-full min-w-[620px] text-sm">
+            <table class="w-full min-w-[760px] text-sm">
               <thead class="bg-gray-50">
                 <tr>
                   <th class="p-3 text-left">품목</th>
+                  <th class="p-3 text-center">단위</th>
                   <th class="p-3 text-right">수량</th>
                   <th class="p-3 text-right">단가</th>
                   <th class="p-3 text-right">금액</th>
+                  <th class="p-3 text-left">비고</th>
                 </tr>
               </thead>
               <tbody class="divide-y">
                 <tr v-for="item in detail.items" :key="`${detail.id}-${item.name}`">
                   <td class="p-3">{{ item.name }}</td>
+                  <td class="p-3 text-center">{{ item.unit || '-' }}</td>
                   <td class="p-3 text-right">{{ item.quantity }}</td>
                   <td class="p-3 text-right">{{ item.unitPrice }}</td>
                   <td class="p-3 text-right font-semibold">{{ item.amount }}</td>
+                  <td class="p-3 text-slate-600">{{ item.remark || '-' }}</td>
                 </tr>
               </tbody>
               <tfoot>
                 <tr class="border-t border-slate-200">
-                  <td colspan="3" class="p-3 text-right text-xs font-bold uppercase tracking-wider text-slate-600">
+                  <td colspan="4" class="p-3 text-right text-xs font-bold uppercase tracking-wider text-slate-600">
                     합계
                   </td>
                   <td class="p-3 text-right text-base font-extrabold text-slate-900">{{ detail.totalAmount }}</td>
+                  <td></td>
                 </tr>
               </tfoot>
             </table>
           </div>
         </div>
+
+        <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+          <h3 class="mb-3 font-bold text-slate-800">비고</h3>
+          <p class="text-sm leading-6 text-slate-700">{{ documentNote }}</p>
+        </div>
       </div>
 
       <div class="space-y-4">
         <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
-          <h3 class="mb-3 font-bold text-slate-800">결재 상태</h3>
+          <h3 class="mb-3 font-bold text-slate-800">결재 정보</h3>
           <div v-if="approvalInfoRows.length" class="space-y-3 text-sm">
             <div
               v-for="row in approvalInfoRows"
@@ -422,7 +485,7 @@ function confirmDelete() {
         </div>
 
         <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
-          <h3 class="mb-3 font-bold text-slate-800">연결 문서</h3>
+          <h3 class="mb-3 font-bold text-slate-800">참조 문서</h3>
           <div class="space-y-2 text-sm">
             <template v-if="detail.linkedDocuments.length">
               <button
@@ -442,16 +505,11 @@ function confirmDelete() {
         </div>
 
         <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
-          <h3 class="mb-3 font-bold text-slate-800">담당자</h3>
-          <div class="text-sm">{{ detail.manager }}</div>
-        </div>
-
-        <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
           <div class="mb-3 flex items-center justify-between">
-            <h3 class="font-bold text-slate-800">수정 이력</h3>
+            <h3 class="font-bold text-slate-800">변경 이력</h3>
           </div>
           <div class="text-xs text-slate-400">
-            {{ detail.revisionHistory.length ? detail.revisionHistory.join(', ') : '수정 이력 없음' }}
+            {{ detail.revisionHistory.length ? detail.revisionHistory.join(', ') : '변경 이력 없음' }}
           </div>
         </div>
       </div>

--- a/src/views/documents/PODetailPage.vue
+++ b/src/views/documents/PODetailPage.vue
@@ -97,6 +97,7 @@ const detail = computed(() => normalizeDetail(
 ))
 
 const approvalInfoRows = computed(() => buildApprovalInfoRows(detail.value))
+const linkedPiDocument = computed(() => piDocuments.value.find((row) => row.id === (detail.value?.piId || detail.value?.linkedPiId)))
 
 const previewFields = computed(() => {
   if (!detail.value) return []
@@ -110,6 +111,19 @@ const previewFields = computed(() => {
     { label: '발행일', value: detail.value.issueDate },
   ]
 })
+
+const summaryRows = computed(() => {
+  if (!detail.value) return []
+
+  return [
+    { label: '거래처', value: detail.value.clientName },
+    { label: '영업담당자', value: detail.value.manager || '-' },
+    { label: '통화 / 총액', value: `${detail.value.currency} / ${detail.value.totalAmount}` },
+    { label: '납기일', value: detail.value.deliveryDate || '-' },
+  ]
+})
+
+const documentNote = computed(() => detail.value?.remarks || '-')
 
 function goBack() {
   router.push({ name: 'po' })
@@ -265,10 +279,21 @@ function confirmDelete() {
       </DetailPageHeader>
     </div>
 
+    <div class="mb-6 grid grid-cols-1 overflow-hidden rounded-xl border border-slate-200 bg-white lg:grid-cols-4">
+      <div
+        v-for="row in summaryRows"
+        :key="row.label"
+        class="border-b border-slate-200 px-5 py-4 last:border-b-0 lg:border-b-0 lg:border-r lg:last:border-r-0"
+      >
+        <div class="text-xs font-semibold uppercase tracking-wider text-slate-500">{{ row.label }}</div>
+        <div class="mt-1 text-sm font-semibold text-slate-900">{{ row.value }}</div>
+      </div>
+    </div>
+
     <div class="grid grid-cols-1 gap-6 lg:grid-cols-3">
       <div class="space-y-4 lg:col-span-2">
         <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
-          <h3 class="mb-4 font-bold text-slate-800">기본 정보</h3>
+          <h3 class="mb-4 font-bold text-slate-800">문서 기본정보</h3>
           <div class="grid grid-cols-1 gap-4 text-sm sm:grid-cols-2">
             <div>
               <span class="text-slate-500">거래처</span>
@@ -279,8 +304,34 @@ function confirmDelete() {
               <div class="mt-0.5 break-words font-medium">{{ detail.buyer }}</div>
             </div>
             <div>
+              <span class="text-slate-500">영문주소</span>
+              <div class="mt-0.5 break-words">{{ detail.clientAddress || '-' }}</div>
+            </div>
+            <div>
+              <span class="text-slate-500">국가</span>
+              <div class="mt-0.5">{{ detail.country || '-' }}</div>
+            </div>
+            <div>
+              <span class="text-slate-500">발행일</span>
+              <div class="mt-0.5">{{ detail.issueDate }}</div>
+            </div>
+            <div>
+              <span class="text-slate-500">PO 번호</span>
+              <div class="mt-0.5 font-medium">{{ detail.id }}</div>
+            </div>
+          </div>
+        </div>
+
+        <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+          <h3 class="mb-4 font-bold text-slate-800">거래 조건 정보</h3>
+          <div class="grid grid-cols-1 gap-4 text-sm sm:grid-cols-2">
+            <div>
               <span class="text-slate-500">통화</span>
               <div class="mt-0.5">{{ detail.currency }}</div>
+            </div>
+            <div>
+              <span class="text-slate-500">총액</span>
+              <div class="mt-0.5 font-semibold text-slate-900">{{ detail.totalAmount }}</div>
             </div>
             <div>
               <span class="text-slate-500">인코텀즈</span>
@@ -291,48 +342,62 @@ function confirmDelete() {
               <div class="mt-0.5">{{ detail.deliveryDate }}</div>
             </div>
             <div>
-              <span class="text-slate-500">발행일</span>
-              <div class="mt-0.5">{{ detail.issueDate }}</div>
+              <span class="text-slate-500">PI 기준 납기일</span>
+              <div class="mt-0.5">{{ detail.sourceDeliveryDate || linkedPiDocument?.deliveryDate || '-' }}</div>
+            </div>
+            <div>
+              <span class="text-slate-500">납기 처리</span>
+              <div class="mt-0.5">{{ detail.deliveryDateOverride ? 'PO 별도 조정' : 'PI 기준값 사용' }}</div>
             </div>
           </div>
         </div>
 
         <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
-          <h3 class="mb-4 font-bold text-slate-800">품목 목록</h3>
+          <h3 class="mb-4 font-bold text-slate-800">품목 내역</h3>
           <div class="overflow-x-auto">
-            <table class="w-full min-w-[620px] text-sm">
+            <table class="w-full min-w-[760px] text-sm">
               <thead class="bg-gray-50">
                 <tr>
                   <th class="p-3 text-left">품목</th>
+                  <th class="p-3 text-center">단위</th>
                   <th class="p-3 text-right">수량</th>
                   <th class="p-3 text-right">단가</th>
                   <th class="p-3 text-right">금액</th>
+                  <th class="p-3 text-left">비고</th>
                 </tr>
               </thead>
               <tbody class="divide-y">
                 <tr v-for="item in detail.items" :key="`${detail.id}-${item.name}`">
                   <td class="p-3">{{ item.name }}</td>
+                  <td class="p-3 text-center">{{ item.unit || '-' }}</td>
                   <td class="p-3 text-right">{{ item.quantity }}</td>
                   <td class="p-3 text-right">{{ item.unitPrice }}</td>
                   <td class="p-3 text-right font-semibold">{{ item.amount }}</td>
+                  <td class="p-3 text-slate-600">{{ item.remark || '-' }}</td>
                 </tr>
               </tbody>
               <tfoot>
                 <tr class="border-t border-slate-200">
-                  <td colspan="3" class="p-3 text-right text-xs font-bold uppercase tracking-wider text-slate-600">
+                  <td colspan="4" class="p-3 text-right text-xs font-bold uppercase tracking-wider text-slate-600">
                     합계
                   </td>
                   <td class="p-3 text-right text-base font-extrabold text-slate-900">{{ detail.totalAmount }}</td>
+                  <td></td>
                 </tr>
               </tfoot>
             </table>
           </div>
         </div>
+
+        <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+          <h3 class="mb-3 font-bold text-slate-800">비고</h3>
+          <p class="text-sm leading-6 text-slate-700">{{ documentNote }}</p>
+        </div>
       </div>
 
       <div class="space-y-4">
         <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
-          <h3 class="mb-3 font-bold text-slate-800">결재 상태</h3>
+          <h3 class="mb-3 font-bold text-slate-800">결재 정보</h3>
           <div v-if="approvalInfoRows.length" class="space-y-3 text-sm">
             <div
               v-for="row in approvalInfoRows"
@@ -353,7 +418,7 @@ function confirmDelete() {
         </div>
 
         <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
-          <h3 class="mb-3 font-bold text-slate-800">연결 문서</h3>
+          <h3 class="mb-3 font-bold text-slate-800">참조 문서</h3>
           <div class="space-y-2 text-sm">
             <button
               v-for="document in detail.linkedDocuments"
@@ -373,16 +438,11 @@ function confirmDelete() {
         </div>
 
         <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
-          <h3 class="mb-3 font-bold text-slate-800">담당자</h3>
-          <div class="text-sm">{{ detail.manager }}</div>
-        </div>
-
-        <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
           <div class="mb-3 flex items-center justify-between">
-            <h3 class="font-bold text-slate-800">수정 이력</h3>
+            <h3 class="font-bold text-slate-800">변경 이력</h3>
           </div>
           <div class="text-xs text-slate-400">
-            {{ detail.revisionHistory.length ? detail.revisionHistory.join(', ') : '수정 이력 없음' }}
+            {{ detail.revisionHistory.length ? detail.revisionHistory.join(', ') : '변경 이력 없음' }}
           </div>
         </div>
       </div>

--- a/src/views/documents/ProductionOrderDetailPage.vue
+++ b/src/views/documents/ProductionOrderDetailPage.vue
@@ -15,6 +15,18 @@ const toast = useToast()
 
 const previewOpen = ref(false)
 
+function parseNumericValue(value) {
+  const numeric = Number.parseFloat(String(value ?? '').replace(/[^0-9.]/g, ''))
+  return Number.isFinite(numeric) ? numeric : 0
+}
+
+function detectCurrencySymbol(value) {
+  const text = String(value ?? '')
+  if (text.includes('€')) return '€'
+  if (text.includes('¥')) return '¥'
+  return '$'
+}
+
 const detailMap = {
   MO2026001: {
     id: 'MO2026001',
@@ -23,11 +35,18 @@ const detailMap = {
     poId: 'PO26001',
     country: '말레이시아',
     clientName: 'COOLSAY SDN BHD',
+    clientAddress: 'Lot 18, Jalan Pelabuhan Utara 27, 42000 Port Klang, Selangor, Malaysia',
     itemName: 'H-Beam 482x300x11x15',
     manager: '김영업',
     dueDate: '2026/04/20',
+    department: '영업부',
+    productionSite: '부산 1공장',
+    requestedBy: '김영업',
+    completionTarget: '2026/04/18',
+    remarks: 'PO 기준 납기보다 2일 선행 생산 완료 요청',
+    linkedDocuments: [{ id: 'PO26001', status: '확정' }],
     items: [
-      { name: 'H-Beam 482x300x11x15', quantity: '30', unitPrice: '$850', amount: '$25,500' },
+      { name: 'H-Beam 482x300x11x15', quantity: '30', unit: 'EA', unitPrice: '$850', amount: '$25,500', remark: '절단 사양 확인 완료' },
     ],
   },
   MO2026002: {
@@ -37,11 +56,18 @@ const detailMap = {
     poId: 'PO26002',
     country: '독일',
     clientName: 'TechBridge GmbH',
+    clientAddress: 'Am Sandtorkai 35, 20457 Hamburg, Germany',
     itemName: 'H-Beam 482x300x11x15',
     manager: '김영업',
     dueDate: '2026/05/25',
+    department: '영업부',
+    productionSite: '포항 2공장',
+    requestedBy: '김영업',
+    completionTarget: '2026/05/22',
+    remarks: '도장 공정 포함, 출하 전 외관 검사 필요',
+    linkedDocuments: [{ id: 'PO26002', status: '발송' }],
     items: [
-      { name: 'H-Beam 482x300x11x15', quantity: '80', unitPrice: '€855', amount: '€68,400' },
+      { name: 'H-Beam 482x300x11x15', quantity: '80', unit: 'EA', unitPrice: '€855', amount: '€68,400', remark: '도장 공정 대기' },
     ],
   },
   MO2026003: {
@@ -51,16 +77,32 @@ const detailMap = {
     poId: 'PO26003',
     country: '미국',
     clientName: 'Pacific Trading Inc.',
+    clientAddress: '1201 Harbor Avenue SW, Seattle, WA 98134, USA',
     itemName: 'Lubricant Oil SAE 10W-40',
     manager: '정영업',
     dueDate: '2026/06/05',
+    department: '영업부',
+    productionSite: '울산 포장센터',
+    requestedBy: '정영업',
+    completionTarget: '2026/06/03',
+    remarks: '신규 거래처 첫 생산, 라벨링 시안 확인 필요',
+    linkedDocuments: [{ id: 'PO26003', status: '초안' }],
     items: [
-      { name: 'Lubricant Oil SAE 10W-40', quantity: '520', unitPrice: '$30', amount: '$15,600' },
+      { name: 'Lubricant Oil SAE 10W-40', quantity: '520', unit: 'EA', unitPrice: '$30', amount: '$15,600', remark: '라벨 확인 대기' },
     ],
   },
 }
 
 const detail = computed(() => detailMap[route.params.id] ?? null)
+const totalQuantity = computed(() => (
+  detail.value?.items.reduce((sum, item) => sum + Number.parseInt(item.quantity, 10), 0) ?? 0
+))
+const totalAmount = computed(() => {
+  if (!detail.value?.items.length) return '-'
+  const symbol = detectCurrencySymbol(detail.value.items[0].amount)
+  const amount = detail.value.items.reduce((sum, item) => sum + parseNumericValue(item.amount), 0)
+  return `${symbol}${amount.toLocaleString('en-US')}`
+})
 
 const previewFields = computed(() => {
   if (!detail.value) return []
@@ -75,6 +117,23 @@ const previewFields = computed(() => {
     { label: '납기일', value: detail.value.dueDate },
   ]
 })
+
+const summaryRows = computed(() => {
+  if (!detail.value) return []
+
+  return [
+    { label: '거래처', value: detail.value.clientName },
+    { label: '영업담당자', value: detail.value.manager || '-' },
+    { label: '총수량', value: `${totalQuantity.value} EA` },
+    { label: '납기일', value: detail.value.dueDate || '-' },
+  ]
+})
+
+function goToLinkedDocument(documentId) {
+  if (documentId?.startsWith('PO')) {
+    router.push({ name: 'po-detail', params: { id: documentId } })
+  }
+}
 
 function goBack() {
   router.push({ name: 'production' })
@@ -124,58 +183,103 @@ function handlePreviewPrint() {
       </DetailPageHeader>
     </div>
 
+    <div class="mb-6 grid grid-cols-1 overflow-hidden rounded-xl border border-slate-200 bg-white lg:grid-cols-4">
+      <div
+        v-for="row in summaryRows"
+        :key="row.label"
+        class="border-b border-slate-200 px-5 py-4 last:border-b-0 lg:border-b-0 lg:border-r lg:last:border-r-0"
+      >
+        <div class="text-xs font-semibold uppercase tracking-wider text-slate-500">{{ row.label }}</div>
+        <div class="mt-1 text-sm font-semibold text-slate-900">{{ row.value }}</div>
+      </div>
+    </div>
+
     <div class="grid grid-cols-1 gap-6 lg:grid-cols-3">
       <div class="space-y-4 lg:col-span-2">
         <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
-          <h3 class="mb-4 font-bold text-slate-800">기본 정보</h3>
+          <h3 class="mb-4 font-bold text-slate-800">문서 기본정보</h3>
           <div class="grid grid-cols-1 gap-4 text-sm sm:grid-cols-2">
             <div><span class="text-slate-500">생산지시일</span><div class="mt-0.5 font-medium">{{ detail.issueDate }}</div></div>
             <div><span class="text-slate-500">PO</span><div class="mt-0.5 font-medium">{{ detail.poId }}</div></div>
-            <div><span class="text-slate-500">국가</span><div class="mt-0.5">{{ detail.country }}</div></div>
+            <div><span class="text-slate-500">지시번호</span><div class="mt-0.5 font-medium">{{ detail.id }}</div></div>
             <div><span class="text-slate-500">거래처</span><div class="mt-0.5 font-medium">{{ detail.clientName }}</div></div>
+            <div><span class="text-slate-500">국가</span><div class="mt-0.5">{{ detail.country }}</div></div>
             <div><span class="text-slate-500">영업담당자</span><div class="mt-0.5">{{ detail.manager }}</div></div>
             <div><span class="text-slate-500">납기일</span><div class="mt-0.5">{{ detail.dueDate }}</div></div>
+            <div><span class="text-slate-500">완료 목표일</span><div class="mt-0.5">{{ detail.completionTarget }}</div></div>
+            <div class="sm:col-span-2"><span class="text-slate-500">영문주소</span><div class="mt-0.5 break-words">{{ detail.clientAddress }}</div></div>
           </div>
         </div>
 
         <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
-          <h3 class="mb-4 font-bold text-slate-800">품목 목록</h3>
+          <h3 class="mb-4 font-bold text-slate-800">지시 정보</h3>
+          <div class="grid grid-cols-1 gap-4 text-sm sm:grid-cols-2">
+            <div><span class="text-slate-500">부서</span><div class="mt-0.5">{{ detail.department }}</div></div>
+            <div><span class="text-slate-500">생산 거점</span><div class="mt-0.5">{{ detail.productionSite }}</div></div>
+            <div><span class="text-slate-500">요청자</span><div class="mt-0.5">{{ detail.requestedBy }}</div></div>
+            <div><span class="text-slate-500">상태</span><div class="mt-0.5">{{ detail.status }}</div></div>
+          </div>
+        </div>
+
+        <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+          <h3 class="mb-4 font-bold text-slate-800">품목 내역</h3>
           <div class="overflow-x-auto">
-            <table class="w-full min-w-[620px] text-sm">
+            <table class="w-full min-w-[760px] text-sm">
               <thead class="bg-gray-50">
                 <tr>
                   <th class="p-3 text-left">품목</th>
+                  <th class="p-3 text-center">단위</th>
                   <th class="p-3 text-right">수량</th>
                   <th class="p-3 text-right">단가</th>
                   <th class="p-3 text-right">금액</th>
+                  <th class="p-3 text-left">비고</th>
                 </tr>
               </thead>
               <tbody class="divide-y">
                 <tr v-for="item in detail.items" :key="`${detail.id}-${item.name}`">
                   <td class="p-3">{{ item.name }}</td>
+                  <td class="p-3 text-center">{{ item.unit || '-' }}</td>
                   <td class="p-3 text-right">{{ item.quantity }}</td>
                   <td class="p-3 text-right">{{ item.unitPrice }}</td>
                   <td class="p-3 text-right font-semibold">{{ item.amount }}</td>
+                  <td class="p-3 text-slate-600">{{ item.remark || '-' }}</td>
                 </tr>
               </tbody>
+              <tfoot>
+                <tr class="border-t border-slate-200">
+                  <td colspan="3" class="p-3 text-right text-xs font-bold uppercase tracking-wider text-slate-600">총수량</td>
+                  <td class="p-3 text-right font-semibold text-slate-900">{{ totalQuantity }} EA</td>
+                  <td class="p-3 text-right text-base font-extrabold text-slate-900">{{ totalAmount }}</td>
+                  <td></td>
+                </tr>
+              </tfoot>
             </table>
           </div>
+        </div>
+
+        <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+          <h3 class="mb-3 font-bold text-slate-800">비고</h3>
+          <p class="text-sm leading-6 text-slate-700">{{ detail.remarks || '-' }}</p>
         </div>
       </div>
 
       <div class="space-y-4">
         <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
-          <h3 class="mb-3 font-bold text-slate-800">연결 문서</h3>
-          <a href="#" class="flex items-center gap-2 rounded-lg p-2.5 text-brand-500 transition hover:bg-slate-50" @click.prevent>
-            <i class="fas fa-file-contract" aria-hidden="true"></i>
-            {{ detail.poId }}
-          </a>
+          <h3 class="mb-3 font-bold text-slate-800">참조 문서</h3>
+          <div class="space-y-2 text-sm">
+            <button
+              v-for="document in detail.linkedDocuments"
+              :key="document.id"
+              type="button"
+              class="flex items-center gap-2 rounded-lg p-2.5 text-brand-500 transition hover:bg-slate-50"
+              @click="goToLinkedDocument(document.id)"
+            >
+              <i class="fas fa-file-contract" aria-hidden="true"></i>
+              {{ document.id }}
+            </button>
+          </div>
         </div>
 
-        <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
-          <h3 class="mb-3 font-bold text-slate-800">담당자</h3>
-          <div class="text-sm">{{ detail.manager }}</div>
-        </div>
       </div>
     </div>
 

--- a/src/views/documents/ShipmentOrderDetailPage.vue
+++ b/src/views/documents/ShipmentOrderDetailPage.vue
@@ -4,63 +4,75 @@ import { useRoute, useRouter } from 'vue-router'
 
 import BaseButton from '@/components/common/BaseButton.vue'
 import DetailPageHeader from '@/components/common/DetailPageHeader.vue'
+import StatusBadge from '@/components/common/StatusBadge.vue'
 import DocumentPreviewModal from '@/components/domain/document/DocumentPreviewModal.vue'
 import ShipmentOrderTemplate from '@/components/domain/document/ShipmentOrderTemplate.vue'
+import { usePoDocuments } from '@/stores/poDocuments'
+import { useShipmentOrderDocuments } from '@/stores/shipmentOrderDocuments'
+import { useShipmentStatusDocuments } from '@/stores/shipmentStatusDocuments'
 import { useToast } from '@/composables/useToast'
 import { openDocumentOutputByType } from '@/utils/documentOutput'
 
 const route = useRoute()
 const router = useRouter()
 const toast = useToast()
+const poDocuments = usePoDocuments()
+const shipmentOrderDocuments = useShipmentOrderDocuments()
+const shipmentStatusDocuments = useShipmentStatusDocuments()
 
 const previewOpen = ref(false)
 
-const detailMap = {
-  SO2026001: {
-    id: 'SO2026001',
-    status: '출하완료',
-    issueDate: '2026/02/24',
-    poId: 'PO26001',
-    clientName: 'COOLSAY SDN BHD',
-    country: '말레이시아',
-    itemName: 'H-Beam 482x300x11x15',
-    manager: '김영업',
-    dueDate: '2026/04/20',
-    items: [
-      { name: 'H-Beam 482x300x11x15', quantity: '30', unitPrice: '$850', amount: '$25,500' },
-    ],
-  },
-  SO2026002: {
-    id: 'SO2026002',
-    status: '준비완료',
-    issueDate: '2026/03/03',
-    poId: 'PO26002',
-    clientName: 'TechBridge GmbH',
-    country: '독일',
-    itemName: 'H-Beam 482x300x11x15',
-    manager: '김영업',
-    dueDate: '2026/05/25',
-    items: [
-      { name: 'H-Beam 482x300x11x15', quantity: '80', unitPrice: '€855', amount: '€68,400' },
-    ],
-  },
-  SO2026003: {
-    id: 'SO2026003',
-    status: '준비완료',
-    issueDate: '2026/03/14',
-    poId: 'PO26003',
-    clientName: 'Pacific Trading Inc.',
-    country: '미국',
-    itemName: 'Lubricant Oil SAE 10W-40',
-    manager: '정영업',
-    dueDate: '2026/06/05',
-    items: [
-      { name: 'Lubricant Oil SAE 10W-40', quantity: '520', unitPrice: '$30', amount: '$15,600' },
-    ],
-  },
+function parseNumericValue(value) {
+  const numeric = Number.parseFloat(String(value ?? '').replace(/[^0-9.]/g, ''))
+  return Number.isFinite(numeric) ? numeric : 0
 }
 
-const detail = computed(() => detailMap[route.params.id] ?? null)
+function detectCurrencySymbol(value) {
+  const text = String(value ?? '')
+  if (text.includes('€')) return '€'
+  if (text.includes('¥')) return '¥'
+  return '$'
+}
+
+const detail = computed(() => shipmentOrderDocuments.value.find((row) => row.id === route.params.id) ?? null)
+const linkedDocuments = computed(() => {
+  if (!detail.value) return []
+
+  const linkedPo = poDocuments.value.find((row) => row.id === detail.value.poId)
+  const linkedShipmentStatus = shipmentStatusDocuments.value.find((row) => row.shipmentOrderId === detail.value.id)
+  const rows = []
+
+  if (linkedPo) {
+    rows.push({
+      id: linkedPo.id,
+      label: `PO: ${linkedPo.id}`,
+      routeName: 'po-detail',
+      iconClass: 'fas fa-file-contract',
+      status: linkedPo.status,
+    })
+  }
+
+  if (linkedShipmentStatus) {
+    rows.push({
+      id: linkedShipmentStatus.id,
+      label: `출하현황: ${linkedShipmentStatus.id}`,
+      routeName: 'shipment-detail',
+      iconClass: 'fas fa-truck',
+      status: linkedShipmentStatus.status,
+    })
+  }
+
+  return rows
+})
+const totalQuantity = computed(() => (
+  detail.value?.items.reduce((sum, item) => sum + Number.parseInt(item.quantity, 10), 0) ?? 0
+))
+const totalAmount = computed(() => {
+  if (!detail.value?.items.length) return '-'
+  const symbol = detectCurrencySymbol(detail.value.items[0].amount)
+  const amount = detail.value.items.reduce((sum, item) => sum + parseNumericValue(item.amount), 0)
+  return `${symbol}${amount.toLocaleString('en-US')}`
+})
 
 const previewFields = computed(() => {
   if (!detail.value) return []
@@ -75,6 +87,22 @@ const previewFields = computed(() => {
     { label: '납기일', value: detail.value.dueDate },
   ]
 })
+
+const summaryRows = computed(() => {
+  if (!detail.value) return []
+
+  return [
+    { label: '거래처', value: detail.value.clientName },
+    { label: '영업담당자', value: detail.value.manager || '-' },
+    { label: '총수량', value: `${totalQuantity.value} EA` },
+    { label: '납기일', value: detail.value.dueDate || '-' },
+  ]
+})
+
+function goToLinkedDocument(document) {
+  if (!document?.routeName || !document?.id) return
+  router.push({ name: document.routeName, params: { id: document.id } })
+}
 
 function goBack() {
   router.push({ name: 'shipment-orders' })
@@ -124,10 +152,21 @@ function handlePreviewPrint() {
       </DetailPageHeader>
     </div>
 
+    <div class="mb-6 grid grid-cols-1 overflow-hidden rounded-xl border border-slate-200 bg-white lg:grid-cols-4">
+      <div
+        v-for="row in summaryRows"
+        :key="row.label"
+        class="border-b border-slate-200 px-5 py-4 last:border-b-0 lg:border-b-0 lg:border-r lg:last:border-r-0"
+      >
+        <div class="text-xs font-semibold uppercase tracking-wider text-slate-500">{{ row.label }}</div>
+        <div class="mt-1 text-sm font-semibold text-slate-900">{{ row.value }}</div>
+      </div>
+    </div>
+
     <div class="grid grid-cols-1 gap-6 lg:grid-cols-3">
       <div class="space-y-4 lg:col-span-2">
         <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
-          <h3 class="mb-4 font-bold text-slate-800">기본 정보</h3>
+          <h3 class="mb-4 font-bold text-slate-800">문서 기본정보</h3>
           <div class="grid grid-cols-1 gap-4 text-sm sm:grid-cols-2">
             <div><span class="text-slate-500">출하지시일</span><div class="mt-0.5 font-medium">{{ detail.issueDate }}</div></div>
             <div><span class="text-slate-500">PO</span><div class="mt-0.5 font-medium">{{ detail.poId }}</div></div>
@@ -135,47 +174,82 @@ function handlePreviewPrint() {
             <div><span class="text-slate-500">국가</span><div class="mt-0.5">{{ detail.country }}</div></div>
             <div><span class="text-slate-500">영업담당자</span><div class="mt-0.5">{{ detail.manager }}</div></div>
             <div><span class="text-slate-500">납기일</span><div class="mt-0.5">{{ detail.dueDate }}</div></div>
+            <div><span class="text-slate-500">출하지시번호</span><div class="mt-0.5 font-medium">{{ detail.id }}</div></div>
+            <div><span class="text-slate-500">출하 예정일</span><div class="mt-0.5">{{ detail.plannedShipDate }}</div></div>
+            <div class="sm:col-span-2"><span class="text-slate-500">영문주소</span><div class="mt-0.5 break-words">{{ detail.clientAddress }}</div></div>
           </div>
         </div>
 
         <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
-          <h3 class="mb-4 font-bold text-slate-800">품목 목록</h3>
+          <h3 class="mb-4 font-bold text-slate-800">출하 요청 정보</h3>
+          <div class="grid grid-cols-1 gap-4 text-sm sm:grid-cols-2">
+            <div><span class="text-slate-500">요청자</span><div class="mt-0.5">{{ detail.requestedBy }}</div></div>
+            <div><span class="text-slate-500">출하 예정일</span><div class="mt-0.5">{{ detail.plannedShipDate }}</div></div>
+            <div><span class="text-slate-500">상태</span><div class="mt-0.5">{{ detail.status }}</div></div>
+            <div><span class="text-slate-500">비고 요약</span><div class="mt-0.5">{{ detail.remarks || '-' }}</div></div>
+          </div>
+        </div>
+
+        <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+          <h3 class="mb-4 font-bold text-slate-800">품목 내역</h3>
           <div class="overflow-x-auto">
-            <table class="w-full min-w-[620px] text-sm">
+            <table class="w-full min-w-[760px] text-sm">
               <thead class="bg-gray-50">
                 <tr>
                   <th class="p-3 text-left">품목</th>
+                  <th class="p-3 text-center">단위</th>
                   <th class="p-3 text-right">수량</th>
                   <th class="p-3 text-right">단가</th>
                   <th class="p-3 text-right">금액</th>
+                  <th class="p-3 text-left">비고</th>
                 </tr>
               </thead>
               <tbody class="divide-y">
                 <tr v-for="item in detail.items" :key="`${detail.id}-${item.name}`">
                   <td class="p-3">{{ item.name }}</td>
+                  <td class="p-3 text-center">{{ item.unit || '-' }}</td>
                   <td class="p-3 text-right">{{ item.quantity }}</td>
                   <td class="p-3 text-right">{{ item.unitPrice }}</td>
                   <td class="p-3 text-right font-semibold">{{ item.amount }}</td>
+                  <td class="p-3 text-slate-600">{{ item.remark || '-' }}</td>
                 </tr>
               </tbody>
+              <tfoot>
+                <tr class="border-t border-slate-200">
+                  <td colspan="3" class="p-3 text-right text-xs font-bold uppercase tracking-wider text-slate-600">총수량</td>
+                  <td class="p-3 text-right font-semibold text-slate-900">{{ totalQuantity }} EA</td>
+                  <td class="p-3 text-right text-base font-extrabold text-slate-900">{{ totalAmount }}</td>
+                  <td></td>
+                </tr>
+              </tfoot>
             </table>
           </div>
+        </div>
+
+        <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+          <h3 class="mb-3 font-bold text-slate-800">비고</h3>
+          <p class="text-sm leading-6 text-slate-700">{{ detail.remarks || '-' }}</p>
         </div>
       </div>
 
       <div class="space-y-4">
         <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
-          <h3 class="mb-3 font-bold text-slate-800">연결 문서</h3>
-          <a href="#" class="flex items-center gap-2 rounded-lg p-2.5 text-brand-500 transition hover:bg-slate-50" @click.prevent>
-            <i class="fas fa-file-contract" aria-hidden="true"></i>
-            {{ detail.poId }}
-          </a>
+          <h3 class="mb-3 font-bold text-slate-800">참조 문서</h3>
+          <div class="space-y-2 text-sm">
+            <button
+              v-for="document in linkedDocuments"
+              :key="document.id"
+              type="button"
+              class="flex items-center gap-2 rounded-lg p-2.5 text-brand-500 transition hover:bg-slate-50"
+              @click="goToLinkedDocument(document)"
+            >
+              <i :class="document.iconClass" aria-hidden="true"></i>
+              {{ document.label }}
+              <StatusBadge :value="document.status" />
+            </button>
+          </div>
         </div>
 
-        <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
-          <h3 class="mb-3 font-bold text-slate-800">담당자</h3>
-          <div class="text-sm">{{ detail.manager }}</div>
-        </div>
       </div>
     </div>
 

--- a/src/views/documents/ShipmentOrderPage.vue
+++ b/src/views/documents/ShipmentOrderPage.vue
@@ -19,6 +19,7 @@ import StatusBadge from '@/components/common/StatusBadge.vue'
 import { useDocumentFilter } from '@/composables/useDocumentFilter'
 import { usePagination } from '@/composables/usePagination'
 import { useSearchModalLookups } from '@/composables/useSearchModalLookups'
+import { useShipmentOrderDocuments } from '@/stores/shipmentOrderDocuments'
 import { useToast } from '@/composables/useToast'
 import { openDocumentOutputByType } from '@/utils/documentOutput'
 import { clientSearchColumns, productSearchColumns } from '@/utils/searchModalColumns'
@@ -67,41 +68,7 @@ const columns = [
   { key: 'actions', label: '', align: 'center', width: '120px' },
 ]
 
-const rowsData = ref([
-  {
-    id: 'SO2026001',
-    issueDate: '2026/02/24',
-    poId: 'PO26001',
-    clientName: 'COOLSAY SDN BHD',
-    country: '말레이시아',
-    itemName: 'H-Beam 482x300x11x15',
-    manager: '김영업',
-    status: '출하완료',
-    dueDate: '2026/04/20',
-  },
-  {
-    id: 'SO2026002',
-    issueDate: '2026/03/03',
-    poId: 'PO26002',
-    clientName: 'TechBridge GmbH',
-    country: '독일',
-    itemName: 'H-Beam 482x300x11x15',
-    manager: '김영업',
-    status: '준비완료',
-    dueDate: '2026/05/25',
-  },
-  {
-    id: 'SO2026003',
-    issueDate: '2026/03/14',
-    poId: 'PO26003',
-    clientName: 'Pacific Trading Inc.',
-    country: '미국',
-    itemName: 'Lubricant Oil SAE 10W-40',
-    manager: '정영업',
-    status: '준비완료',
-    dueDate: '2026/06/05',
-  },
-])
+const rowsData = useShipmentOrderDocuments()
 
 const { filters, filteredRows, resetFilters, applyFilters } = useDocumentFilter(rowsData, {
   keywordFields: ['id', 'issueDate', 'poId', 'clientName', 'country', 'itemName', 'manager', 'status', 'dueDate'],

--- a/src/views/documents/ShipmentsDetailPage.vue
+++ b/src/views/documents/ShipmentsDetailPage.vue
@@ -4,64 +4,33 @@ import { useRoute, useRouter } from 'vue-router'
 
 import BaseButton from '@/components/common/BaseButton.vue'
 import DetailPageHeader from '@/components/common/DetailPageHeader.vue'
+import StatusBadge from '@/components/common/StatusBadge.vue'
+import { usePoDocuments } from '@/stores/poDocuments'
+import { useShipmentOrderDocuments } from '@/stores/shipmentOrderDocuments'
+import { useShipmentStatusDocuments } from '@/stores/shipmentStatusDocuments'
 import { useToast } from '@/composables/useToast'
 
 const route = useRoute()
 const router = useRouter()
 const toast = useToast()
-
-const detailMap = {
-  SH26001: {
-    id: 'SH26001',
-    status: '출하준비',
-    clientName: 'COOLSAY SDN BHD',
-    poId: 'PO26001',
-    shipmentOrderId: 'SO2026001',
-    requestDate: '2026/03/26',
-    dueDate: '2026/04/05',
-    updatedAt: '2026/03/28 14:30',
-    items: [
-      { name: 'H-Beam 482x300x11x15', quantity: '30 EA' },
-      { name: 'Lubricant Oil SAE 10W-40', quantity: '200 EA' },
-      { name: 'Industrial Grease EP-2', quantity: '100 EA' },
-      { name: 'Hydraulic Oil ISO VG 46', quantity: '32 EA' },
-    ],
-  },
-  SH26004: {
-    id: 'SH26004',
-    status: '출하준비',
-    clientName: 'Viet Steel JSC',
-    poId: 'PO26004',
-    shipmentOrderId: 'SO2026002',
-    requestDate: '2026/03/29',
-    dueDate: '2026/04/30',
-    updatedAt: '2026/03/30 09:40',
-    items: [
-      { name: 'H-Beam 482x300x11x15', quantity: '40 EA' },
-    ],
-  },
-  SH26005: {
-    id: 'SH26005',
-    status: '출하완료',
-    clientName: 'Pacific Trading Inc.',
-    poId: 'PO26003',
-    shipmentOrderId: 'SO2026003',
-    requestDate: '2026/03/18',
-    dueDate: '2026/06/05',
-    updatedAt: '2026/03/31 18:10',
-    items: [
-      { name: 'Lubricant Oil SAE 10W-40', quantity: '520 EA' },
-    ],
-  },
-}
-
-const detail = ref(
-  detailMap[route.params.id]
-    ? { ...detailMap[route.params.id], items: [...detailMap[route.params.id].items] }
-    : null,
-)
+const poDocuments = usePoDocuments()
+const shipmentOrderDocuments = useShipmentOrderDocuments()
+const shipmentStatusDocuments = useShipmentStatusDocuments()
+const detail = computed(() => shipmentStatusDocuments.value.find((row) => row.id === route.params.id) ?? null)
+const linkedPo = computed(() => poDocuments.value.find((row) => row.id === detail.value?.poId))
+const linkedShipmentOrder = computed(() => shipmentOrderDocuments.value.find((row) => row.id === detail.value?.shipmentOrderId))
 
 const currentStep = computed(() => (detail.value?.status === '출하완료' ? 2 : 1))
+const summaryRows = computed(() => {
+  if (!detail.value) return []
+
+  return [
+    { label: '거래처', value: detail.value.clientName },
+    { label: '영업담당자', value: detail.value.manager || '-' },
+    { label: '품목 건수', value: `${detail.value.items.length}건` },
+    { label: '납기일', value: detail.value.dueDate || '-' },
+  ]
+})
 
 function goBack() {
   router.push({ name: 'shipments' })
@@ -77,8 +46,11 @@ function goToShipmentOrder() {
 
 function completeShipment() {
   if (!detail.value || detail.value.status === '출하완료') return
-  detail.value.status = '출하완료'
-  detail.value.updatedAt = '2026/03/31 10:00'
+  shipmentStatusDocuments.value = shipmentStatusDocuments.value.map((row) => (
+    row.id === detail.value.id
+      ? { ...row, status: '출하완료', updatedAt: '2026/03/31 10:00' }
+      : row
+  ))
   toast.success(`${detail.value.id}가 출하완료 처리되었습니다.`)
 }
 </script>
@@ -102,10 +74,21 @@ function completeShipment() {
       </DetailPageHeader>
     </div>
 
+    <div class="mb-6 grid grid-cols-1 overflow-hidden rounded-xl border border-slate-200 bg-white lg:grid-cols-4">
+      <div
+        v-for="row in summaryRows"
+        :key="row.label"
+        class="border-b border-slate-200 px-5 py-4 last:border-b-0 lg:border-b-0 lg:border-r lg:last:border-r-0"
+      >
+        <div class="text-xs font-semibold uppercase tracking-wider text-slate-500">{{ row.label }}</div>
+        <div class="mt-1 text-sm font-semibold text-slate-900">{{ row.value }}</div>
+      </div>
+    </div>
+
     <div class="grid grid-cols-1 gap-6 lg:grid-cols-3">
       <div class="space-y-4 lg:col-span-2">
         <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
-          <h3 class="mb-4 font-bold text-slate-800">출하 정보</h3>
+          <h3 class="mb-4 font-bold text-slate-800">문서 기본정보</h3>
           <div class="grid grid-cols-1 gap-4 text-sm sm:grid-cols-2">
             <div><span class="text-slate-500">출하번호</span><div class="mt-0.5 font-mono font-medium">{{ detail.id }}</div></div>
             <div><span class="text-slate-500">거래처</span><div class="mt-0.5 font-medium">{{ detail.clientName }}</div></div>
@@ -118,12 +101,13 @@ function completeShipment() {
             <div><span class="text-slate-500">출하지시서</span><div class="mt-0.5">{{ detail.shipmentOrderId }}</div></div>
             <div><span class="text-slate-500">출하요청일</span><div class="mt-0.5 font-medium">{{ detail.requestDate }}</div></div>
             <div><span class="text-slate-500">납기일</span><div class="mt-0.5 font-medium">{{ detail.dueDate }}</div></div>
+            <div><span class="text-slate-500">영업담당자</span><div class="mt-0.5">{{ detail.manager || '-' }}</div></div>
             <div><span class="text-slate-500">최종 업데이트</span><div class="mt-0.5 text-xs text-slate-400">{{ detail.updatedAt }}</div></div>
           </div>
         </div>
 
         <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
-          <h3 class="mb-4 font-bold text-slate-800">진행 단계</h3>
+          <h3 class="mb-4 font-bold text-slate-800">처리 상태</h3>
           <div class="flex items-center justify-center py-4">
             <div class="flex items-center gap-0.5">
               <div class="flex h-9 w-9 items-center justify-center rounded-full text-sm font-bold" :class="currentStep >= 1 ? 'bg-slate-500 text-white' : 'bg-slate-200 text-slate-400'">1</div>
@@ -137,25 +121,32 @@ function completeShipment() {
             출하팀 담당자 또는 관리자가 출하 상태를 변경할 수 있습니다.
           </div>
         </div>
+
+        <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+          <h3 class="mb-3 font-bold text-slate-800">비고</h3>
+          <p class="text-sm leading-6 text-slate-700">{{ detail.remarks || '-' }}</p>
+        </div>
       </div>
 
       <div class="space-y-4">
         <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
-          <h3 class="mb-3 font-bold text-slate-800">연결 문서</h3>
+          <h3 class="mb-3 font-bold text-slate-800">참조 문서</h3>
           <div class="space-y-2 text-sm">
             <button type="button" class="flex w-full items-center gap-2 rounded-lg p-2.5 text-left text-brand-500 transition hover:bg-slate-50" @click="goToPo">
               <i class="fas fa-file-contract" aria-hidden="true"></i>
               PO: {{ detail.poId }}
+              <StatusBadge v-if="linkedPo" :value="linkedPo.status" />
             </button>
             <button type="button" class="flex w-full cursor-pointer items-center gap-2 rounded-lg bg-slate-50 p-2.5 text-left text-slate-600 transition hover:bg-slate-100" @click="goToShipmentOrder">
               <i class="fas fa-truck" aria-hidden="true"></i>
               출하지시서: {{ detail.shipmentOrderId }}
+              <StatusBadge v-if="linkedShipmentOrder" :value="linkedShipmentOrder.status" />
             </button>
           </div>
         </div>
 
         <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
-          <h3 class="mb-3 font-bold text-slate-800">PO 품목</h3>
+          <h3 class="mb-3 font-bold text-slate-800">품목 내역</h3>
           <div class="space-y-2 text-xs">
             <div v-for="item in detail.items" :key="item.name" class="flex justify-between rounded bg-slate-50 p-2">
               <span>{{ item.name }}</span>

--- a/src/views/documents/ShipmentsPage.vue
+++ b/src/views/documents/ShipmentsPage.vue
@@ -18,6 +18,7 @@ import StatusBadge from '@/components/common/StatusBadge.vue'
 import { useDocumentFilter } from '@/composables/useDocumentFilter'
 import { usePagination } from '@/composables/usePagination'
 import { useSearchModalLookups } from '@/composables/useSearchModalLookups'
+import { useShipmentStatusDocuments } from '@/stores/shipmentStatusDocuments'
 import { clientSearchColumns } from '@/utils/searchModalColumns'
 
 const router = useRouter()
@@ -49,35 +50,7 @@ const columns = [
   { key: 'status', label: '상태', align: 'center', width: '120px' },
 ]
 
-const rowsData = ref([
-  {
-    id: 'SH26001',
-    clientName: 'COOLSAY SDN BHD',
-    country: '말레이시아',
-    poId: 'PO26001',
-    requestDate: '2026/03/26',
-    dueDate: '2026/04/05',
-    status: '출하준비',
-  },
-  {
-    id: 'SH26004',
-    clientName: 'Viet Steel JSC',
-    country: '베트남',
-    poId: 'PO26004',
-    requestDate: '2026/03/12',
-    dueDate: '2026/04/30',
-    status: '출하준비',
-  },
-  {
-    id: 'SH26005',
-    clientName: 'Pacific Trading Inc.',
-    country: '미국',
-    poId: 'PO26003',
-    requestDate: '2026/03/18',
-    dueDate: '2026/06/05',
-    status: '출하완료',
-  },
-])
+const rowsData = useShipmentStatusDocuments()
 
 const { filters, filteredRows, resetFilters, applyFilters } = useDocumentFilter(rowsData, {
   keywordFields: ['id', 'clientName', 'country', 'poId', 'requestDate', 'dueDate', 'status'],


### PR DESCRIPTION
## 📋 작업 내용

<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
  - PI / PO / 생산지시서 / 출하지시서 상세 화면을 문서형 UI 기준으로 재정리했습니다.
  - 상세 화면에서 필요한 컬럼값을 보강하고, 정보 우선순위를 문서 검토 흐름에 맞게 조정했습니다.
  - 출하지시서와 출하현황은 참조 문서 관계가 실제 생성 문서 기준으로 보이도록 정리했습니다.
  - 중복으로 보이던 보조 정보 카드는 제거해 화면 밀도를 정리했습니다.

## 🔗 관련 이슈

<!-- 관련 이슈 번호를 적어주세요 (자동으로 이슈가 닫힙니다) -->
- closes #136 

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->
<img width="2896" height="1688" alt="image" src="https://github.com/user-attachments/assets/56f8e5ab-f49b-42f0-8693-a3fd66ebad66" />




## ✅ 체크리스트
  - [x] 정상 동작 확인
  - [x] 불필요한 코드/주석 제거
  - [x] 충돌(conflict) 해결 완료
## 💬 리뷰어에게

<!-- 리뷰할 때 중점적으로 봐줬으면 하는 부분이 있다면 적어주세요 -->

  - 이번 작업은 상세 화면을 “문서 미리보기 보조 화면”이 아니라, 실제 업무 검토용 상세 화면으로 보이도록 정리하는 데 초점을 맞췄습니다.
  - 재고/창고처럼 현재 시스템에 없는 업무 축은 제거했고, 대신 문서 기본정보 / 거래조건 / 품목내역 / 비고 / 참조 문서 중심으로 화면을 재구성했습니다.
  - 출하지시서와 출하현황은 역할이 겹치지 않도록 문서와 진행상태 관점으로 분리했습니다.

