### PR TITLE
[refactor] 출하팀 대시보드 카드를 출하현황과 완료 대기 기준으로 정리

### DIFF
--- a/src/views/DashboardPage.vue
+++ b/src/views/DashboardPage.vue
@@ -6,43 +6,24 @@ import BaseCard from '@/components/common/BaseCard.vue'
 import ConfirmModal from '@/components/common/ConfirmModal.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
 import { useAuthStore } from '@/stores/auth'
+import { useCiDocuments } from '@/stores/ciDocuments'
+import { usePlDocuments } from '@/stores/plDocuments'
 import { usePiDocuments } from '@/stores/piDocuments'
 import { usePoDocuments } from '@/stores/poDocuments'
+import { useProductionOrderDocuments } from '@/stores/productionOrderDocuments'
+import { useShipmentStatusDocuments } from '@/stores/shipmentStatusDocuments'
 
 const router = useRouter()
 const authStore = useAuthStore()
+const ciDocuments = useCiDocuments()
+const plDocuments = usePlDocuments()
 const piDocuments = usePiDocuments()
 const poDocuments = usePoDocuments()
+const productionOrderDocuments = useProductionOrderDocuments()
+const shipmentStatusDocuments = useShipmentStatusDocuments()
 const selectedRequest = ref(null)
 const decisionConfirmOpen = ref(false)
 const pendingDecision = ref('')
