### PR TITLE
[Feature] 메인 대시보드 결재함 클릭 시 결재 검토 모달 

### DIFF
--- a/src/components/common/ApprovalReviewModal.vue
+++ b/src/components/common/ApprovalReviewModal.vue
@@ -1,0 +1,318 @@
+<script setup>
+import BaseButton from '@/components/common/BaseButton.vue'
+import BaseModal from '@/components/common/BaseModal.vue'
+
+const props = defineProps({
+  open: {
+    type: Boolean,
+    default: false,
+  },
+  title: {
+    type: String,
+    default: '결재 검토',
+  },
+  message: {
+    type: String,
+    default: '',
+  },
+  requestRows: {
+    type: Array,
+    default: () => [],
+  },
+  requestSectionTitle: {
+    type: String,
+    default: '결재 요청 정보',
+  },
+  documentRows: {
+    type: Array,
+    default: () => [],
+  },
+  documentSectionTitle: {
+    type: String,
+    default: '문서 정보',
+  },
+  changeColumns: {
+    type: Array,
+    default: () => [],
+  },
+  changeRows: {
+    type: Array,
+    default: () => [],
+  },
+  changeSectionTitle: {
+    type: String,
+    default: '변경 사항',
+  },
+  itemColumns: {
+    type: Array,
+    default: () => [],
+  },
+  itemRows: {
+    type: Array,
+    default: () => [],
+  },
+  itemSummaryRows: {
+    type: Array,
+    default: () => [],
+  },
+  itemSectionTitle: {
+    type: String,
+    default: '품목 정보',
+  },
+  itemEmptyText: {
+    type: String,
+    default: '품목 정보가 없습니다.',
+  },
+  referenceRows: {
+    type: Array,
+    default: () => [],
+  },
+  referenceSectionTitle: {
+    type: String,
+    default: '참조 문서 정보',
+  },
+  helperText: {
+    type: String,
+    default: '',
+  },
+  width: {
+    type: String,
+    default: 'max-w-6xl',
+  },
+  zIndex: {
+    type: Number,
+    default: 70,
+  },
+  canApprove: {
+    type: Boolean,
+    default: false,
+  },
+  approveLabel: {
+    type: String,
+    default: '승인',
+  },
+  rejectLabel: {
+    type: String,
+    default: '반려',
+  },
+  detailLabel: {
+    type: String,
+    default: '문서 상세 보기',
+  },
+})
+
+const emit = defineEmits(['approve', 'reject', 'detail', 'close'])
+
+function getAlignmentClass(align) {
+  if (align === 'right') return 'text-right'
+  if (align === 'center') return 'text-center'
+  return 'text-left'
+}
+</script>
+
+<template>
+  <BaseModal
+    :open="open"
+    :title="title"
+    :width="width"
+    :z-index="zIndex"
+    @close="emit('close')"
+  >
+    <div class="space-y-4 text-sm text-slate-600">
+      <div v-if="message" class="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3">
+        <p class="leading-6 text-slate-700">{{ message }}</p>
+      </div>
+
+      <div v-if="requestRows.length" class="overflow-hidden rounded-lg border border-slate-200 bg-white">
+        <div class="border-b border-slate-100 bg-slate-50 px-4 py-3">
+          <p class="text-sm font-semibold text-slate-800">{{ requestSectionTitle }}</p>
+        </div>
+        <dl class="grid grid-cols-1 gap-2 p-4 md:grid-cols-2">
+          <div
+            v-for="(row, index) in requestRows"
+            :key="`${row.label}-${index}`"
+            class="rounded-md border border-slate-200 bg-white px-4 py-3"
+            :class="row.fullWidth ? 'md:col-span-2' : ''"
+          >
+            <dt class="text-xs font-medium text-slate-500">{{ row.label }}</dt>
+            <dd class="mt-2 break-words text-sm font-medium text-slate-800">{{ row.value }}</dd>
+          </div>
+        </dl>
+      </div>
+
+      <div v-if="documentRows.length" class="overflow-hidden rounded-lg border border-slate-200 bg-white">
+        <div class="border-b border-slate-100 bg-slate-50 px-4 py-3">
+          <p class="text-sm font-semibold text-slate-800">{{ documentSectionTitle }}</p>
+        </div>
+        <dl class="grid grid-cols-1 gap-2 p-4 md:grid-cols-2">
+          <div
+            v-for="(row, index) in documentRows"
+            :key="`${row.label}-${index}`"
+            class="rounded-md border px-4 py-3"
+            :class="[
+              row.fullWidth ? 'md:col-span-2' : '',
+              row.emphasis ? 'border-slate-300 bg-slate-50' : 'border-slate-200 bg-white',
+            ]"
+          >
+            <dt class="text-xs font-medium text-slate-500">{{ row.label }}</dt>
+            <dd
+              class="mt-2 break-words text-slate-800"
+              :class="row.emphasis ? 'text-base font-bold' : 'text-sm font-medium'"
+            >
+              {{ row.value }}
+            </dd>
+          </div>
+        </dl>
+      </div>
+
+      <div v-if="changeColumns.length" class="overflow-hidden rounded-lg border border-slate-200 bg-white">
+        <div class="border-b border-slate-100 bg-slate-50 px-4 py-3">
+          <p class="text-sm font-semibold text-slate-800">{{ changeSectionTitle }}</p>
+        </div>
+        <div class="max-h-[280px] overflow-auto">
+          <table class="min-w-full border-collapse">
+            <thead class="bg-slate-50">
+              <tr>
+                <th
+                  v-for="column in changeColumns"
+                  :key="column.key"
+                  class="border-b border-r border-slate-200 px-4 py-3 text-xs font-semibold text-slate-600 last:border-r-0"
+                  :class="getAlignmentClass(column.align)"
+                >
+                  {{ column.label }}
+                </th>
+              </tr>
+            </thead>
+            <tbody v-if="changeRows.length" class="bg-white">
+              <tr
+                v-for="(row, rowIndex) in changeRows"
+                :key="row.id ?? rowIndex"
+                class="align-top"
+              >
+                <td
+                  v-for="column in changeColumns"
+                  :key="`${column.key}-${rowIndex}`"
+                  class="border-b border-r border-slate-200 px-4 py-3 text-sm text-slate-700 last:border-r-0"
+                  :class="getAlignmentClass(column.align)"
+                >
+                  {{ row[column.key] || '-' }}
+                </td>
+              </tr>
+            </tbody>
+            <tbody v-else class="bg-white">
+              <tr>
+                <td :colspan="changeColumns.length" class="px-4 py-10 text-center text-sm text-slate-400">
+                  변경 사항이 없습니다.
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div v-if="itemColumns.length" class="overflow-hidden rounded-lg border border-slate-200 bg-white">
+        <div class="border-b border-slate-100 bg-slate-50 px-4 py-3">
+          <p class="text-sm font-semibold text-slate-800">{{ itemSectionTitle }}</p>
+        </div>
+        <div class="max-h-[320px] overflow-auto">
+          <table class="min-w-full border-collapse">
+            <thead class="bg-slate-50">
+              <tr>
+                <th
+                  v-for="column in itemColumns"
+                  :key="column.key"
+                  class="border-b border-r border-slate-200 px-4 py-3 text-xs font-semibold text-slate-600 last:border-r-0"
+                  :class="getAlignmentClass(column.align)"
+                >
+                  {{ column.label }}
+                </th>
+              </tr>
+            </thead>
+            <tbody v-if="itemRows.length" class="bg-white">
+              <tr
+                v-for="(row, rowIndex) in itemRows"
+                :key="row.id ?? rowIndex"
+                class="align-top"
+              >
+                <td
+                  v-for="column in itemColumns"
+                  :key="`${column.key}-${rowIndex}`"
+                  class="border-b border-r border-slate-200 px-4 py-3 text-sm text-slate-700 last:border-r-0"
+                  :class="getAlignmentClass(column.align)"
+                >
+                  {{ row[column.key] || '-' }}
+                </td>
+              </tr>
+            </tbody>
+            <tbody v-else class="bg-white">
+              <tr>
+                <td :colspan="itemColumns.length" class="px-4 py-10 text-center text-sm text-slate-400">
+                  {{ itemEmptyText }}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <dl
+          v-if="itemSummaryRows.length"
+          class="grid grid-cols-1 gap-2 border-t border-slate-100 bg-slate-50 p-4 md:grid-cols-2"
+        >
+          <div
+            v-for="(row, index) in itemSummaryRows"
+            :key="`${row.label}-${index}`"
+            class="rounded-md border px-4 py-3"
+            :class="[
+              row.fullWidth ? 'md:col-span-2' : '',
+              row.emphasis ? 'border-slate-300 bg-white' : 'border-slate-200 bg-white',
+            ]"
+          >
+            <dt class="text-xs font-medium text-slate-500">{{ row.label }}</dt>
+            <dd
+              class="mt-2 break-words text-slate-800"
+              :class="row.emphasis ? 'text-base font-bold' : 'text-sm font-medium'"
+            >
+              {{ row.value }}
+            </dd>
+          </div>
+        </dl>
+      </div>
+
+      <div v-if="referenceRows.length" class="overflow-hidden rounded-lg border border-slate-200 bg-white">
+        <div class="border-b border-slate-100 bg-slate-50 px-4 py-3">
+          <p class="text-sm font-semibold text-slate-800">{{ referenceSectionTitle }}</p>
+        </div>
+        <dl class="grid grid-cols-1 gap-2 p-4 md:grid-cols-2">
+          <div
+            v-for="(row, index) in referenceRows"
+            :key="`${row.label}-${index}`"
+            class="rounded-md border px-4 py-3"
+            :class="[
+              row.fullWidth ? 'md:col-span-2' : '',
+              row.emphasis ? 'border-slate-300 bg-slate-50' : 'border-slate-200 bg-white',
+            ]"
+          >
+            <dt class="text-xs font-medium text-slate-500">{{ row.label }}</dt>
+            <dd
+              class="mt-2 break-words text-slate-800"
+              :class="row.emphasis ? 'text-base font-bold' : 'text-sm font-medium'"
+            >
+              {{ row.value }}
+            </dd>
+          </div>
+        </dl>
+      </div>
+
+      <div v-if="helperText" class="rounded-lg border border-slate-200 bg-white px-4 py-3 text-xs text-slate-500">
+        {{ helperText }}
+      </div>
+    </div>
+
+    <template #footer>
+      <BaseButton variant="secondary" @click="emit('close')">닫기</BaseButton>
+      <BaseButton variant="secondary" @click="emit('detail')">{{ detailLabel }}</BaseButton>
+      <BaseButton v-if="canApprove" variant="danger" @click="emit('reject')">{{ rejectLabel }}</BaseButton>
+      <BaseButton v-if="canApprove" @click="emit('approve')">{{ approveLabel }}</BaseButton>
+    </template>
+  </BaseModal>
+</template>

