### PR TITLE
feat: 부서별 RBAC 대시보드 라우팅 및 로고 홈 네비게이션 개선

### DIFF
--- a/src/components/layout/AppHeader.vue
+++ b/src/components/layout/AppHeader.vue
@@ -5,12 +5,28 @@ import ConfirmModal from '@/components/common/ConfirmModal.vue'
 import PasswordChangeModal from '@/components/domain/auth/PasswordChangeModal.vue'
 import { useUiStore } from '@/stores/ui'
 import { useAuthStore } from '@/stores/auth'
+import { getRoleHomePath } from '@/utils/roleAccess'
 
 const uiStore = useUiStore()
 const authStore = useAuthStore()
 const route = useRoute()
 const router = useRouter()
-const pageTitle = computed(() => String(route.meta.serviceName ?? '공통 대시보드'))
+const roleDashboardTitles = { admin: '관리자 대시보드', sales: '영업 대시보드', production: '생산 대시보드', shipping: '출하 대시보드' }
+
+const pageTitle = computed(() => {
+  const currentPath = route.path
+  const role = authStore.currentUser?.role
+  const home = getRoleHomePath(role)
+
+  if (currentPath === home) {
+    return roleDashboardTitles[role] || '대시보드'
+  }
+  if (currentPath === '/') {
+    return '대시보드'
+  }
+
+  return String(route.meta.serviceName ?? '대시보드')
+})
 const isNotificationOpen = ref(false)
 const isPasswordModalOpen = ref(false)
 const notificationRef = ref(null)

--- a/src/components/layout/AppSidebar.vue
+++ b/src/components/layout/AppSidebar.vue
@@ -4,11 +4,12 @@ import { fetchNavigationItems } from '@/api/navigation'
 import { RouterLink, useRoute } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 import { useUiStore } from '@/stores/ui'
-import { canAccessPathByRole } from '@/utils/roleAccess'
+import { canAccessPathByRole, getRoleHomePath } from '@/utils/roleAccess'
 
 const uiStore = useUiStore()
 const authStore = useAuthStore()
 const route = useRoute()
+const homePath = computed(() => getRoleHomePath(authStore.currentUser?.role))
 const navigationItems = ref([])
 
 const sectionOrder = ['basic', 'sales', 'orders', 'status', 'activity', 'admin']
@@ -62,7 +63,7 @@ onMounted(async () => {
     :class="uiStore.sidebarOpen ? 'translate-x-0' : '-translate-x-[260px]'"
   >
     <div class="flex h-[77px] flex-shrink-0 items-center border-b border-slate-200 px-4">
-      <RouterLink to="/" class="flex items-center gap-3" @click="uiStore.closeSidebar">
+      <RouterLink :to="homePath" class="flex items-center gap-3" @click="uiStore.closeSidebar">
         <div class="flex h-11 w-11 items-center justify-center overflow-hidden rounded-xl bg-white shadow-sm">
           <img src="/salesboost.svg" alt="SalesBoost" class="h-9 w-9 object-contain" />
         </div>
@@ -138,7 +139,7 @@ onMounted(async () => {
       class="flex h-[77px] flex-shrink-0 items-center border-b border-slate-200"
       :class="uiStore.sidebarOpen ? 'px-4' : 'justify-center px-0'"
     >
-      <RouterLink to="/" class="flex items-center gap-3" :class="{ 'justify-center': !uiStore.sidebarOpen }">
+      <RouterLink :to="homePath" class="flex items-center gap-3" :class="{ 'justify-center': !uiStore.sidebarOpen }">
         <div class="flex h-8 w-8 flex-shrink-0 items-center justify-center overflow-hidden rounded-lg">
           <img src="/salesboost.svg" alt="SalesBoost" class="h-8 w-8 object-contain" />
         </div>

--- a/src/main.js
+++ b/src/main.js
@@ -4,7 +4,7 @@ import App from './App.vue'
 import router from './router'
 import { useAuthStore } from './stores/auth'
 import { setupApiInterceptors } from './lib/api'
-import { canAccessRouteByRole } from './utils/roleAccess'
+import { canAccessRouteByRole, getRoleHomePath } from './utils/roleAccess'
 import './styles/tailwind.css'
 
 const app = createApp(App)
@@ -23,17 +23,17 @@ router.beforeEach(async (to) => {
   // 공개 페이지는 통과
   if (PUBLIC_ROUTES.includes(to.name)) {
     // 이미 로그인 상태면 대시보드로
-    if (authStore.isLoggedIn) return { name: 'dashboard' }
+    if (authStore.isLoggedIn) return getRoleHomePath(authStore.currentUser?.role)
     return true
   }
 
   // 로그인 상태면 통과
   if (authStore.isLoggedIn) {
     if (to.meta.requiredRole && authStore.currentUser?.role !== to.meta.requiredRole) {
-      return { name: 'dashboard' }
+      return getRoleHomePath(authStore.currentUser?.role)
     }
     if (!canAccessRouteByRole(authStore.currentUser, to.name)) {
-      return { name: 'dashboard' }
+      return getRoleHomePath(authStore.currentUser?.role)
     }
     return true
   }
@@ -42,10 +42,10 @@ router.beforeEach(async (to) => {
   const restored = await authStore.restoreSession()
   if (restored) {
     if (to.meta.requiredRole && authStore.currentUser?.role !== to.meta.requiredRole) {
-      return { name: 'dashboard' }
+      return getRoleHomePath(authStore.currentUser?.role)
     }
     if (!canAccessRouteByRole(authStore.currentUser, to.name)) {
-      return { name: 'dashboard' }
+      return getRoleHomePath(authStore.currentUser?.role)
     }
     return true
   }

--- a/src/utils/roleAccess.js
+++ b/src/utils/roleAccess.js
@@ -41,3 +41,9 @@ export function canAccessPathByRole(user, path) {
 
   return false
 }
+
+export function getRoleHomePath(role) {
+  if (role === 'production') return '/production'
+  if (role === 'shipping') return '/shipments'
+  return '/'
+}


### PR DESCRIPTION
## 📋 작업 내용

사용자의 부서(role)에 따라 대시보드 진입 경로와 로고 홈 네비게이션을 RBAC 기반으로 개선합니다.

- `getRoleHomePath(role)` 유틸 함수 추가 — 역할별 홈 경로 반환
- 라우터 가드에서 권한 없는 접근 시 역할별 홈으로 리다이렉트
- 사이드바 로고 클릭 시 역할별 홈 경로로 이동
- 헤더 타이틀을 역할별 대시보드명으로 표시 (영업 대시보드, 생산 대시보드 등)

| 역할 | 홈 경로 | 대시보드 타이틀 |
|------|---------|----------------|
| admin | `/` | 관리자 대시보드 |
| sales | `/` | 영업 대시보드 |
| production | `/production` | 생산 대시보드 |
| shipping | `/shipments` | 출하 대시보드 |

## 🔗 관련 이슈

- closes #183

## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료
- [x] admin/sales/production/shipping 4개 역할별 라우팅 검증
- [x] 로고 클릭 시 역할별 홈 이동 확인
- [x] 엣지 케이스 (null user, 미인식 역할) 안전 처리 확인

## 💬 리뷰어에게

- `common/` 컴포넌트는 변경하지 않았습니다 (layout/ 컴포넌트만 수정)
- `getRoleHomePath`는 path 문자열을 반환하며, Vue Router beforeEach에서 직접 return 가능합니다
- 생산/출하 사용자가 `/` (공통 대시보드)에 직접 접근한 경우 '대시보드'로 표시되고, 자신의 홈 경로에서는 역할별 타이틀이 표시됩니다