-
-const summaryCards = ref([
-  {
-    id: 'pi',
-    title: 'PI 문서',
-    count: '3',
-    status: '확정',
-    helper: '최근 발행 2026/03/10',
-    to: '/pi',
-  },
-  {
-    id: 'po',
-    title: 'PO 문서',
-    count: '3',
-    status: '발송',
-    helper: '최근 발행 2026/03/03',
-    to: '/po',
-  },
-  {
-    id: 'cipl',
-    title: 'CI/PL 문서',
-    count: '1',
-    status: '준비완료',
-    helper: '최근 발행 2026/03/12',
-    to: '/ci',
-  },
-])
 
 const shipmentItems = [
   {
@@ -110,11 +91,128 @@ const recentActivities = [
 ]
 
 const currentUser = computed(() => authStore.currentUser ?? null)
+const isAdmin = computed(() => currentUser.value?.role === 'admin')
+const isProductionUser = computed(() => currentUser.value?.role === 'production')
+const isShippingUser = computed(() => currentUser.value?.role === 'shipping')
+const isSalesUser = computed(() => currentUser.value?.role === 'sales')
 const isSalesManager = computed(() => currentUser.value?.role === 'sales' && Number(currentUser.value?.positionId) === 1)
 const isSalesMember = computed(() => currentUser.value?.role === 'sales' && Number(currentUser.value?.positionId) === 2)
 const canApproveRequests = computed(() => isSalesManager.value)
 const showApprovalSection = computed(() => canApproveRequests.value || isSalesMember.value)
 const requestSectionTitle = computed(() => (canApproveRequests.value ? '결재 요청함' : '내 요청 현황'))
+
+function parseDocumentDate(value) {
+  const normalized = String(value ?? '').trim().replace(/\./g, '-').replace(/\//g, '-')
+  if (!normalized) return 0
+  return new Date(normalized).getTime() || 0
+}
+
+function getLatestDocument(rows, dateField = 'issueDate') {
+  return [...rows].sort((a, b) => parseDocumentDate(b?.[dateField]) - parseDocumentDate(a?.[dateField]))[0] ?? null
+}
+
+const piCard = computed(() => {
+  const latest = getLatestDocument(piDocuments.value)
+
+  return {
+    id: 'pi',
+    title: 'PI 관리',
+    count: String(piDocuments.value.length),
+    status: latest?.status || '-',
+    helper: latest?.issueDate ? `최근 발행 ${latest.issueDate}` : '문서 없음',
+    to: '/pi',
+  }
+})
+
+const poCard = computed(() => {
+  const latest = getLatestDocument(poDocuments.value)
+
+  return {
+    id: 'po',
+    title: 'PO 관리',
+    count: String(poDocuments.value.length),
+    status: latest?.status || '-',
+    helper: latest?.issueDate ? `최근 발행 ${latest.issueDate}` : '문서 없음',
+    to: '/po',
+  }
+})
+
+const ciplCard = computed(() => {
+  const mergedRows = [...ciDocuments.value, ...plDocuments.value]
+  const latest = getLatestDocument(mergedRows)
+
+  return {
+    id: 'cipl',
+    title: 'CI/PL 관리',
+    count: String(mergedRows.length),
+    status: latest?.status || '-',
+    helper: latest?.issueDate ? `최근 발행 ${latest.issueDate}` : '문서 없음',
+    to: '/ci',
+  }
+})
+
+const productionCard = computed(() => {
+  const totalCount = productionOrderDocuments.value.length
+  const inProgressCount = productionOrderDocuments.value.filter((row) => row.status === '진행중').length
+  const completedCount = productionOrderDocuments.value.filter((row) => row.status === '생산완료').length
+
+  return {
+    id: 'production',
+    title: '생산 관리',
+    count: String(totalCount),
+    status: inProgressCount > 0 ? '진행중' : '생산완료',
+    helper: `진행중 ${inProgressCount}건 · 완료 ${completedCount}건`,
+    to: '/production',
+  }
+})
+
+const shipmentsCard = computed(() => {
+  const totalCount = shipmentStatusDocuments.value.length
+  const preparingCount = shipmentStatusDocuments.value.filter((row) => row.status !== '출하완료').length
+  const completedCount = shipmentStatusDocuments.value.filter((row) => row.status === '출하완료').length
+
+  return {
+    id: 'shipments',
+    title: '출하현황',
+    count: String(totalCount),
+    status: preparingCount > 0 ? '출하준비' : '출하완료',
+    helper: `출하준비 ${preparingCount}건 · 완료 ${completedCount}건`,
+    to: '/shipments',
+  }
+})
+
+const shipmentPendingCard = computed(() => {
+  const pendingCount = shipmentStatusDocuments.value.filter((row) => row.status !== '출하완료').length
+  const latestPending = getLatestDocument(
+    shipmentStatusDocuments.value.filter((row) => row.status !== '출하완료'),
+    'dueDate',
+  )
+
+  return {
+    id: 'shipment-pending',
+    title: '출하완료 대기',
+    count: String(pendingCount),
+    status: '출하준비',
+    helper: latestPending?.dueDate ? `가장 빠른 납기 ${latestPending.dueDate}` : '대기 건 없음',
+    to: { path: '/shipments', query: { status: '출하준비' } },
+  }
+})
+
+const summaryCards = computed(() => {
+  if (isProductionUser.value) {
+    return [productionCard.value]
+  }
+
+  if (isShippingUser.value) {
+    return [shipmentsCard.value, shipmentPendingCard.value]
+  }
+
+  if (isSalesUser.value || isAdmin.value) {
+    return [piCard.value, poCard.value, ciplCard.value]
+  }
+
+  return []
+})
 
 function parseRequestedAt(value) {
   const normalized = String(value ?? '').trim()
@@ -351,7 +449,11 @@ function goToShipmentItem(item) {
 
 <template>
   <div class="fade-in space-y-6">
-    <section class="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+    <section
+      v-if="summaryCards.length"
+      class="grid gap-4 sm:grid-cols-2 xl:grid-cols-3"
+      :class="{ 'xl:grid-cols-2': summaryCards.length === 2, 'xl:grid-cols-1': summaryCards.length === 1 }"
+    >
       <RouterLink
         v-for="card in summaryCards"
         :key="card.id"
@@ -362,7 +464,19 @@ function goToShipmentItem(item) {
           <div class="flex h-10 w-10 items-center justify-center rounded-lg bg-slate-50">
             <i
               class="fas text-sm text-slate-500"
-              :class="card.id === 'pi' ? 'fa-file-invoice' : card.id === 'po' ? 'fa-file-contract' : 'fa-file-pdf'"
+              :class="
+                card.id === 'pi'
+                  ? 'fa-file-invoice'
+                  : card.id === 'po'
+                    ? 'fa-file-contract'
+                    : card.id === 'cipl'
+                      ? 'fa-file-pdf'
+                      : card.id === 'production'
+                        ? 'fa-industry'
+                        : card.id === 'shipment-orders'
+                          ? 'fa-truck-loading'
+                          : 'fa-shipping-fast'
+              "
             />
           </div>
           <StatusBadge :value="card.status" />


### PR DESCRIPTION
## 📋 작업 내용

<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
  - 메인 대시보드 상단 카드 노출 기준을 역할별로 정리했습니다.
  - 영업팀 / 관리자는 기존 문서 중심 카드(PI / PO / CI·PL)를 유지합니다.
  - 생산팀은 `생산 관리` 카드만 보이도록 변경했습니다.
  - 출하팀은 `출하현황`, `출하완료 대기` 카드만 보이도록 변경했습니다.
  - 역할별 카드 개수에 맞춰 상단 그리드 레이아웃도 함께 정리했습니다.
  - 결재 영역은 기존처럼 영업팀 기준으로만 유지해 역할 충돌이 없도록 했습니다.


## 🔗 관련 이슈

<!-- 관련 이슈 번호를 적어주세요 (자동으로 이슈가 닫힙니다) -->
- closes #

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->
# 생산팀 대시보드
<img width="3372" height="1686" alt="image" src="https://github.com/user-attachments/assets/e68fb112-ea89-4b5c-a524-b7d11389c767" />

# 출하팀 대시보드
<img width="3370" height="1694" alt="image" src="https://github.com/user-attachments/assets/92fe8b1e-4dd8-43a6-b985-f9d6862b3895" />



## ✅ 체크리스트

  - [x] 정상 동작 확인
  - [x] 불필요한 코드/주석 제거
  - [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

<!-- 리뷰할 때 중점적으로 봐줬으면 하는 부분이 있다면 적어주세요 -->

  - 이번 작업은 같은 대시보드 레이아웃을 유지하되, 사용자 역할에 따라 상단 카드만 업무 중심으로 재구성하는 데 초점을 맞췄습니다.
  - 생산팀 / 출하팀에게는 영업 문서 카드가 불필요하다고 판단해 제거했고, 대신 각 부서가 실제로 바로 확인해야 하는 운영 카드만 남겼습니다.
  - 출하팀 카드는 `출하 관리`와 `출하현황`이 중복되어 보일 수 있어, 최종적으로 `출하현황`과 `출하완료 대기` 기준으로 정리했습니다.