--- a/src/components/common/SearchableCombobox.vue
+++ b/src/components/common/SearchableCombobox.vue
@@ -75,7 +75,7 @@ watch(
   () => props.modelValue,
   (value) => {
     const matched = normalizedOptions.value.find((option) => String(option.value) === String(value))
-    const label = matched?.label ?? ''
+    const label = matched?.label ?? (value == null ? '' : String(value))
     inputValue.value = label
     rawQuery.value = label
   },

--- a/src/components/common/StatusBadge.vue
+++ b/src/components/common/StatusBadge.vue
@@ -68,6 +68,12 @@ const statusMap = {
   completed: 'border-teal-200 bg-teal-50 text-teal-700',
   COMPLETED: 'border-teal-200 bg-teal-50 text-teal-700',
   완료: 'border-teal-200 bg-teal-50 text-teal-700',
+  approved: 'border-green-200 bg-green-50 text-green-700',
+  APPROVED: 'border-green-200 bg-green-50 text-green-700',
+  승인: 'border-green-200 bg-green-50 text-green-700',
+  rejected: 'border-rose-200 bg-rose-50 text-rose-700',
+  REJECTED: 'border-rose-200 bg-rose-50 text-rose-700',
+  반려: 'border-rose-200 bg-rose-50 text-rose-700',
 
   paid: 'border-green-200 bg-green-50 text-green-700',
   PAID: 'border-green-200 bg-green-50 text-green-700',

--- a/src/components/domain/document/PIFormModal.vue
+++ b/src/components/domain/document/PIFormModal.vue
@@ -39,17 +39,14 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['close', 'save', 'open-client-search'])
-const { error, success } = useToast()
+const { error } = useToast()
 
 const defaultCurrencyOptions = ['USD', 'EUR', 'JPY', 'GBP', 'AUD', 'CAD', 'SGD', 'AED', 'CNY', 'MYR', 'THB', 'VND', 'IDR', 'INR', 'SAR', 'BRL', 'SEK', 'CHF']
 const defaultBuyerOptions = [
   'Mr. Ahmad Razak (Purchasing Manager)',
   'Ms. Siti Nurhaliza (Director)',
 ]
-const defaultApproverOptions = [
-  '최관리 (경영지원 · 관리자)',
-  '박리드 (영업지원 · 팀장)',
-]
+const defaultApproverOptions = ['김영업']
 const fallbackProductCatalog = [
   { id: '1', code: 'ITM001', name: 'Wireless Presenter', spec: '2.4GHz / 100m / USB Receiver / Laser Pointer', unit: 'EA', unitPrice: 55000 },
   { id: '2', code: 'ITM002', name: 'Tablet PC 10"', spec: '10.1" FHD / Octa-core / 4GB / 64GB / WiFi', unit: 'EA', unitPrice: 650000 },
@@ -195,11 +192,53 @@ const buyerOptions = computed(() => {
   return [...buyers]
 })
 
-const productOptions = computed(() => productCatalog.value.map((item) => ({
-  label: item.name,
-  value: item.name,
-  sublabel: [item.code, item.spec, `${Number(item.unitPrice ?? 0).toLocaleString('ko-KR')} KRW`].filter(Boolean).join(' · '),
-})))
+function parseNumericInput(value) {
+  const normalized = Number.parseFloat(String(value ?? '').replace(/[^0-9.]/g, ''))
+  return Number.isFinite(normalized) ? normalized : 0
+}
+
+const mergedProductCatalog = computed(() => {
+  const merged = productCatalog.value.map((item) => ({
+    ...item,
+    source: 'catalog',
+  }))
+  const existingNames = new Set(merged.map((item) => item.name))
+
+  for (const item of form.value.items ?? []) {
+    const name = String(item.name ?? '').trim()
+
+    if (!name || existingNames.has(name)) continue
+
+    merged.unshift({
+      id: `legacy-${item.id}`,
+      code: '',
+      name,
+      spec: '',
+      unit: item.unit ?? '',
+      unitPrice: parseNumericInput(item.unitPrice),
+      source: 'legacy',
+    })
+    existingNames.add(name)
+  }
+
+  return merged
+})
+
+const productOptions = computed(() => {
+  const catalogOptions = mergedProductCatalog.value.map((item) => ({
+    label: item.name,
+    value: item.name,
+    sublabel: [
+      item.code,
+      item.spec,
+      item.source === 'legacy'
+        ? '기존 문서 품목'
+        : `${Number(item.unitPrice ?? 0).toLocaleString('ko-KR')} KRW`,
+    ].filter(Boolean).join(' · '),
+  }))
+
+  return catalogOptions
+})
 
 const reasonFieldLabel = computed(() => (
   props.mode === 'create' ? '특기사항' : '수정 사유'
@@ -273,6 +312,7 @@ async function loadReferenceData() {
 
     const activeUsers = usersData
       .filter((user) => user.status === '재직')
+      .filter((user) => user.role === 'sales' && Number(user.positionId) === 1)
       .map((user) => user.name)
       .filter(Boolean)
 
@@ -357,7 +397,7 @@ function clearItemErrors(itemId) {
 }
 
 function findProductByName(name) {
-  return productCatalog.value.find((item) => item.name === name) ?? null
+  return mergedProductCatalog.value.find((item) => item.name === name) ?? null
 }
 
 function formatUnitPriceValue(value) {
@@ -419,6 +459,14 @@ function applyCatalogItemToRow(itemRow, productName) {
 
   itemRow.name = product.name
   itemRow.unit = product.unit || itemRow.unit
+
+  if (product.source === 'legacy') {
+    itemRow.baseUnitPrice = null
+    itemRow.unitPrice = formatUnitPriceValue(parseNumericInput(product.unitPrice))
+    updateItemAmount(itemRow)
+    return
+  }
+
   itemRow.baseUnitPrice = product.unitPrice
   itemRow.unitPrice = formatUnitPriceValue(
     convertKrwPriceToCurrency(product.unitPrice, form.value.currency, form.value.issueDate),
@@ -547,6 +595,29 @@ function updateItemAmount(item) {
   item.amount = formatAmount(quantity * unitPrice)
 }
 
+function normalizeEditItem(item, index) {
+  const normalizedQty = parseNumericInput(item.qty ?? item.quantity)
+  const normalizedUnitPrice = parseNumericInput(item.unitPrice)
+  const normalizedAmount = parseNumericInput(item.amount)
+  const resolvedUnitPrice = normalizedUnitPrice > 0
+    ? normalizedUnitPrice
+    : (normalizedAmount > 0 && normalizedQty > 0 ? Math.round(normalizedAmount / normalizedQty) : 0)
+  const resolvedAmount = normalizedAmount > 0
+    ? normalizedAmount
+    : normalizedQty * resolvedUnitPrice
+
+  return {
+    id: item.id ?? index + 1,
+    name: item.name ?? '',
+    qty: String(item.qty ?? item.quantity ?? ''),
+    unit: item.unit ?? '',
+    unitPrice: String(resolvedUnitPrice),
+    amount: String(resolvedAmount),
+    remark: item.remark ?? item.remarks ?? '',
+    baseUnitPrice: null,
+  }
+}
+
 async function initializeForm() {
   if (!props.open) return
 
@@ -572,19 +643,55 @@ async function initializeForm() {
       namedPlace: normalizedIncoterms.namedPlace || getIncotermMeta(normalizedIncoterms.code, incotermCatalog.value).defaultNamedPlace || '',
       reason: '',
       approver: getDefaultApprover(),
-      items: props.document.items?.map((item, index) => ({
-        id: item.id ?? index + 1,
-        name: item.name ?? '',
-        qty: String(item.qty ?? item.quantity ?? ''),
-        unit: item.unit ?? '',
-        unitPrice: String(item.unitPrice ?? ''),
-        amount: String(item.amount ?? '0').replace(/[^0-9.]/g, '') || '0',
-        remark: item.remark ?? item.remarks ?? '',
-        baseUnitPrice: null,
-      })) ?? [],
+      items: props.document.items?.map(normalizeEditItem) ?? [],
     }
-    form.value.items.forEach(updateItemAmount)
+    form.value.items.forEach((itemRow) => {
+      const matchedProduct = findProductByName(itemRow.name)
+
+      if (!matchedProduct) {
+        updateItemAmount(itemRow)
+        return
+      }
+
+      if (!String(itemRow.unit ?? '').trim()) {
+        itemRow.unit = matchedProduct.unit || ''
+      }
+
+      if (parseNumericInput(itemRow.unitPrice) <= 0) {
+        applyCatalogItemToRow(itemRow, itemRow.name)
+        return
+      }
+
+      if (matchedProduct.source === 'catalog') {
+        itemRow.baseUnitPrice = Number(matchedProduct.unitPrice ?? 0)
+      }
+
+      updateItemAmount(itemRow)
+    })
     await loadReferenceData()
+    form.value.items.forEach((itemRow) => {
+      const matchedProduct = findProductByName(itemRow.name)
+
+      if (!matchedProduct) {
+        updateItemAmount(itemRow)
+        return
+      }
+
+      if (!String(itemRow.unit ?? '').trim()) {
+        itemRow.unit = matchedProduct.unit || itemRow.unit
+      }
+
+      if (parseNumericInput(itemRow.unitPrice) <= 0) {
+        applyCatalogItemToRow(itemRow, itemRow.name)
+        return
+      }
+
+      if (matchedProduct.source === 'catalog') {
+        itemRow.baseUnitPrice = Number(matchedProduct.unitPrice ?? 0)
+      }
+
+      updateItemAmount(itemRow)
+    })
     await loadBuyerOptions()
     return
   }
@@ -611,12 +718,6 @@ function openClientSearch() {
 
 function addItem() {
   const itemRow = createEmptyItemRow()
-  const defaultProductName = productCatalog.value[0]?.name ?? fallbackProductCatalog[0]?.name ?? ''
-
-  if (defaultProductName) {
-    applyCatalogItemToRow(itemRow, defaultProductName)
-  }
-
   form.value.items.push(itemRow)
   clearError('items')
 }
@@ -631,7 +732,6 @@ function removeItem(index) {
 function handleSave() {
   if (!validateForm()) return
 
-  success(props.mode === 'create' ? 'PI 작성 폼 구조가 준비되었습니다.' : 'PI 수정 폼 구조가 준비되었습니다.')
   emit('save', {
     ...form.value,
     items: form.value.items.map(({ baseUnitPrice, ...item }) => ({ ...item })),

--- a/src/components/domain/document/POFormModal.vue
+++ b/src/components/domain/document/POFormModal.vue
@@ -5,7 +5,6 @@ import BaseButton from '@/components/common/BaseButton.vue'
 import BaseModal from '@/components/common/BaseModal.vue'
 import BaseSelect from '@/components/common/BaseSelect.vue'
 import { fetchUsers } from '@/api/master'
-import { useToast } from '@/composables/useToast'
 
 const props = defineProps({
   open: { type: Boolean, default: false },
@@ -16,11 +15,7 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['close', 'save', 'open-pi-search', 'open-client-search'])
-const { success } = useToast()
-const defaultApproverOptions = [
-  '최관리 (경영지원 · 관리자)',
-  '박리드 (영업지원 · 팀장)',
-]
+const defaultApproverOptions = ['김영업']
 
 function createInitialForm() {
   return {
@@ -31,7 +26,7 @@ function createInitialForm() {
     deliveryDate: '',
     sourceDeliveryDate: '',
     deliveryDateOverride: false,
-    approver: defaultApproverOptions[1],
+    approver: defaultApproverOptions[0],
   }
 }
 
@@ -45,6 +40,7 @@ async function loadApproverOptions() {
     const users = await fetchUsers()
     const activeUsers = users
       .filter((user) => user.status === '재직')
+      .filter((user) => user.role === 'sales' && Number(user.positionId) === 1)
       .map((user) => user.name)
       .filter(Boolean)
 
@@ -56,7 +52,7 @@ async function loadApproverOptions() {
   }
 
   if (!approverOptions.value.includes(form.value.approver)) {
-    form.value.approver = approverOptions.value[0] ?? defaultApproverOptions[1]
+    form.value.approver = approverOptions.value[0] ?? defaultApproverOptions[0]
   }
 }
 
@@ -76,7 +72,7 @@ watch(
         deliveryDate: props.document.deliveryDate?.replaceAll('/', '-') ?? '',
         sourceDeliveryDate: props.document.sourceDeliveryDate?.replaceAll('/', '-') ?? props.document.deliveryDate?.replaceAll('/', '-') ?? '',
         deliveryDateOverride: Boolean(props.document.deliveryDateOverride),
-        approver: props.document.approver ?? approverOptions.value[0] ?? defaultApproverOptions[1],
+        approver: props.document.approver ?? approverOptions.value[0] ?? defaultApproverOptions[0],
       }
       return
     }
@@ -103,7 +99,6 @@ function clearLinkedPi() {
 }
 
 function handleSave() {
-  success(props.mode === 'create' ? 'PO 작성 폼 구조가 준비되었습니다.' : 'PO 수정 폼 구조가 준비되었습니다.')
   emit('save', { ...form.value })
 }
 

--- a/src/views/DashboardPage.vue
+++ b/src/views/DashboardPage.vue
@@ -1,10 +1,21 @@
 <script setup>
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { RouterLink, useRouter } from 'vue-router'
+import ApprovalReviewModal from '@/components/common/ApprovalReviewModal.vue'
 import BaseCard from '@/components/common/BaseCard.vue'
+import ConfirmModal from '@/components/common/ConfirmModal.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
+import { useAuthStore } from '@/stores/auth'
+import { usePiDocuments } from '@/stores/piDocuments'
+import { usePoDocuments } from '@/stores/poDocuments'
 
 const router = useRouter()
+const authStore = useAuthStore()
+const piDocuments = usePiDocuments()
+const poDocuments = usePoDocuments()
+const selectedRequest = ref(null)
+const decisionConfirmOpen = ref(false)
+const pendingDecision = ref('')
 
 const summaryCards = ref([
   {
@@ -32,42 +43,6 @@ const summaryCards = ref([
     to: '/ci',
   },
 ])
-
-const requestItems = [
-  {
-    id: 1,
-    docType: 'PO',
-    docId: 'PO26002',
-    actionLabel: '수정',
-    company: 'COOLSAY SDN BHD',
-    requester: '김영업(과장)',
-    approver: '최관리(이사)',
-    status: '대기',
-    urgent: false,
-  },
-  {
-    id: 2,
-    docType: 'PO',
-    docId: 'PO26004',
-    actionLabel: '삭제',
-    company: 'TechBridge GmbH',
-    requester: '정영업(대리)',
-    approver: '최관리(이사)',
-    status: '진행중',
-    urgent: true,
-  },
-  {
-    id: 3,
-    docType: 'PI',
-    docId: 'PI26005',
-    actionLabel: '수정',
-    company: 'Sakura Electronics',
-    requester: '정영업(대리)',
-    approver: '최관리(이사)',
-    status: '완료',
-    urgent: false,
-  },
-]
 
 const shipmentItems = [
   {
@@ -134,16 +109,223 @@ const recentActivities = [
   },
 ]
 
-function goToRequestItem(item) {
-  const targetPath = item.docType === 'PI' ? '/pi' : '/po'
+const currentUser = computed(() => authStore.currentUser ?? null)
+const isSalesManager = computed(() => currentUser.value?.role === 'sales' && Number(currentUser.value?.positionId) === 1)
+const isSalesMember = computed(() => currentUser.value?.role === 'sales' && Number(currentUser.value?.positionId) === 2)
+const canApproveRequests = computed(() => isSalesManager.value)
+const showApprovalSection = computed(() => canApproveRequests.value || isSalesMember.value)
+const requestSectionTitle = computed(() => (canApproveRequests.value ? '결재 요청함' : '내 요청 현황'))
+
+function parseRequestedAt(value) {
+  const normalized = String(value ?? '').trim()
+  if (!normalized) return 0
+  return new Date(normalized.replace(/\./g, '-')).getTime() || 0
+}
+
+function buildFallbackReview(docType, row) {
+  const itemRows = (row.items ?? []).map((item, index) => ({
+    id: `${row.id}-item-${index}`,
+    name: item.name || '-',
+    qty: item.qty ?? item.quantity ?? '-',
+    unit: item.unit || '-',
+    unitPrice: item.unitPrice || '-',
+    amount: item.amount || '-',
+    remark: item.remark || '-',
+  }))
+
+  return {
+    title: `${docType} ${row.approvalAction || row.requestStatus || '결재'} 검토`,
+    message: '요청 시점의 검토 데이터가 없어 현재 문서 스냅샷 기준으로 표시합니다.',
+    requestRows: [
+      { label: '요청 유형', value: `${row.approvalAction || '-'} 요청` },
+      { label: '결재자', value: row.approver || '-' },
+      { label: '요청자', value: row.approvalRequestedBy || '-' },
+      { label: '문서 상태', value: row.status || '-' },
+      { label: '요청 상태', value: row.requestStatus || '-' },
+      { label: '요청 시각', value: row.approvalRequestedAt || '-' },
+    ],
+    requestSectionTitle: '팀장 결재 정보',
+    documentRows: [
+      { label: `${docType} 번호`, value: row.id || '-' },
+      { label: '거래처', value: row.clientName || '-' },
+      { label: '통화', value: row.currency || '-' },
+      { label: '발행일', value: row.issueDate || '-' },
+      { label: '납기일', value: row.deliveryDate || '-' },
+    ],
+    documentSectionTitle: `${docType} 문서 정보`,
+    changeColumns: [],
+    changeRows: [],
+    itemColumns: [
+      { key: 'name', label: '품목명', align: 'left' },
+      { key: 'qty', label: '수량', align: 'right' },
+      { key: 'unit', label: '단위', align: 'center' },
+      { key: 'unitPrice', label: '단가', align: 'right' },
+      { key: 'amount', label: '금액', align: 'right' },
+      { key: 'remark', label: '비고', align: 'left' },
+    ],
+    itemRows,
+    itemSummaryRows: [
+      { label: '품목 건수', value: `${itemRows.length}건` },
+      { label: '총액', value: row.amount || '-', emphasis: true },
+    ],
+    itemSectionTitle: `${docType} 품목 정보`,
+    referenceRows: [],
+    referenceSectionTitle: '참조 문서 정보',
+    helperText: '',
+  }
+}
+
+function createRequestItem(docType, row) {
+  return {
+    id: `${docType}-${row.id}`,
+    docType,
+    docId: row.id,
+    actionLabel: row.approvalAction || row.requestStatus?.replace('요청', '') || '결재',
+    company: row.clientName || '-',
+    requester: row.approvalRequestedBy || '-',
+    approver: row.approver || '-',
+    status: row.approvalStatus || '-',
+    requestStatus: row.requestStatus || '-',
+    requestedAt: row.approvalRequestedAt || '-',
+    urgent: false,
+    routeName: docType === 'PI' ? 'pi-detail' : 'po-detail',
+    review: row.approvalReview || buildFallbackReview(docType, row),
+  }
+}
+
+function canReviewRequest(item) {
+  if (isSalesManager.value) {
+    return item.docType === 'PI' || item.docType === 'PO'
+  }
+  return false
+}
+
+const allRequestItems = computed(() => {
+  const piItems = piDocuments.value
+    .filter((row) => row.requestStatus)
+    .map((row) => createRequestItem('PI', row))
+
+  const poItems = poDocuments.value
+    .filter((row) => row.requestStatus)
+    .map((row) => createRequestItem('PO', row))
+
+  return [...poItems, ...piItems].sort((a, b) => parseRequestedAt(b.requestedAt) - parseRequestedAt(a.requestedAt))
+})
+
+const requestItems = computed(() => {
+  if (canApproveRequests.value) {
+    return allRequestItems.value.filter((item) => item.status === '대기' && canReviewRequest(item))
+  }
+
+  if (isSalesMember.value) {
+    return allRequestItems.value.filter((item) => item.requester === currentUser.value?.name)
+  }
+
+  return []
+})
+
+const selectedRequestReview = computed(() => selectedRequest.value?.review ?? null)
+
+function openRequestReview(item) {
+  selectedRequest.value = item
+}
+
+function closeRequestReview() {
+  selectedRequest.value = null
+}
+
+function closeDecisionConfirm() {
+  decisionConfirmOpen.value = false
+  pendingDecision.value = ''
+}
+
+function updateRequestDocument(item, patch) {
+  const targetStore = item.docType === 'PI' ? piDocuments : poDocuments
+  targetStore.value = targetStore.value.map((row) => (
+    row.id === item.docId
+      ? { ...row, ...patch }
+      : row
+  ))
+}
+
+function getReviewedAt() {
+  const now = new Date()
+  const year = now.getFullYear()
+  const month = String(now.getMonth() + 1).padStart(2, '0')
+  const day = String(now.getDate()).padStart(2, '0')
+  const hours = String(now.getHours()).padStart(2, '0')
+  const minutes = String(now.getMinutes()).padStart(2, '0')
+  return `${year}/${month}/${day} ${hours}:${minutes}`
+}
+
+const decisionConfirmTitle = computed(() => (
+  pendingDecision.value === 'approve' ? '결재 승인' : '결재 반려'
+))
+
+const decisionConfirmMessage = computed(() => {
+  if (!selectedRequest.value) return ''
+
+  return pendingDecision.value === 'approve'
+    ? `해당 ${selectedRequest.value.docType} 결재 요청을 승인하시겠습니까?`
+    : `해당 ${selectedRequest.value.docType} 결재 요청을 반려하시겠습니까?`
+})
+
+const decisionConfirmDetailRows = computed(() => {
+  if (!selectedRequest.value) return []
+
+  return [
+    { label: '문서 종류', value: selectedRequest.value.docType },
+    { label: '문서 번호', value: selectedRequest.value.docId },
+    { label: '요청 유형', value: `${selectedRequest.value.actionLabel} 요청` },
+    { label: '요청자', value: selectedRequest.value.requester || '-' },
+    { label: '결재자', value: selectedRequest.value.approver || '-' },
+    { label: '요청 시각', value: selectedRequest.value.requestedAt || '-' },
+  ]
+})
+
+function openApproveConfirm() {
+  pendingDecision.value = 'approve'
+  decisionConfirmOpen.value = true
+}
+
+function openRejectConfirm() {
+  pendingDecision.value = 'reject'
+  decisionConfirmOpen.value = true
+}
+
+function confirmDecision() {
+  if (!selectedRequest.value || !pendingDecision.value) return
+
+  if (pendingDecision.value === 'approve') {
+    const nextStatus = selectedRequest.value.actionLabel === '삭제' ? '취소' : '확정'
+    updateRequestDocument(selectedRequest.value, {
+      status: nextStatus,
+      approvalStatus: '승인',
+      approvalReviewedBy: currentUser.value?.name || '',
+      approvalReviewedAt: getReviewedAt(),
+    })
+  } else {
+    updateRequestDocument(selectedRequest.value, {
+      status: '반려',
+      approvalStatus: '반려',
+      approvalReviewedBy: currentUser.value?.name || '',
+      approvalReviewedAt: getReviewedAt(),
+    })
+  }
+
+  closeDecisionConfirm()
+  closeRequestReview()
+}
+
+function goToRequestDetail() {
+  if (!selectedRequest.value) return
 
   router.push({
-    path: targetPath,
-    query: {
-      code: item.docId,
-      source: 'dashboard-request',
-    },
+    name: selectedRequest.value.routeName,
+    params: { id: selectedRequest.value.docId },
+    query: { source: 'dashboard-approval-review' },
   })
+  closeRequestReview()
 }
 
 function goToActivityItem(item) {
@@ -196,21 +378,30 @@ function goToShipmentItem(item) {
       </RouterLink>
     </section>
 
-    <BaseCard body-class="-mx-5 -mb-5 max-h-[400px] divide-y divide-slate-100 overflow-y-auto">
+    <BaseCard
+      v-if="showApprovalSection"
+      body-class="-mx-5 -mb-5 max-h-[400px] divide-y divide-slate-100 overflow-y-auto"
+    >
       <template #title>
         <h3 class="flex items-center gap-2 font-bold text-slate-800">
           <i class="fas fa-stamp text-brand-500" />
-          결재란
+          {{ requestSectionTitle }}
         </h3>
       </template>
       <template #header-actions>
         <span class="text-xs font-medium text-slate-400">{{ requestItems.length }}건</span>
       </template>
       <div
+        v-if="!requestItems.length"
+        class="px-5 py-10 text-center text-sm text-slate-400"
+      >
+        표시할 결재 요청이 없습니다.
+      </div>
+      <div
         v-for="item in requestItems"
         :key="item.id"
         class="flex cursor-pointer flex-col items-start gap-3 px-5 py-3.5 transition hover:bg-slate-50/50 sm:flex-row sm:items-center sm:justify-between"
-        @click="goToRequestItem(item)"
+        @click="openRequestReview(item)"
       >
         <div class="flex min-w-0 items-center gap-3">
           <div
@@ -224,7 +415,7 @@ function goToShipmentItem(item) {
           </div>
           <div class="min-w-0">
             <div class="truncate text-sm font-medium text-slate-800">
-              {{ item.docType }} {{ item.docId }} — {{ item.actionLabel }} 결재
+              {{ item.docType }} {{ item.docId }} — {{ item.actionLabel }} 요청
             </div>
             <div class="truncate text-xs text-slate-400 sm:whitespace-normal">
               {{ item.company }} · 요청: {{ item.requester }} → 결재: {{ item.approver }}
@@ -300,5 +491,44 @@ function goToShipmentItem(item) {
         </div>
       </BaseCard>
     </section>
+
+    <ApprovalReviewModal
+      :open="Boolean(selectedRequest)"
+      :title="selectedRequestReview?.title || '결재 검토'"
+      :message="selectedRequestReview?.message || ''"
+      :request-rows="selectedRequestReview?.requestRows || []"
+      :request-section-title="selectedRequestReview?.requestSectionTitle || '결재 요청 정보'"
+      :document-rows="selectedRequestReview?.documentRows || []"
+      :document-section-title="selectedRequestReview?.documentSectionTitle || '문서 정보'"
+      :change-columns="selectedRequestReview?.changeColumns || []"
+      :change-rows="selectedRequestReview?.changeRows || []"
+      :change-section-title="selectedRequestReview?.changeSectionTitle || '변경 사항'"
+      :item-columns="selectedRequestReview?.itemColumns || []"
+      :item-rows="selectedRequestReview?.itemRows || []"
+      :item-summary-rows="selectedRequestReview?.itemSummaryRows || []"
+      :item-section-title="selectedRequestReview?.itemSectionTitle || '품목 정보'"
+      :reference-rows="selectedRequestReview?.referenceRows || []"
+      :reference-section-title="selectedRequestReview?.referenceSectionTitle || '참조 문서 정보'"
+      :helper-text="selectedRequestReview?.helperText || ''"
+      :can-approve="canApproveRequests"
+      @close="closeRequestReview"
+      @detail="goToRequestDetail"
+      @approve="openApproveConfirm"
+      @reject="openRejectConfirm"
+    />
+
+    <ConfirmModal
+      :open="decisionConfirmOpen"
+      :title="decisionConfirmTitle"
+      :message="decisionConfirmMessage"
+      :detail-rows="decisionConfirmDetailRows"
+      :confirm-label="pendingDecision === 'approve' ? '승인' : '반려'"
+      :confirm-variant="pendingDecision === 'approve' ? 'primary' : 'danger'"
+      helper-text="처리 후 요청 상태와 문서 상태가 즉시 갱신됩니다."
+      width="max-w-2xl"
+      :z-index="90"
+      @confirm="confirmDecision"
+      @cancel="closeDecisionConfirm"
+    />
   </div>
 </template>

--- a/src/views/documents/PIDetailPage.vue
+++ b/src/views/documents/PIDetailPage.vue
@@ -2,6 +2,7 @@
 import { computed, onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
+import ApprovalRequestModal from '@/components/common/ApprovalRequestModal.vue'
 import BaseButton from '@/components/common/BaseButton.vue'
 import ConfirmModal from '@/components/common/ConfirmModal.vue'
 import DetailPageHeader from '@/components/common/DetailPageHeader.vue'
@@ -12,25 +13,54 @@ import PIDocumentTemplate from '@/components/domain/document/PIDocumentTemplate.
 import PIFormModal from '@/components/domain/document/PIFormModal.vue'
 import { fetchBuyers, fetchClients, fetchCountries } from '@/api/master'
 import { useToast } from '@/composables/useToast'
+import { useAuthStore } from '@/stores/auth'
 import { usePiDocuments } from '@/stores/piDocuments'
 import { usePoDocuments } from '@/stores/poDocuments'
-import { buildApprovalInfoRows } from '@/utils/documentApproval'
+import {
+  buildApprovalInfoRows,
+  buildApprovalRequestRows,
+  createDeleteApprovalMeta,
+  createEditApprovalMeta,
+  DELETE_REQUEST_DOCUMENT_STATUS,
+  DELETE_REQUEST_STATUS,
+  EDIT_REQUEST_DOCUMENT_STATUS,
+  EDIT_REQUEST_STATUS,
+} from '@/utils/documentApproval'
 import { openDocumentOutputByType } from '@/utils/documentOutput'
 import { formatIncotermsLabel, resolveIncotermState } from '@/utils/incoterms'
 import { clientSearchColumns } from '@/utils/searchModalColumns'
 
 const route = useRoute()
 const router = useRouter()
-const { info, success } = useToast()
+const authStore = useAuthStore()
+const { info, success, warning } = useToast()
 
 const previewOpen = ref(false)
 const formOpen = ref(false)
-const deleteOpen = ref(false)
+const editConfirmOpen = ref(false)
+const editApprovalRequestOpen = ref(false)
+const deleteApprovalRequestOpen = ref(false)
 const clientSearchOpen = ref(false)
 const clientSearchKeyword = ref('')
 const selectedClient = ref(null)
+const pendingEditRequest = ref(null)
 const piDocuments = usePiDocuments()
 const poDocuments = usePoDocuments()
+
+const approvalItemColumns = [
+  { key: 'name', label: '품목명', align: 'left' },
+  { key: 'qty', label: '수량', align: 'right' },
+  { key: 'unit', label: '단위', align: 'center' },
+  { key: 'unitPrice', label: '단가', align: 'right' },
+  { key: 'amount', label: '금액', align: 'right' },
+  { key: 'remark', label: '비고', align: 'left' },
+]
+
+const approvalChangeColumns = [
+  { key: 'label', label: '변경 항목', align: 'left' },
+  { key: 'before', label: '원본값', align: 'left' },
+  { key: 'after', label: '변경값', align: 'left' },
+]
 
 const fallbackClientRowsSource = [
   { id: 'CL001', code: 'CL001', name: 'COOLSAY SDN BHD', country: '말레이시아', city: 'Port Klang', currency: 'USD', manager: 'Ahmad Razak', tel: '+60-3-555-0101', status: '활성', buyers: ['Mr. Ahmad Razak (Purchasing Manager)', 'Ms. Siti Nurhaliza (Director)'] },
@@ -129,6 +159,154 @@ function buildLinkedDocuments(documentId) {
     .map((row) => ({ id: row.id, status: row.status }))
 }
 
+function getCurrentRequesterName() {
+  return authStore.currentUser?.name || '김영업'
+}
+
+function getRequestedAt() {
+  const now = new Date()
+  const year = now.getFullYear()
+  const month = String(now.getMonth() + 1).padStart(2, '0')
+  const day = String(now.getDate()).padStart(2, '0')
+  const hours = String(now.getHours()).padStart(2, '0')
+  const minutes = String(now.getMinutes()).padStart(2, '0')
+  return `${year}/${month}/${day} ${hours}:${minutes}`
+}
+
+function getDefaultDeleteApprover(row) {
+  return row?.approver || '김영업'
+}
+
+function createComparableItem(item) {
+  const quantity = parseNumericValue(item.qty ?? item.quantity)
+  const unitPrice = parseNumericValue(item.unitPrice)
+  const amount = parseNumericValue(item.amount) || quantity * unitPrice
+
+  return {
+    name: item.name ?? '',
+    qty: quantity,
+    unit: item.unit ?? '',
+    unitPrice,
+    amount,
+    remark: item.remark ?? '',
+  }
+}
+
+function createComparableSnapshot(source) {
+  const currency = source.currency || 'USD'
+  const items = (source.items ?? []).map(createComparableItem)
+  const totalAmount = items.reduce((sum, item) => sum + item.amount, 0)
+
+  return {
+    id: source.id ?? '',
+    clientName: source.clientName ?? '',
+    clientAddress: source.clientAddress ?? '',
+    buyerName: source.buyerName ?? source.buyer ?? '',
+    currency,
+    issueDate: source.issueDate ?? '-',
+    deliveryDate: source.deliveryDate ?? '-',
+    incoterms: source.incoterms ?? '',
+    namedPlace: source.namedPlace ?? '',
+    items,
+    amount: formatCurrencyValue(currency, totalAmount),
+  }
+}
+
+function createItemDigest(items) {
+  if (!items.length) return '없음'
+
+  const firstItem = items[0]
+  const quantityLabel = firstItem.qty > 0
+    ? ` / ${firstItem.qty.toLocaleString()}${firstItem.unit ? ` ${firstItem.unit}` : ''}`
+    : ''
+  const tailLabel = items.length > 1 ? ` 외 ${items.length - 1}건` : ''
+
+  return `${firstItem.name || '품목'}${quantityLabel}${tailLabel}`
+}
+
+function buildChangeRows(originalSnapshot, revisedSnapshot) {
+  return [
+    { label: '거래처', before: originalSnapshot.clientName || '-', after: revisedSnapshot.clientName || '-' },
+    { label: '영문주소', before: originalSnapshot.clientAddress || '-', after: revisedSnapshot.clientAddress || '-' },
+    { label: '바이어', before: originalSnapshot.buyerName || '-', after: revisedSnapshot.buyerName || '-' },
+    { label: '통화', before: originalSnapshot.currency || '-', after: revisedSnapshot.currency || '-' },
+    { label: '발행일', before: originalSnapshot.issueDate || '-', after: revisedSnapshot.issueDate || '-' },
+    { label: '납기일', before: originalSnapshot.deliveryDate || '-', after: revisedSnapshot.deliveryDate || '-' },
+    {
+      label: '인코텀즈',
+      before: formatIncotermsLabel(originalSnapshot.incoterms, originalSnapshot.namedPlace) || '-',
+      after: formatIncotermsLabel(revisedSnapshot.incoterms, revisedSnapshot.namedPlace) || '-',
+    },
+    {
+      label: '품목 목록',
+      before: createItemDigest(originalSnapshot.items),
+      after: createItemDigest(revisedSnapshot.items),
+    },
+    { label: '총액', before: originalSnapshot.amount || '-', after: revisedSnapshot.amount || '-' },
+  ].filter((row) => row.before !== row.after)
+}
+
+function createApprovalReviewSnapshot({
+  title,
+  message,
+  requestRows = [],
+  documentRows = [],
+  changeRows = [],
+  itemRows = [],
+  itemSummaryRows = [],
+  documentSectionTitle = '문서 정보',
+  changeSectionTitle = '변경 사항',
+  itemSectionTitle = '품목 정보',
+  helperText = '',
+}) {
+  return {
+    title,
+    message,
+    requestRows: requestRows.map((row) => ({ ...row })),
+    requestSectionTitle: '팀장 결재 정보',
+    documentRows: documentRows.map((row) => ({ ...row })),
+    documentSectionTitle,
+    changeColumns: changeRows.length ? approvalChangeColumns.map((column) => ({ ...column })) : [],
+    changeRows: changeRows.map((row) => ({ ...row })),
+    changeSectionTitle,
+    itemColumns: itemRows.length ? approvalItemColumns.map((column) => ({ ...column })) : [],
+    itemRows: itemRows.map((row) => ({ ...row })),
+    itemSummaryRows: itemSummaryRows.map((row) => ({ ...row })),
+    itemSectionTitle,
+    referenceRows: [],
+    referenceSectionTitle: '참조 문서 정보',
+    helperText,
+  }
+}
+
+function resolveItemUnitPriceValue(item) {
+  const quantity = parseNumericValue(item.qty ?? item.quantity)
+  const unitPrice = parseNumericValue(item.unitPrice)
+  const amount = parseNumericValue(item.amount)
+
+  if (unitPrice > 0) {
+    return unitPrice
+  }
+
+  if (quantity > 0 && amount > 0) {
+    return Math.round(amount / quantity)
+  }
+
+  return 0
+}
+
+function resolveItemAmountValue(item) {
+  const quantity = parseNumericValue(item.qty ?? item.quantity)
+  const unitPrice = resolveItemUnitPriceValue(item)
+  const amount = parseNumericValue(item.amount)
+
+  if (amount > 0) {
+    return amount
+  }
+
+  return quantity * unitPrice
+}
+
 function normalizeDetail(row) {
   if (!row) return null
 
@@ -160,11 +338,128 @@ function normalizeDetail(row) {
   }
 }
 
-const detail = computed(() => normalizeDetail(
-  piDocuments.value.find((row) => row.id === route.params.id),
+const sourceRow = computed(() => (
+  piDocuments.value.find((row) => row.id === route.params.id) ?? null
 ))
 
+const detail = computed(() => normalizeDetail(sourceRow.value))
+
 const approvalInfoRows = computed(() => buildApprovalInfoRows(detail.value))
+
+const editApprovalRequestRows = computed(() => {
+  if (!pendingEditRequest.value) return []
+
+  return buildApprovalRequestRows({
+    approver: pendingEditRequest.value.approver,
+    requesterName: getCurrentRequesterName(),
+    requestedAt: getRequestedAt(),
+    documentStatus: EDIT_REQUEST_DOCUMENT_STATUS,
+    requestStatus: EDIT_REQUEST_STATUS,
+    requestTypeLabel: '수정 요청',
+    applyPolicy: '팀장 승인 후 PI 수정 내용이 반영됩니다.',
+  })
+})
+
+const editApprovalDocumentRows = computed(() => {
+  if (!pendingEditRequest.value) return []
+
+  const { revisedSnapshot, id } = pendingEditRequest.value
+
+  return [
+    { label: '대상 PI 번호', value: id || '-' },
+    { label: '거래처', value: revisedSnapshot.clientName || '-' },
+    { label: '영문주소', value: revisedSnapshot.clientAddress || '-', fullWidth: true },
+    { label: '바이어', value: revisedSnapshot.buyerName || '-' },
+    { label: '통화', value: revisedSnapshot.currency || '-' },
+    { label: '발행일', value: revisedSnapshot.issueDate || '-' },
+    { label: '납기일', value: revisedSnapshot.deliveryDate || '-' },
+    { label: '인코텀즈', value: formatIncotermsLabel(revisedSnapshot.incoterms, revisedSnapshot.namedPlace) || '-' },
+  ]
+})
+
+const editApprovalItemRows = computed(() => {
+  if (!pendingEditRequest.value) return []
+
+  return pendingEditRequest.value.revisedSnapshot.items.map((item, index) => ({
+    id: `${item.name || 'item'}-${index}`,
+    name: item.name || '-',
+    qty: item.qty > 0 ? item.qty.toLocaleString() : '-',
+    unit: item.unit || '-',
+    unitPrice: formatCurrencyValue(pendingEditRequest.value.revisedSnapshot.currency, item.unitPrice),
+    amount: formatCurrencyValue(pendingEditRequest.value.revisedSnapshot.currency, item.amount),
+    remark: item.remark || '-',
+  }))
+})
+
+const editApprovalItemSummaryRows = computed(() => {
+  if (!pendingEditRequest.value) return []
+
+  const { revisedSnapshot } = pendingEditRequest.value
+
+  return [
+    { label: '품목 건수', value: `${revisedSnapshot.items.length}건` },
+    { label: '총액', value: revisedSnapshot.amount, emphasis: true },
+  ]
+})
+
+const deleteApprovalRequestRows = computed(() => {
+  if (!sourceRow.value || !deleteApprovalRequestOpen.value) return []
+
+  return buildApprovalRequestRows({
+    approver: getDefaultDeleteApprover(sourceRow.value),
+    requesterName: getCurrentRequesterName(),
+    requestedAt: getRequestedAt(),
+    documentStatus: DELETE_REQUEST_DOCUMENT_STATUS,
+    requestStatus: DELETE_REQUEST_STATUS,
+    requestTypeLabel: '삭제 요청',
+    applyPolicy: '팀장 승인 후 PI가 삭제 처리됩니다.',
+  })
+})
+
+const deleteApprovalDocumentRows = computed(() => {
+  if (!sourceRow.value || !deleteApprovalRequestOpen.value) return []
+
+  const snapshot = createComparableSnapshot(sourceRow.value)
+
+  return [
+    { label: '대상 PI 번호', value: sourceRow.value.id || '-' },
+    { label: '현재 상태', value: sourceRow.value.status || '-' },
+    { label: '거래처', value: snapshot.clientName || '-' },
+    { label: '영문주소', value: snapshot.clientAddress || '-', fullWidth: true },
+    { label: '바이어', value: snapshot.buyerName || '-' },
+    { label: '통화', value: snapshot.currency || '-' },
+    { label: '발행일', value: snapshot.issueDate || '-' },
+    { label: '납기일', value: snapshot.deliveryDate || '-' },
+    { label: '인코텀즈', value: formatIncotermsLabel(snapshot.incoterms, snapshot.namedPlace) || '-' },
+  ]
+})
+
+const deleteApprovalItemRows = computed(() => {
+  if (!sourceRow.value || !deleteApprovalRequestOpen.value) return []
+
+  const snapshot = createComparableSnapshot(sourceRow.value)
+
+  return snapshot.items.map((item, index) => ({
+    id: `${item.name || 'item'}-${index}`,
+    name: item.name || '-',
+    qty: item.qty > 0 ? item.qty.toLocaleString() : '-',
+    unit: item.unit || '-',
+    unitPrice: formatCurrencyValue(snapshot.currency, item.unitPrice),
+    amount: formatCurrencyValue(snapshot.currency, item.amount),
+    remark: item.remark || '-',
+  }))
+})
+
+const deleteApprovalItemSummaryRows = computed(() => {
+  if (!sourceRow.value || !deleteApprovalRequestOpen.value) return []
+
+  const snapshot = createComparableSnapshot(sourceRow.value)
+
+  return [
+    { label: '품목 건수', value: `${snapshot.items.length}건` },
+    { label: '총액', value: snapshot.amount, emphasis: true },
+  ]
+})
 
 async function loadClientRows() {
   try {
@@ -215,11 +510,12 @@ function openPreview() {
 }
 
 function handleEdit() {
+  selectedClient.value = null
   formOpen.value = true
 }
 
 function handleDelete() {
-  deleteOpen.value = true
+  deleteApprovalRequestOpen.value = true
 }
 
 function handlePrint() {
@@ -241,57 +537,56 @@ function handlePreviewPrint() {
 }
 
 function handleSave(formValue) {
-  if (!detail.value) return
+  if (!sourceRow.value) return
 
   const normalizedIncoterms = resolveIncotermState(formValue.incoterms, formValue.namedPlace)
-  const normalizedItems = (formValue.items ?? []).map((item) => {
-    const quantity = String(item.qty ?? item.quantity ?? '')
-    const unitPriceValue = parseNumericValue(item.unitPrice)
-    const amountValue = parseNumericValue(item.amount)
-
-    return {
+  const nextRow = {
+    clientName: formValue.clientName,
+    clientAddress: formValue.clientAddress ?? sourceRow.value.clientAddress ?? '',
+    clientTel: formValue.clientTel ?? sourceRow.value.clientTel ?? '',
+    clientEmail: formValue.clientEmail ?? sourceRow.value.clientEmail ?? '',
+    buyerName: formValue.buyerName,
+    currency: formValue.currency,
+    incoterms: normalizedIncoterms.code,
+    namedPlace: normalizedIncoterms.namedPlace,
+    issueDate: formatSlashDate(formValue.issueDate),
+    deliveryDate: formatSlashDate(formValue.deliveryDate),
+    itemName: formValue.items?.[0]?.name || sourceRow.value.itemName,
+    amount: formatCurrencyValue(
+      formValue.currency,
+      (formValue.items ?? []).reduce((sum, item) => sum + resolveItemAmountValue(item), 0),
+    ),
+    items: (formValue.items ?? []).map((item) => ({
       name: item.name ?? '',
-      quantity,
+      qty: String(item.qty ?? item.quantity ?? ''),
       unit: item.unit ?? '',
-      unitPrice: formatCurrencyValue(formValue.currency, unitPriceValue),
-      amount: formatCurrencyValue(formValue.currency, amountValue),
+      unitPrice: String(resolveItemUnitPriceValue(item)),
+      amount: String(resolveItemAmountValue(item)),
       remark: item.remark ?? '',
-    }
+    })),
+  }
+
+  const originalSnapshot = createComparableSnapshot(sourceRow.value)
+  const revisedSnapshot = createComparableSnapshot({
+    id: sourceRow.value.id,
+    ...sourceRow.value,
+    ...nextRow,
   })
+  const changeRows = buildChangeRows(originalSnapshot, revisedSnapshot)
 
-  const totalAmount = normalizedItems.reduce((sum, item) => sum + parseNumericValue(item.amount), 0)
+  if (!changeRows.length) {
+    warning('변경된 내용이 없습니다.')
+    return
+  }
 
-  piDocuments.value = piDocuments.value.map((row) => (
-    row.id === detail.value.id
-      ? {
-        ...row,
-        clientName: formValue.clientName,
-        clientAddress: formValue.clientAddress ?? row.clientAddress ?? '',
-        clientTel: formValue.clientTel ?? row.clientTel ?? '',
-        clientEmail: formValue.clientEmail ?? row.clientEmail ?? '',
-        buyerName: formValue.buyerName,
-        currency: formValue.currency,
-        incoterms: normalizedIncoterms.code,
-        namedPlace: normalizedIncoterms.namedPlace,
-        issueDate: formatSlashDate(formValue.issueDate),
-        deliveryDate: formatSlashDate(formValue.deliveryDate),
-        itemName: normalizedItems[0]?.name || row.itemName,
-        amount: formatCurrencyValue(formValue.currency, totalAmount),
-        totalAmount: formatCurrencyValue(formValue.currency, totalAmount),
-        items: normalizedItems.map((item) => ({
-          name: item.name,
-          qty: item.quantity,
-          unit: item.unit,
-          unitPrice: String(parseNumericValue(item.unitPrice)),
-          amount: String(parseNumericValue(item.amount)),
-          remark: item.remark ?? '',
-        })),
-      }
-      : row
-  ))
-
-  formOpen.value = false
-  success(`${detail.value?.id} 수정 폼이 연결되었습니다.`)
+  pendingEditRequest.value = {
+    id: sourceRow.value.id,
+    approver: formValue.approver || sourceRow.value.approver || '',
+    nextRow,
+    revisedSnapshot,
+    changeRows,
+  }
+  editConfirmOpen.value = true
 }
 
 function openClientSearch() {
@@ -309,11 +604,97 @@ function goToLinkedDocument(documentId) {
   router.push({ name: 'po-detail', params: { id: documentId } })
 }
 
-function confirmDelete() {
-  piDocuments.value = piDocuments.value.filter((row) => row.id !== detail.value?.id)
-  deleteOpen.value = false
-  success(`${detail.value?.id}가 삭제되었습니다.`)
-  router.push({ name: 'pi' })
+function confirmEditRequestIntent() {
+  editConfirmOpen.value = false
+  editApprovalRequestOpen.value = true
+}
+
+function cancelEditRequestIntent() {
+  editConfirmOpen.value = false
+  pendingEditRequest.value = null
+}
+
+function confirmEditApprovalRequest() {
+  if (!pendingEditRequest.value) return
+
+  const requesterName = getCurrentRequesterName()
+  const requestedAt = getRequestedAt()
+  const approvalReview = createApprovalReviewSnapshot({
+    title: 'PI 수정 결재 검토',
+    message: '요청된 변경 사항과 변경 후 문서 정보를 검토한 뒤 승인 또는 반려를 결정합니다.',
+    requestRows: editApprovalRequestRows.value,
+    documentRows: editApprovalDocumentRows.value,
+    changeRows: pendingEditRequest.value.changeRows ?? [],
+    itemRows: editApprovalItemRows.value,
+    itemSummaryRows: editApprovalItemSummaryRows.value,
+    documentSectionTitle: '수정 대상 PI 정보',
+    changeSectionTitle: '변경 사항 비교',
+    itemSectionTitle: '변경 후 PI 품목 정보',
+    helperText: '수정 요청은 승인 전까지 확정되지 않으며, 반려 시 요청 상태만 반영됩니다.',
+  })
+
+  piDocuments.value = piDocuments.value.map((row) => (
+    row.id === pendingEditRequest.value.id
+      ? {
+        ...row,
+        ...pendingEditRequest.value.nextRow,
+        approvalReview,
+        ...createEditApprovalMeta({
+          approver: pendingEditRequest.value.approver,
+          requesterName,
+          requestedAt,
+        }),
+      }
+      : row
+  ))
+
+  editApprovalRequestOpen.value = false
+  pendingEditRequest.value = null
+  formOpen.value = false
+  success(`${sourceRow.value?.id} 수정 결재 요청이 전송되었습니다.`)
+}
+
+function cancelEditApprovalRequest() {
+  editApprovalRequestOpen.value = false
+}
+
+function confirmDeleteApprovalRequest() {
+  if (!sourceRow.value) return
+
+  const requesterName = getCurrentRequesterName()
+  const requestedAt = getRequestedAt()
+  const approvalReview = createApprovalReviewSnapshot({
+    title: 'PI 삭제 결재 검토',
+    message: '선택한 PI 삭제 요청 건입니다. 문서와 품목 정보를 확인한 뒤 승인 또는 반려를 결정합니다.',
+    requestRows: deleteApprovalRequestRows.value,
+    documentRows: deleteApprovalDocumentRows.value,
+    itemRows: deleteApprovalItemRows.value,
+    itemSummaryRows: deleteApprovalItemSummaryRows.value,
+    documentSectionTitle: '삭제 대상 PI 정보',
+    itemSectionTitle: '삭제 대상 PI 품목 정보',
+    helperText: '삭제 요청은 승인 전까지 실제 삭제되지 않으며, 승인 시 문서 상태가 취소로 전환됩니다.',
+  })
+
+  piDocuments.value = piDocuments.value.map((row) => (
+    row.id === sourceRow.value.id
+      ? {
+        ...row,
+        approvalReview,
+        ...createDeleteApprovalMeta({
+          approver: getDefaultDeleteApprover(sourceRow.value),
+          requesterName,
+          requestedAt,
+        }),
+      }
+      : row
+  ))
+
+  deleteApprovalRequestOpen.value = false
+  success(`${sourceRow.value.id} 삭제 결재 요청이 전송되었습니다.`)
+}
+
+function cancelDeleteApprovalRequest() {
+  deleteApprovalRequestOpen.value = false
 }
 </script>
 
@@ -530,27 +911,36 @@ function confirmDelete() {
       :open="formOpen"
       mode="edit"
       :document="{
-        id: detail.id,
-        clientName: detail.clientName,
-        clientAddress: detail.clientAddress,
-        clientTel: detail.clientTel,
-        clientEmail: detail.clientEmail,
-        buyerName: detail.buyer,
-        country: selectedClient?.country ?? '',
-        currency: detail.currency,
-        incoterms: detail.incoterms,
-        namedPlace: detail.namedPlace,
-        issueDate: detail.issueDate,
-        deliveryDate: detail.deliveryDate,
-        approver: detail.approver,
-        items: detail.items.map((item) => ({
-          name: item.name,
-          qty: item.quantity,
-          unit: item.unit ?? 'EA',
-          unitPrice: item.unitPrice.replace(/[^0-9.]/g, ''),
-          amount: item.amount,
-          remark: item.remark ?? '',
-        })),
+        id: sourceRow?.id,
+        clientName: sourceRow?.clientName,
+        clientAddress: sourceRow?.clientAddress,
+        clientTel: sourceRow?.clientTel,
+        clientEmail: sourceRow?.clientEmail,
+        buyerName: sourceRow?.buyerName,
+        country: sourceRow?.country ?? '',
+        currency: sourceRow?.currency,
+        incoterms: sourceRow?.incoterms,
+        namedPlace: sourceRow?.namedPlace,
+        issueDate: sourceRow?.issueDate,
+        deliveryDate: sourceRow?.deliveryDate,
+        approver: sourceRow?.approver,
+        items: (sourceRow?.items ?? []).map((item) => {
+          const quantity = parseNumericValue(item.qty ?? item.quantity)
+          const amount = parseNumericValue(item.amount ?? '0')
+          const unitPrice = parseNumericValue(item.unitPrice)
+          const resolvedUnitPrice = unitPrice > 0
+            ? unitPrice
+            : (quantity > 0 && amount > 0 ? Math.round(amount / quantity) : 0)
+
+          return {
+            name: item.name,
+            qty: item.qty ?? item.quantity,
+            unit: item.unit ?? 'EA',
+            unitPrice: String(resolvedUnitPrice),
+            amount: String(amount > 0 ? amount : quantity * resolvedUnitPrice),
+            remark: item.remark ?? '',
+          }
+        }),
       }"
       :selected-client="selectedClient"
       @open-client-search="openClientSearch"
@@ -559,14 +949,54 @@ function confirmDelete() {
     />
 
     <ConfirmModal
-      :open="deleteOpen"
-      title="PI 삭제"
-      message="아래 PI를 삭제하시겠습니까?"
-      :detail="detail.id"
-      confirm-label="삭제"
-      confirm-variant="danger"
-      @confirm="confirmDelete"
-      @cancel="deleteOpen = false"
+      :open="editConfirmOpen"
+      title="PI 수정 요청"
+      message="해당 PI의 수정 결재 요청을 진행하시겠습니까?"
+      :detail="sourceRow?.id || ''"
+      confirm-label="수정 요청"
+      @confirm="confirmEditRequestIntent"
+      @cancel="cancelEditRequestIntent"
+    />
+
+    <ApprovalRequestModal
+      :open="editApprovalRequestOpen"
+      title="PI 수정 결재 요청"
+      message="변경 사항을 확인한 뒤 선택한 결재자에게 PI 수정 결재 요청을 전송하시겠습니까?"
+      :request-rows="editApprovalRequestRows"
+      request-section-title="팀장 결재 정보"
+      :document-rows="editApprovalDocumentRows"
+      :change-columns="approvalChangeColumns"
+      :change-rows="pendingEditRequest?.changeRows ?? []"
+      :item-columns="approvalItemColumns"
+      :item-rows="editApprovalItemRows"
+      :item-summary-rows="editApprovalItemSummaryRows"
+      document-section-title="수정 대상 PI 정보"
+      change-section-title="변경 사항 비교"
+      item-section-title="변경 후 PI 품목 정보"
+      helper-text="요청 후 PI는 결재대기 상태가 되며, 승인 전까지 수정 내용이 확정되지 않습니다."
+      width="max-w-6xl"
+      confirm-label="수정 요청"
+      @confirm="confirmEditApprovalRequest"
+      @cancel="cancelEditApprovalRequest"
+    />
+
+    <ApprovalRequestModal
+      :open="deleteApprovalRequestOpen"
+      title="PI 삭제 결재 요청"
+      message="선택한 PI 문서의 삭제 결재 요청을 전송하시겠습니까?"
+      :request-rows="deleteApprovalRequestRows"
+      request-section-title="팀장 결재 정보"
+      :document-rows="deleteApprovalDocumentRows"
+      :item-columns="approvalItemColumns"
+      :item-rows="deleteApprovalItemRows"
+      :item-summary-rows="deleteApprovalItemSummaryRows"
+      document-section-title="삭제 대상 PI 정보"
+      item-section-title="삭제 대상 PI 품목 정보"
+      helper-text="요청 후 PI는 결재대기 상태가 되며, 승인 전까지 실제 삭제되지 않습니다."
+      width="max-w-6xl"
+      confirm-label="삭제 요청"
+      @confirm="confirmDeleteApprovalRequest"
+      @cancel="cancelDeleteApprovalRequest"
     />
 
     <SearchModal

--- a/src/views/documents/PIPage.vue
+++ b/src/views/documents/PIPage.vue
@@ -306,9 +306,23 @@ function openEditForm(row) {
     namedPlace: normalizedIncoterms.namedPlace,
     issueDate: row.issueDate,
     deliveryDate: row.deliveryDate,
-    items: (row.items ?? []).map((item) => ({
-      ...item,
-    })),
+    items: (row.items ?? []).map((item) => {
+      const qty = parseAmount(item.qty ?? item.quantity)
+      const amount = parseAmount(item.amount)
+      const unitPrice = parseAmount(item.unitPrice)
+      const resolvedUnitPrice = unitPrice > 0
+        ? unitPrice
+        : (qty > 0 && amount > 0 ? Math.round(amount / qty) : 0)
+
+      return {
+        ...item,
+        qty: String(item.qty ?? item.quantity ?? ''),
+        unit: item.unit ?? '',
+        unitPrice: String(resolvedUnitPrice),
+        amount: String(amount > 0 ? amount : qty * resolvedUnitPrice),
+        remark: item.remark ?? item.remarks ?? '',
+      }
+    }),
   }
   formOpen.value = true
 }
@@ -327,14 +341,38 @@ function formatSlashDate(value) {
   return value ? value.replaceAll('-', '/') : '-'
 }
 
+function resolveUnitPriceValue(item) {
+  const qty = parseAmount(item.qty ?? item.quantity)
+  const unitPrice = parseAmount(item.unitPrice)
+  const amount = parseAmount(item.amount)
+
+  if (unitPrice > 0) {
+    return unitPrice
+  }
+
+  if (qty > 0 && amount > 0) {
+    return Math.round(amount / qty)
+  }
+
+  return 0
+}
+
+function resolveAmountValue(item) {
+  const qty = parseAmount(item.qty ?? item.quantity)
+  const unitPrice = resolveUnitPriceValue(item)
+  const amount = parseAmount(item.amount)
+
+  if (amount > 0) {
+    return amount
+  }
+
+  return qty * unitPrice
+}
+
 function buildRowPayload(formValue) {
   const currency = formValue.currency || 'USD'
   const totalAmount = (formValue.items ?? []).reduce((sum, item) => {
-    const qty = parseAmount(item.qty)
-    const unitPrice = parseAmount(item.unitPrice)
-    const amount = parseAmount(item.amount)
-    const calculatedAmount = amount > 0 ? amount : (qty > 0 && unitPrice > 0 ? qty * unitPrice : 0)
-    return sum + calculatedAmount
+    return sum + resolveAmountValue(item)
   }, 0)
   const matchedClient = clientRowsSource.value.find((client) => client.name === formValue.clientName)
   const nextRow = {
@@ -356,8 +394,8 @@ function buildRowPayload(formValue) {
       name: item.name ?? '',
       qty: String(item.qty ?? ''),
       unit: item.unit ?? '',
-      unitPrice: String(item.unitPrice ?? ''),
-      amount: String(item.amount ?? '0'),
+      unitPrice: String(resolveUnitPriceValue(item)),
+      amount: String(resolveAmountValue(item)),
       remark: item.remark ?? '',
     })),
   }
@@ -443,7 +481,7 @@ function getCurrentRequesterName() {
 }
 
 function getDefaultDeleteApprover(row) {
-  return row?.approver || '박리드 (영업지원 · 팀장)'
+  return row?.approver || '김영업'
 }
 
 function getRequestedAt() {
@@ -458,6 +496,41 @@ function getRequestedAt() {
 
 function buildNextPiId() {
   return `PI26${String(rowsData.value.length + 1).padStart(3, '0')}`
+}
+
+function createApprovalReviewSnapshot({
+  title,
+  message,
+  requestRows = [],
+  documentRows = [],
+  changeRows = [],
+  itemRows = [],
+  itemSummaryRows = [],
+  referenceRows = [],
+  documentSectionTitle = '문서 정보',
+  changeSectionTitle = '변경 사항',
+  itemSectionTitle = '품목 정보',
+  referenceSectionTitle = '참조 문서 정보',
+  helperText = '',
+}) {
+  return {
+    title,
+    message,
+    requestRows: requestRows.map((row) => ({ ...row })),
+    requestSectionTitle: '팀장 결재 정보',
+    documentRows: documentRows.map((row) => ({ ...row })),
+    documentSectionTitle,
+    changeColumns: changeRows.length ? approvalChangeColumns.map((column) => ({ ...column })) : [],
+    changeRows: changeRows.map((row) => ({ ...row })),
+    changeSectionTitle,
+    itemColumns: itemRows.length ? approvalItemColumns.map((column) => ({ ...column })) : [],
+    itemRows: itemRows.map((row) => ({ ...row })),
+    itemSummaryRows: itemSummaryRows.map((row) => ({ ...row })),
+    itemSectionTitle,
+    referenceRows: referenceRows.map((row) => ({ ...row })),
+    referenceSectionTitle,
+    helperText,
+  }
 }
 
 const createApprovalRequestRows = computed(() => {
@@ -639,12 +712,24 @@ function confirmCreateApprovalRequest() {
   const { nextRow } = buildRowPayload(pendingCreateFormValue.value)
   const requesterName = getCurrentRequesterName()
   const requestedAt = getRequestedAt()
+  const approvalReview = createApprovalReviewSnapshot({
+    title: 'PI 등록 결재 검토',
+    message: '선택한 결재자에게 PI 등록 결재 요청이 접수되었습니다. 아래 문서 정보를 기준으로 승인 여부를 검토합니다.',
+    requestRows: createApprovalRequestRows.value,
+    documentRows: createApprovalDocumentRows.value,
+    itemRows: createApprovalItemRows.value,
+    itemSummaryRows: createApprovalItemSummaryRows.value,
+    documentSectionTitle: 'PI 문서 정보',
+    itemSectionTitle: 'PI 품목 정보',
+    helperText: '등록 요청은 팀장 승인 후 확정되며, 승인 전까지 문서는 결재대기 상태로 유지됩니다.',
+  })
 
   rowsData.value = [
     {
       id: buildNextPiId(),
       ...nextRow,
       manager: requesterName,
+      approvalReview,
       ...createRegistrationApprovalMeta({
         approver: pendingCreateFormValue.value.approver,
         requesterName,
@@ -670,12 +755,26 @@ function confirmEditApprovalRequest() {
 
   const requesterName = getCurrentRequesterName()
   const requestedAt = getRequestedAt()
+  const approvalReview = createApprovalReviewSnapshot({
+    title: 'PI 수정 결재 검토',
+    message: '요청된 변경 사항과 변경 후 문서 정보를 검토한 뒤 승인 또는 반려를 결정합니다.',
+    requestRows: editApprovalRequestRows.value,
+    documentRows: editApprovalDocumentRows.value,
+    changeRows: pendingEditRequest.value.changeRows ?? [],
+    itemRows: editApprovalItemRows.value,
+    itemSummaryRows: editApprovalItemSummaryRows.value,
+    documentSectionTitle: '수정 대상 PI 정보',
+    changeSectionTitle: '변경 사항 비교',
+    itemSectionTitle: '변경 후 PI 품목 정보',
+    helperText: '수정 요청은 승인 전까지 확정되지 않으며, 반려 시 요청 상태만 반영됩니다.',
+  })
 
   rowsData.value = rowsData.value.map((row) => (
     row.id === pendingEditRequest.value.id
       ? {
         ...row,
         ...pendingEditRequest.value.nextRow,
+        approvalReview,
         ...createEditApprovalMeta({
           approver: pendingEditRequest.value.approver || row.approver || '',
           requesterName,
@@ -741,11 +840,23 @@ function confirmDeleteApprovalRequest() {
 
   const requesterName = getCurrentRequesterName()
   const requestedAt = getRequestedAt()
+  const approvalReview = createApprovalReviewSnapshot({
+    title: 'PI 삭제 결재 검토',
+    message: '선택한 PI 삭제 요청 건입니다. 문서와 품목 정보를 확인한 뒤 승인 또는 반려를 결정합니다.',
+    requestRows: deleteApprovalRequestRows.value,
+    documentRows: deleteApprovalDocumentRows.value,
+    itemRows: deleteApprovalItemRows.value,
+    itemSummaryRows: deleteApprovalItemSummaryRows.value,
+    documentSectionTitle: '삭제 대상 PI 정보',
+    itemSectionTitle: '삭제 대상 PI 품목 정보',
+    helperText: '삭제 요청은 승인 전까지 실제 삭제되지 않으며, 승인 시 문서 상태가 취소로 전환됩니다.',
+  })
 
   rowsData.value = rowsData.value.map((row) => (
     row.id === selectedRow.value?.id
       ? {
         ...row,
+        approvalReview,
         ...createDeleteApprovalMeta({
           approver: getDefaultDeleteApprover(selectedRow.value),
           requesterName,

--- a/src/views/documents/PODetailPage.vue
+++ b/src/views/documents/PODetailPage.vue
@@ -2,6 +2,7 @@
 import { computed, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
+import ApprovalRequestModal from '@/components/common/ApprovalRequestModal.vue'
 import BaseButton from '@/components/common/BaseButton.vue'
 import ConfirmModal from '@/components/common/ConfirmModal.vue'
 import DetailPageHeader from '@/components/common/DetailPageHeader.vue'
@@ -12,29 +13,58 @@ import PODocumentTemplate from '@/components/domain/document/PODocumentTemplate.
 import POFormModal from '@/components/domain/document/POFormModal.vue'
 import { useSearchModalLookups } from '@/composables/useSearchModalLookups'
 import { useToast } from '@/composables/useToast'
+import { useAuthStore } from '@/stores/auth'
 import { usePiDocuments } from '@/stores/piDocuments'
 import { usePoDocuments } from '@/stores/poDocuments'
-import { buildApprovalInfoRows } from '@/utils/documentApproval'
+import {
+  buildApprovalInfoRows,
+  buildApprovalRequestRows,
+  createDeleteApprovalMeta,
+  createEditApprovalMeta,
+  DELETE_REQUEST_DOCUMENT_STATUS,
+  DELETE_REQUEST_STATUS,
+  EDIT_REQUEST_DOCUMENT_STATUS,
+  EDIT_REQUEST_STATUS,
+} from '@/utils/documentApproval'
 import { openDocumentOutputByType } from '@/utils/documentOutput'
 import { clientSearchColumns } from '@/utils/searchModalColumns'
 
 const route = useRoute()
 const router = useRouter()
-const { info, success } = useToast()
+const authStore = useAuthStore()
+const { info, success, warning } = useToast()
 
 const previewOpen = ref(false)
 const formOpen = ref(false)
-const deleteOpen = ref(false)
+const editConfirmOpen = ref(false)
+const editApprovalRequestOpen = ref(false)
+const deleteApprovalRequestOpen = ref(false)
 const piSearchOpen = ref(false)
 const piSearchKeyword = ref('')
 const clientSearchOpen = ref(false)
 const clientSearchKeyword = ref('')
 const selectedPi = ref(null)
 const selectedClient = ref(null)
+const pendingEditRequest = ref(null)
 const piDocuments = usePiDocuments()
 const poDocuments = usePoDocuments()
 
 const { createClientRows } = useSearchModalLookups()
+
+const approvalItemColumns = [
+  { key: 'name', label: '품목명', align: 'left' },
+  { key: 'qty', label: '수량', align: 'right' },
+  { key: 'unit', label: '단위', align: 'center' },
+  { key: 'unitPrice', label: '단가', align: 'right' },
+  { key: 'amount', label: '금액', align: 'right' },
+  { key: 'remark', label: '비고', align: 'left' },
+]
+
+const approvalChangeColumns = [
+  { key: 'label', label: '변경 항목', align: 'left' },
+  { key: 'before', label: '원본값', align: 'left' },
+  { key: 'after', label: '변경값', align: 'left' },
+]
 
 const piRows = computed(() => {
   const keyword = piSearchKeyword.value.trim().toLowerCase()
@@ -66,6 +96,139 @@ function buildLinkedDocuments(row) {
   return linkedPi ? [{ id: linkedPi.id, status: linkedPi.status }] : []
 }
 
+function getCurrentRequesterName() {
+  return authStore.currentUser?.name || '김영업'
+}
+
+function getRequestedAt() {
+  const now = new Date()
+  const year = now.getFullYear()
+  const month = String(now.getMonth() + 1).padStart(2, '0')
+  const day = String(now.getDate()).padStart(2, '0')
+  const hours = String(now.getHours()).padStart(2, '0')
+  const minutes = String(now.getMinutes()).padStart(2, '0')
+  return `${year}/${month}/${day} ${hours}:${minutes}`
+}
+
+function getDefaultDeleteApprover(row) {
+  return row?.approver || '김영업'
+}
+
+function createComparableItem(item) {
+  const quantity = parseNumericValue(item.qty ?? item.quantity)
+  const unitPrice = parseNumericValue(item.unitPrice)
+  const amount = parseNumericValue(item.amount) || quantity * unitPrice
+
+  return {
+    name: item.name ?? '',
+    qty: quantity,
+    unit: item.unit ?? '',
+    unitPrice,
+    amount,
+    remark: item.remark ?? '',
+  }
+}
+
+function createItemDigest(items) {
+  if (!items.length) return '없음'
+
+  const firstItem = items[0]
+  const quantityLabel = firstItem.qty > 0
+    ? ` / ${firstItem.qty.toLocaleString()}${firstItem.unit ? ` ${firstItem.unit}` : ''}`
+    : ''
+  const tailLabel = items.length > 1 ? ` 외 ${items.length - 1}건` : ''
+
+  return `${firstItem.name || '품목'}${quantityLabel}${tailLabel}`
+}
+
+function createComparableSnapshot(source) {
+  const linkedPi = piDocuments.value.find((row) => row.id === (source.piId || source.linkedPiId))
+  const currency = source.currency || linkedPi?.currency || 'USD'
+  const items = (source.items?.length ? source.items : linkedPi?.items ?? []).map(createComparableItem)
+  const totalAmount = items.reduce((sum, item) => sum + item.amount, 0)
+  const issueDate = source.issueDate || '-'
+  const sourceDeliveryDate = source.sourceDeliveryDate || linkedPi?.deliveryDate || source.deliveryDate || ''
+  const deliveryDate = source.deliveryDate || sourceDeliveryDate || ''
+  const deliveryMode = source.deliveryDateOverride && deliveryDate !== sourceDeliveryDate
+    ? 'PI 기준값에서 별도 조정'
+    : 'PI 기준값 사용'
+
+  return {
+    piId: source.piId || source.linkedPiId || '',
+    clientName: source.clientName || linkedPi?.clientName || '',
+    clientAddress: source.clientAddress || linkedPi?.clientAddress || '',
+    buyerName: source.buyerName || linkedPi?.buyerName || '',
+    currency,
+    issueDate,
+    deliveryDate,
+    sourceDeliveryDate,
+    deliveryMode,
+    incoterms: source.incoterms || linkedPi?.incoterms || '',
+    namedPlace: source.namedPlace || linkedPi?.namedPlace || '',
+    items,
+    amount: formatCurrencyValue(currency, totalAmount),
+  }
+}
+
+function buildChangeRows(originalSnapshot, revisedSnapshot) {
+  return [
+    { label: '기준 PI 번호', before: originalSnapshot.piId || '-', after: revisedSnapshot.piId || '-' },
+    { label: '거래처', before: originalSnapshot.clientName || '-', after: revisedSnapshot.clientName || '-' },
+    { label: '영문주소', before: originalSnapshot.clientAddress || '-', after: revisedSnapshot.clientAddress || '-' },
+    { label: '바이어', before: originalSnapshot.buyerName || '-', after: revisedSnapshot.buyerName || '-' },
+    { label: '통화', before: originalSnapshot.currency || '-', after: revisedSnapshot.currency || '-' },
+    { label: '발행일', before: originalSnapshot.issueDate || '-', after: revisedSnapshot.issueDate || '-' },
+    { label: '납기일', before: originalSnapshot.deliveryDate || '-', after: revisedSnapshot.deliveryDate || '-' },
+    { label: '납기 처리', before: originalSnapshot.deliveryMode || '-', after: revisedSnapshot.deliveryMode || '-' },
+    {
+      label: '인코텀즈',
+      before: originalSnapshot.incoterms ? `${originalSnapshot.incoterms}${originalSnapshot.namedPlace ? ` ${originalSnapshot.namedPlace}` : ''}` : '-',
+      after: revisedSnapshot.incoterms ? `${revisedSnapshot.incoterms}${revisedSnapshot.namedPlace ? ` ${revisedSnapshot.namedPlace}` : ''}` : '-',
+    },
+    {
+      label: '품목 목록',
+      before: createItemDigest(originalSnapshot.items),
+      after: createItemDigest(revisedSnapshot.items),
+    },
+    { label: '총액', before: originalSnapshot.amount || '-', after: revisedSnapshot.amount || '-' },
+  ].filter((row) => row.before !== row.after)
+}
+
+function createApprovalReviewSnapshot({
+  title,
+  message,
+  requestRows = [],
+  documentRows = [],
+  changeRows = [],
+  itemRows = [],
+  itemSummaryRows = [],
+  referenceRows = [],
+  documentSectionTitle = '문서 정보',
+  changeSectionTitle = '변경 사항',
+  itemSectionTitle = '품목 정보',
+  referenceSectionTitle = '참조 문서 정보',
+  helperText = '',
+}) {
+  return {
+    title,
+    message,
+    requestRows: requestRows.map((row) => ({ ...row })),
+    requestSectionTitle: '팀장 결재 정보',
+    documentRows: documentRows.map((row) => ({ ...row })),
+    documentSectionTitle,
+    changeColumns: changeRows.length ? approvalChangeColumns.map((column) => ({ ...column })) : [],
+    changeRows: changeRows.map((row) => ({ ...row })),
+    changeSectionTitle,
+    itemColumns: itemRows.length ? approvalItemColumns.map((column) => ({ ...column })) : [],
+    itemRows: itemRows.map((row) => ({ ...row })),
+    itemSummaryRows: itemSummaryRows.map((row) => ({ ...row })),
+    itemSectionTitle,
+    referenceRows: referenceRows.map((row) => ({ ...row })),
+    referenceSectionTitle,
+    helperText,
+  }
+}
+
 function normalizeDetail(row) {
   if (!row) return null
 
@@ -92,12 +255,167 @@ function normalizeDetail(row) {
   }
 }
 
-const detail = computed(() => normalizeDetail(
-  poDocuments.value.find((row) => row.id === route.params.id),
+const sourceRow = computed(() => (
+  poDocuments.value.find((row) => row.id === route.params.id) ?? null
 ))
+
+const detail = computed(() => normalizeDetail(sourceRow.value))
 
 const approvalInfoRows = computed(() => buildApprovalInfoRows(detail.value))
 const linkedPiDocument = computed(() => piDocuments.value.find((row) => row.id === (detail.value?.piId || detail.value?.linkedPiId)))
+
+const editApprovalRequestRows = computed(() => {
+  if (!pendingEditRequest.value) return []
+
+  return buildApprovalRequestRows({
+    approver: pendingEditRequest.value.approver,
+    requesterName: getCurrentRequesterName(),
+    requestedAt: getRequestedAt(),
+    documentStatus: EDIT_REQUEST_DOCUMENT_STATUS,
+    requestStatus: EDIT_REQUEST_STATUS,
+    requestTypeLabel: '수정 요청',
+    applyPolicy: '팀장 승인 후 PO 수정 내용이 반영됩니다.',
+  })
+})
+
+const editApprovalDocumentRows = computed(() => {
+  if (!pendingEditRequest.value) return []
+
+  const { revisedSnapshot, id } = pendingEditRequest.value
+
+  return [
+    { label: '대상 PO 번호', value: id || '-' },
+    { label: '발행일', value: revisedSnapshot.issueDate || '-' },
+    { label: '납기일', value: revisedSnapshot.deliveryDate || '-' },
+    { label: '납기 처리', value: revisedSnapshot.deliveryMode || '-' },
+  ]
+})
+
+const editApprovalReferenceRows = computed(() => {
+  if (!pendingEditRequest.value) return []
+
+  const { revisedSnapshot } = pendingEditRequest.value
+
+  if (!revisedSnapshot.piId) return []
+
+  return [
+    { label: '기준 PI 번호', value: revisedSnapshot.piId || '-' },
+    { label: '거래처', value: revisedSnapshot.clientName || '-' },
+    { label: '영문주소', value: revisedSnapshot.clientAddress || '-', fullWidth: true },
+    { label: '바이어', value: revisedSnapshot.buyerName || '-' },
+    { label: '통화', value: revisedSnapshot.currency || '-' },
+    {
+      label: '인코텀즈',
+      value: revisedSnapshot.incoterms
+        ? `${revisedSnapshot.incoterms}${revisedSnapshot.namedPlace ? ` ${revisedSnapshot.namedPlace}` : ''}`
+        : '-',
+    },
+    { label: 'PI 기준 납기일', value: revisedSnapshot.sourceDeliveryDate || '-' },
+  ]
+})
+
+const editApprovalItemRows = computed(() => {
+  if (!pendingEditRequest.value) return []
+
+  return pendingEditRequest.value.revisedSnapshot.items.map((item, index) => ({
+    id: `${item.name || 'item'}-${index}`,
+    name: item.name || '-',
+    qty: item.qty > 0 ? item.qty.toLocaleString() : '-',
+    unit: item.unit || '-',
+    unitPrice: formatCurrencyValue(pendingEditRequest.value.revisedSnapshot.currency, item.unitPrice),
+    amount: formatCurrencyValue(pendingEditRequest.value.revisedSnapshot.currency, item.amount),
+    remark: item.remark || '-',
+  }))
+})
+
+const editApprovalItemSummaryRows = computed(() => {
+  if (!pendingEditRequest.value) return []
+
+  const { revisedSnapshot } = pendingEditRequest.value
+
+  return [
+    { label: '품목 건수', value: `${revisedSnapshot.items.length}건` },
+    { label: '총액', value: revisedSnapshot.amount, emphasis: true },
+  ]
+})
+
+const deleteApprovalRequestRows = computed(() => {
+  if (!sourceRow.value || !deleteApprovalRequestOpen.value) return []
+
+  return buildApprovalRequestRows({
+    approver: getDefaultDeleteApprover(sourceRow.value),
+    requesterName: getCurrentRequesterName(),
+    requestedAt: getRequestedAt(),
+    documentStatus: DELETE_REQUEST_DOCUMENT_STATUS,
+    requestStatus: DELETE_REQUEST_STATUS,
+    requestTypeLabel: '삭제 요청',
+    applyPolicy: '팀장 승인 후 PO가 삭제 처리됩니다.',
+  })
+})
+
+const deleteApprovalDocumentRows = computed(() => {
+  if (!sourceRow.value || !deleteApprovalRequestOpen.value) return []
+
+  const snapshot = createComparableSnapshot(sourceRow.value)
+
+  return [
+    { label: '대상 PO 번호', value: sourceRow.value.id || '-' },
+    { label: '현재 상태', value: sourceRow.value.status || '-' },
+    { label: '발행일', value: snapshot.issueDate || '-' },
+    { label: '납기일', value: snapshot.deliveryDate || '-' },
+    { label: '납기 처리', value: snapshot.deliveryMode || '-' },
+  ]
+})
+
+const deleteApprovalReferenceRows = computed(() => {
+  if (!sourceRow.value || !deleteApprovalRequestOpen.value) return []
+
+  const snapshot = createComparableSnapshot(sourceRow.value)
+
+  if (!snapshot.piId) return []
+
+  return [
+    { label: '기준 PI 번호', value: snapshot.piId || '-' },
+    { label: '거래처', value: snapshot.clientName || '-' },
+    { label: '영문주소', value: snapshot.clientAddress || '-', fullWidth: true },
+    { label: '바이어', value: snapshot.buyerName || '-' },
+    { label: '통화', value: snapshot.currency || '-' },
+    {
+      label: '인코텀즈',
+      value: snapshot.incoterms
+        ? `${snapshot.incoterms}${snapshot.namedPlace ? ` ${snapshot.namedPlace}` : ''}`
+        : '-',
+    },
+    { label: 'PI 기준 납기일', value: snapshot.sourceDeliveryDate || '-' },
+  ]
+})
+
+const deleteApprovalItemRows = computed(() => {
+  if (!sourceRow.value || !deleteApprovalRequestOpen.value) return []
+
+  const snapshot = createComparableSnapshot(sourceRow.value)
+
+  return snapshot.items.map((item, index) => ({
+    id: `${item.name || 'item'}-${index}`,
+    name: item.name || '-',
+    qty: item.qty > 0 ? item.qty.toLocaleString() : '-',
+    unit: item.unit || '-',
+    unitPrice: formatCurrencyValue(snapshot.currency, item.unitPrice),
+    amount: formatCurrencyValue(snapshot.currency, item.amount),
+    remark: item.remark || '-',
+  }))
+})
+
+const deleteApprovalItemSummaryRows = computed(() => {
+  if (!sourceRow.value || !deleteApprovalRequestOpen.value) return []
+
+  const snapshot = createComparableSnapshot(sourceRow.value)
+
+  return [
+    { label: '품목 건수', value: `${snapshot.items.length}건` },
+    { label: '총액', value: snapshot.amount, emphasis: true },
+  ]
+})
 
 const previewFields = computed(() => {
   if (!detail.value) return []
@@ -134,11 +452,13 @@ function openPreview() {
 }
 
 function handleEdit() {
+  selectedPi.value = null
+  selectedClient.value = null
   formOpen.value = true
 }
 
 function handleDelete() {
-  deleteOpen.value = true
+  deleteApprovalRequestOpen.value = true
 }
 
 function handlePrint() {
@@ -164,11 +484,11 @@ function formatSlashDate(value) {
 }
 
 function handleSave(formValue) {
-  if (!detail.value) return
+  if (!sourceRow.value) return
 
   const linkedPi = piDocuments.value.find((row) => row.id === formValue.linkedPiId)
-  const currency = linkedPi?.currency || formValue.currency || detail.value.currency || 'USD'
-  const items = (linkedPi?.items ?? detail.value.items ?? []).map((item) => ({
+  const currency = linkedPi?.currency || formValue.currency || sourceRow.value.currency || 'USD'
+  const items = (linkedPi?.items ?? sourceRow.value.items ?? []).map((item) => ({
     name: item.name ?? '',
     qty: String(item.qty ?? item.quantity ?? ''),
     unit: item.unit ?? 'EA',
@@ -177,34 +497,47 @@ function handleSave(formValue) {
     remark: item.remark ?? '',
   }))
   const totalAmount = items.reduce((sum, item) => sum + parseNumericValue(item.amount), 0)
+  const nextRow = {
+    piId: formValue.linkedPiId || '',
+    linkedPiId: formValue.linkedPiId || '',
+    clientName: linkedPi?.clientName || formValue.clientName || sourceRow.value.clientName,
+    clientAddress: linkedPi?.clientAddress || sourceRow.value.clientAddress || '',
+    buyerName: linkedPi?.buyerName || sourceRow.value.buyerName || '',
+    currency,
+    country: linkedPi?.country || sourceRow.value.country || '-',
+    itemName: items[0]?.name || sourceRow.value.itemName,
+    amount: formatCurrencyValue(currency, totalAmount),
+    totalAmount: formatCurrencyValue(currency, totalAmount),
+    incoterms: linkedPi?.incoterms || sourceRow.value.incoterms || '',
+    namedPlace: linkedPi?.namedPlace || sourceRow.value.namedPlace || '',
+    deliveryDate: formatSlashDate(formValue.deliveryDate),
+    sourceDeliveryDate: formatSlashDate(formValue.sourceDeliveryDate),
+    deliveryDateOverride: Boolean(formValue.linkedPiId && formValue.deliveryDateOverride),
+    approver: formValue.approver || sourceRow.value.approver || '',
+    items,
+  }
 
-  poDocuments.value = poDocuments.value.map((row) => (
-    row.id === detail.value.id
-      ? {
-        ...row,
-        piId: formValue.linkedPiId || '',
-        linkedPiId: formValue.linkedPiId || '',
-        clientName: linkedPi?.clientName || formValue.clientName || row.clientName,
-        clientAddress: linkedPi?.clientAddress || row.clientAddress || '',
-        buyerName: linkedPi?.buyerName || row.buyerName || '',
-        currency,
-        country: linkedPi?.country || row.country || '-',
-        itemName: items[0]?.name || row.itemName,
-        amount: formatCurrencyValue(currency, totalAmount),
-        totalAmount: formatCurrencyValue(currency, totalAmount),
-        incoterms: linkedPi?.incoterms || row.incoterms || '',
-        namedPlace: linkedPi?.namedPlace || row.namedPlace || '',
-        deliveryDate: formatSlashDate(formValue.deliveryDate),
-        sourceDeliveryDate: formatSlashDate(formValue.sourceDeliveryDate),
-        deliveryDateOverride: Boolean(formValue.linkedPiId && formValue.deliveryDateOverride),
-        approver: formValue.approver || row.approver || '',
-        items,
-      }
-      : row
-  ))
+  const originalSnapshot = createComparableSnapshot(sourceRow.value)
+  const revisedSnapshot = createComparableSnapshot({
+    id: sourceRow.value.id,
+    ...sourceRow.value,
+    ...nextRow,
+  })
+  const changeRows = buildChangeRows(originalSnapshot, revisedSnapshot)
 
-  formOpen.value = false
-  success(`${detail.value?.id} 수정 내용이 반영되었습니다.`)
+  if (!changeRows.length) {
+    warning('변경된 내용이 없습니다.')
+    return
+  }
+
+  pendingEditRequest.value = {
+    id: sourceRow.value.id,
+    approver: formValue.approver || sourceRow.value.approver || '',
+    nextRow,
+    revisedSnapshot,
+    changeRows,
+  }
+  editConfirmOpen.value = true
 }
 
 function openPiSearch() {
@@ -238,11 +571,101 @@ function goToLinkedDocument(documentId) {
   }
 }
 
-function confirmDelete() {
-  poDocuments.value = poDocuments.value.filter((row) => row.id !== detail.value?.id)
-  deleteOpen.value = false
-  success(`${detail.value?.id}가 삭제되었습니다.`)
-  router.push({ name: 'po' })
+function confirmEditRequestIntent() {
+  editConfirmOpen.value = false
+  editApprovalRequestOpen.value = true
+}
+
+function cancelEditRequestIntent() {
+  editConfirmOpen.value = false
+  pendingEditRequest.value = null
+}
+
+function confirmEditApprovalRequest() {
+  if (!pendingEditRequest.value) return
+
+  const requesterName = getCurrentRequesterName()
+  const requestedAt = getRequestedAt()
+  const approvalReview = createApprovalReviewSnapshot({
+    title: 'PO 수정 결재 검토',
+    message: '요청된 변경 사항과 연결 PI 기준 정보를 함께 검토한 뒤 승인 또는 반려를 결정합니다.',
+    requestRows: editApprovalRequestRows.value,
+    documentRows: editApprovalDocumentRows.value,
+    changeRows: pendingEditRequest.value.changeRows ?? [],
+    itemRows: editApprovalItemRows.value,
+    itemSummaryRows: editApprovalItemSummaryRows.value,
+    referenceRows: editApprovalReferenceRows.value,
+    documentSectionTitle: '수정 대상 PO 정보',
+    changeSectionTitle: '변경 사항 비교',
+    itemSectionTitle: '변경 후 PO 품목 정보',
+    referenceSectionTitle: '연결 PI 정보',
+    helperText: '수정 요청은 승인 전까지 확정되지 않으며, 반려 시 요청 상태만 반영됩니다.',
+  })
+
+  poDocuments.value = poDocuments.value.map((row) => (
+    row.id === pendingEditRequest.value.id
+      ? {
+        ...row,
+        ...pendingEditRequest.value.nextRow,
+        approvalReview,
+        ...createEditApprovalMeta({
+          approver: pendingEditRequest.value.approver,
+          requesterName,
+          requestedAt,
+        }),
+      }
+      : row
+  ))
+
+  editApprovalRequestOpen.value = false
+  pendingEditRequest.value = null
+  formOpen.value = false
+  success(`${sourceRow.value?.id} 수정 결재 요청이 전송되었습니다.`)
+}
+
+function cancelEditApprovalRequest() {
+  editApprovalRequestOpen.value = false
+}
+
+function confirmDeleteApprovalRequest() {
+  if (!sourceRow.value) return
+
+  const requesterName = getCurrentRequesterName()
+  const requestedAt = getRequestedAt()
+  const approvalReview = createApprovalReviewSnapshot({
+    title: 'PO 삭제 결재 검토',
+    message: '선택한 PO 삭제 요청 건입니다. 문서와 품목 정보를 확인한 뒤 승인 또는 반려를 결정합니다.',
+    requestRows: deleteApprovalRequestRows.value,
+    documentRows: deleteApprovalDocumentRows.value,
+    itemRows: deleteApprovalItemRows.value,
+    itemSummaryRows: deleteApprovalItemSummaryRows.value,
+    referenceRows: deleteApprovalReferenceRows.value,
+    documentSectionTitle: '삭제 대상 PO 정보',
+    itemSectionTitle: '삭제 대상 PO 품목 정보',
+    referenceSectionTitle: '연결 PI 정보',
+    helperText: '삭제 요청은 승인 전까지 실제 삭제되지 않으며, 승인 시 문서 상태가 취소로 전환됩니다.',
+  })
+
+  poDocuments.value = poDocuments.value.map((row) => (
+    row.id === sourceRow.value.id
+      ? {
+        ...row,
+        approvalReview,
+        ...createDeleteApprovalMeta({
+          approver: getDefaultDeleteApprover(sourceRow.value),
+          requesterName,
+          requestedAt,
+        }),
+      }
+      : row
+  ))
+
+  deleteApprovalRequestOpen.value = false
+  success(`${sourceRow.value.id} 삭제 결재 요청이 전송되었습니다.`)
+}
+
+function cancelDeleteApprovalRequest() {
+  deleteApprovalRequestOpen.value = false
 }
 </script>
 
@@ -463,14 +886,14 @@ function confirmDelete() {
       :open="formOpen"
       mode="edit"
       :document="{
-        id: detail.id,
-        piId: detail.linkedDocuments.find((document) => document.id.startsWith('PI'))?.id ?? '',
-        clientName: detail.clientName,
-        currency: detail.currency,
-        deliveryDate: detail.deliveryDate,
-        sourceDeliveryDate: detail.sourceDeliveryDate,
-        deliveryDateOverride: detail.deliveryDateOverride,
-        approver: detail.approver,
+        id: sourceRow?.id,
+        piId: sourceRow?.piId || sourceRow?.linkedPiId || '',
+        clientName: sourceRow?.clientName,
+        currency: sourceRow?.currency,
+        deliveryDate: sourceRow?.deliveryDate,
+        sourceDeliveryDate: sourceRow?.sourceDeliveryDate,
+        deliveryDateOverride: sourceRow?.deliveryDateOverride,
+        approver: sourceRow?.approver,
       }"
       :selected-pi="selectedPi"
       :selected-client="selectedClient"
@@ -481,14 +904,58 @@ function confirmDelete() {
     />
 
     <ConfirmModal
-      :open="deleteOpen"
-      title="PO 삭제"
-      message="아래 PO를 삭제하시겠습니까?"
-      :detail="detail.id"
-      confirm-label="삭제"
-      confirm-variant="danger"
-      @confirm="confirmDelete"
-      @cancel="deleteOpen = false"
+      :open="editConfirmOpen"
+      title="PO 수정 요청"
+      message="해당 PO의 수정 결재 요청을 진행하시겠습니까?"
+      :detail="sourceRow?.id || ''"
+      confirm-label="수정 요청"
+      @confirm="confirmEditRequestIntent"
+      @cancel="cancelEditRequestIntent"
+    />
+
+    <ApprovalRequestModal
+      :open="editApprovalRequestOpen"
+      title="PO 수정 결재 요청"
+      message="변경 사항을 확인한 뒤 선택한 결재자에게 PO 수정 결재 요청을 전송하시겠습니까?"
+      :request-rows="editApprovalRequestRows"
+      request-section-title="팀장 결재 정보"
+      :document-rows="editApprovalDocumentRows"
+      :change-columns="approvalChangeColumns"
+      :change-rows="pendingEditRequest?.changeRows ?? []"
+      :item-columns="approvalItemColumns"
+      :item-rows="editApprovalItemRows"
+      :item-summary-rows="editApprovalItemSummaryRows"
+      :reference-rows="editApprovalReferenceRows"
+      document-section-title="수정 대상 PO 정보"
+      change-section-title="변경 사항 비교"
+      item-section-title="변경 후 PO 품목 정보"
+      reference-section-title="연결 PI 정보"
+      helper-text="요청 후 PO는 결재대기 상태가 되며, 승인 전까지 수정 내용이 확정되지 않습니다."
+      width="max-w-6xl"
+      confirm-label="수정 요청"
+      @confirm="confirmEditApprovalRequest"
+      @cancel="cancelEditApprovalRequest"
+    />
+
+    <ApprovalRequestModal
+      :open="deleteApprovalRequestOpen"
+      title="PO 삭제 결재 요청"
+      message="선택한 PO 문서의 삭제 결재 요청을 전송하시겠습니까?"
+      :request-rows="deleteApprovalRequestRows"
+      request-section-title="팀장 결재 정보"
+      :document-rows="deleteApprovalDocumentRows"
+      :item-columns="approvalItemColumns"
+      :item-rows="deleteApprovalItemRows"
+      :item-summary-rows="deleteApprovalItemSummaryRows"
+      :reference-rows="deleteApprovalReferenceRows"
+      document-section-title="삭제 대상 PO 정보"
+      item-section-title="삭제 대상 PO 품목 정보"
+      reference-section-title="연결 PI 정보"
+      helper-text="요청 후 PO는 결재대기 상태가 되며, 승인 전까지 실제 삭제되지 않습니다."
+      width="max-w-6xl"
+      confirm-label="삭제 요청"
+      @confirm="confirmDeleteApprovalRequest"
+      @cancel="cancelDeleteApprovalRequest"
     />
 
     <SearchModal

--- a/src/views/documents/POPage.vue
+++ b/src/views/documents/POPage.vue
@@ -333,7 +333,7 @@ function getCurrentRequesterName() {
 }
 
 function getDefaultDeleteApprover(row) {
-  return row?.approver || '박리드 (영업지원 · 팀장)'
+  return row?.approver || '김영업'
 }
 
 function getRequestedAt() {
@@ -348,6 +348,41 @@ function getRequestedAt() {
 
 function buildNextPoId() {
   return `PO26${String(rowsData.value.length + 1).padStart(3, '0')}`
+}
+
+function createApprovalReviewSnapshot({
+  title,
+  message,
+  requestRows = [],
+  documentRows = [],
+  changeRows = [],
+  itemRows = [],
+  itemSummaryRows = [],
+  referenceRows = [],
+  documentSectionTitle = '문서 정보',
+  changeSectionTitle = '변경 사항',
+  itemSectionTitle = '품목 정보',
+  referenceSectionTitle = '참조 문서 정보',
+  helperText = '',
+}) {
+  return {
+    title,
+    message,
+    requestRows: requestRows.map((row) => ({ ...row })),
+    requestSectionTitle: '팀장 결재 정보',
+    documentRows: documentRows.map((row) => ({ ...row })),
+    documentSectionTitle,
+    changeColumns: changeRows.length ? approvalChangeColumns.map((column) => ({ ...column })) : [],
+    changeRows: changeRows.map((row) => ({ ...row })),
+    changeSectionTitle,
+    itemColumns: itemRows.length ? approvalItemColumns.map((column) => ({ ...column })) : [],
+    itemRows: itemRows.map((row) => ({ ...row })),
+    itemSummaryRows: itemSummaryRows.map((row) => ({ ...row })),
+    itemSectionTitle,
+    referenceRows: referenceRows.map((row) => ({ ...row })),
+    referenceSectionTitle,
+    helperText,
+  }
 }
 
 const createApprovalRequestRows = computed(() => {
@@ -588,12 +623,26 @@ function confirmCreateApprovalRequest() {
   const nextRow = buildRowPayload(pendingCreateFormValue.value)
   const requesterName = getCurrentRequesterName()
   const requestedAt = getRequestedAt()
+  const approvalReview = createApprovalReviewSnapshot({
+    title: 'PO 등록 결재 검토',
+    message: '선택한 결재자에게 PO 등록 결재 요청이 접수되었습니다. 연결 PI 기준 정보와 품목 내역을 검토합니다.',
+    requestRows: createApprovalRequestRows.value,
+    documentRows: createApprovalDocumentRows.value,
+    itemRows: createApprovalItemRows.value,
+    itemSummaryRows: createApprovalItemSummaryRows.value,
+    referenceRows: createApprovalReferenceRows.value,
+    documentSectionTitle: 'PO 문서 정보',
+    itemSectionTitle: '연결 PI 기준 품목',
+    referenceSectionTitle: '연결 PI 정보',
+    helperText: '등록 요청은 팀장 승인 후 확정되며, 승인 전까지 문서는 결재대기 상태로 유지됩니다.',
+  })
 
   rowsData.value = [
     {
       id: buildNextPoId(),
       ...nextRow,
       manager: requesterName,
+      approvalReview,
       ...createRegistrationApprovalMeta({
         approver: pendingCreateFormValue.value.approver,
         requesterName,
@@ -620,12 +669,28 @@ function confirmEditApprovalRequest() {
 
   const requesterName = getCurrentRequesterName()
   const requestedAt = getRequestedAt()
+  const approvalReview = createApprovalReviewSnapshot({
+    title: 'PO 수정 결재 검토',
+    message: '요청된 변경 사항과 연결 PI 기준 정보를 함께 검토한 뒤 승인 또는 반려를 결정합니다.',
+    requestRows: editApprovalRequestRows.value,
+    documentRows: editApprovalDocumentRows.value,
+    changeRows: pendingEditRequest.value.changeRows ?? [],
+    itemRows: editApprovalItemRows.value,
+    itemSummaryRows: editApprovalItemSummaryRows.value,
+    referenceRows: editApprovalReferenceRows.value,
+    documentSectionTitle: '수정 대상 PO 정보',
+    changeSectionTitle: '변경 사항 비교',
+    itemSectionTitle: '변경 후 PO 품목 정보',
+    referenceSectionTitle: '연결 PI 정보',
+    helperText: '수정 요청은 승인 전까지 확정되지 않으며, 반려 시 요청 상태만 반영됩니다.',
+  })
 
   rowsData.value = rowsData.value.map((row) => (
     row.id === pendingEditRequest.value.id
       ? {
         ...row,
         ...pendingEditRequest.value.nextRow,
+        approvalReview,
         ...createEditApprovalMeta({
           approver: pendingEditRequest.value.approver || row.approver || '',
           requesterName,
@@ -691,11 +756,25 @@ function confirmDeleteApprovalRequest() {
 
   const requesterName = getCurrentRequesterName()
   const requestedAt = getRequestedAt()
+  const approvalReview = createApprovalReviewSnapshot({
+    title: 'PO 삭제 결재 검토',
+    message: '선택한 PO 삭제 요청 건입니다. 연결 PI와 품목 정보를 확인한 뒤 승인 또는 반려를 결정합니다.',
+    requestRows: deleteApprovalRequestRows.value,
+    documentRows: deleteApprovalDocumentRows.value,
+    itemRows: deleteApprovalItemRows.value,
+    itemSummaryRows: deleteApprovalItemSummaryRows.value,
+    referenceRows: deleteApprovalReferenceRows.value,
+    documentSectionTitle: '삭제 대상 PO 정보',
+    itemSectionTitle: '삭제 대상 PO 품목 정보',
+    referenceSectionTitle: '연결 PI 정보',
+    helperText: '삭제 요청은 승인 전까지 실제 삭제되지 않으며, 승인 시 문서 상태가 취소로 전환됩니다.',
+  })
 
   rowsData.value = rowsData.value.map((row) => (
     row.id === selectedRow.value?.id
       ? {
         ...row,
+        approvalReview,
         ...createDeleteApprovalMeta({
           approver: getDefaultDeleteApprover(selectedRow.value),
           requesterName,


### PR DESCRIPTION
## 📋 작업 내용

<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
  - PI / PO 결재 흐름에서 권한 기준과 컨펌 모달 동작을 정리했습니다.
  - PI 수정 폼에서 기존 문서 품목명과 단가가 정상적으로 보이도록 보완했습니다.
  - 대시보드 결재 검토 화면에서 승인 / 반려 전 컨펌 모달이 정상적으로 동작하도록 수정했습니다.
  - PI 품목 추가 시 기본 품목이 자동 입력되지 않도록 변경했습니다.



## 🔗 관련 이슈

<!-- 관련 이슈 번호를 적어주세요 (자동으로 이슈가 닫힙니다) -->
- closes #173 

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->
<img width="2302" height="1618" alt="image" src="https://github.com/user-attachments/assets/4807181e-ad93-45d2-b059-bfa4139ac885" />



## ✅ 체크리스트

  - [x] 정상 동작 확인
  - [x] 불필요한 코드/주석 제거
  - [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

<!-- 리뷰할 때 중점적으로 봐줬으면 하는 부분이 있다면 적어주세요 -->
  - 이번 작업은 결재 흐름의 실제 사용성 문제와 PI 수정 폼의 품목 입력 문제를 함께 정리하는 데 초점을 맞췄습니다.
  - 결재자 후보는 영업 문서 결재 주체에 맞게 영업팀장만 표시되도록 좁혔습니다.
  - PI 수정 시 기존 문서 품목이 현재 마스터와 다르더라도 품목명과 단가가 최대한 복구되도록 보정 로직을 추가했습니다.

