### PR TITLE
[fix] 재전송 날짜 포맷 로케일 의존 제거 및 PO 검색 TypeError 방어 처리

### DIFF
--- a/src/views/activity/ActivityCreatePage.vue
+++ b/src/views/activity/ActivityCreatePage.vue
@@ -186,7 +186,7 @@ const filteredPoList = computed(() => {
   if (!poKeyword.value) return poList.value
   const kw = poKeyword.value.toLowerCase()
   return poList.value.filter(
-    (p) => p.id.toLowerCase().includes(kw) || p.title.toLowerCase().includes(kw),
+    (p) => p.id.toLowerCase().includes(kw) || (p.title ?? '').toLowerCase().includes(kw),
   )
 })
 

--- a/src/views/emails/EmailListPage.vue
+++ b/src/views/emails/EmailListPage.vue
@@ -164,8 +164,7 @@ async function resendEmail() {
     const newRecord = {
       ...rest,
       status: '발송',
-      sentAt: new Date().toLocaleDateString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit' })
-        .replace(/\. /g, '/').replace('.', ''),
+      sentAt: (() => { const d = new Date(); return `${d.getFullYear()}/${String(d.getMonth() + 1).padStart(2, '0')}/${String(d.getDate()).padStart(2, '0')}` })(),
     }
     await api.post('/activityEmails', newRecord)
     closeDetail()


### PR DESCRIPTION
## 📋 작업 내용

<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
- `EmailListPage` 메일 재전송 시 `toLocaleDateString('ko-KR')` 로케일 의존 제거 → `getFullYear/Month/Date` 명시적
  포맷으로 교체
- `ActivityCreatePage` PO 검색 필터에서 `p.title`이 없는 데이터에 대한 TypeError 방어 처리 (`(p.title ??
  '').toLowerCase()`)


## 🔗 관련 이슈

<!-- 관련 이슈 번호를 적어주세요 (자동으로 이슈가 닫힙니다) -->
- closes #175 

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->



## ✅ 체크리스트

- [ ] 정상 동작 확인
- [ ] 불필요한 코드/주석 제거
- [ ] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

<!-- 리뷰할 때 중점적으로 봐줬으면 하는 부분이 있다면 적어주세요 -->
- 날짜 포맷 함수는 `ActivityPackagePage`의 `todayKr()`와 동일한 방식으로 통일했습니다

