### PR TITLE
feat: Master 영역 RBAC - 거래처 부서별 할당 및 품목 관리 권한 분리

### DIFF
--- a/db.json
+++ b/db.json
@@ -752,6 +752,7 @@
       "paymentTermsId": 1,
       "currencyId": 1,
       "manager": "John Smith",
+      "departmentId": 1,
       "status": "활성",
       "regDate": "2025/01/15"
     },
@@ -769,6 +770,7 @@
       "paymentTermsId": 2,
       "currencyId": 2,
       "manager": "Hans Mueller",
+      "departmentId": 1,
       "status": "활성",
       "regDate": "2025/02/10"
     },
@@ -786,6 +788,7 @@
       "paymentTermsId": 1,
       "currencyId": 3,
       "manager": "Tanaka Yuki",
+      "departmentId": 1,
       "status": "활성",
       "regDate": "2025/03/05"
     },
@@ -803,6 +806,7 @@
       "paymentTermsId": 3,
       "currencyId": 4,
       "manager": "Wang Lei",
+      "departmentId": 1,
       "status": "활성",
       "regDate": "2025/03/20"
     },
@@ -820,6 +824,7 @@
       "paymentTermsId": 2,
       "currencyId": 6,
       "manager": "James Brown",
+      "departmentId": 1,
       "status": "비활성",
       "regDate": "2025/04/01"
     },
@@ -837,6 +842,7 @@
       "paymentTermsId": 4,
       "currencyId": 2,
       "manager": "Pierre Dupont",
+      "departmentId": 1,
       "status": "활성",
       "regDate": "2025/04/15"
     },
@@ -854,6 +860,7 @@
       "paymentTermsId": 1,
       "currencyId": 1,
       "manager": "Raj Patel",
+      "departmentId": 1,
       "status": "활성",
       "regDate": "2025/05/01"
     },
@@ -871,6 +878,7 @@
       "paymentTermsId": 5,
       "currencyId": 1,
       "manager": "Carlos Silva",
+      "departmentId": 1,
       "status": "활성",
       "regDate": "2025/05/20"
     },
@@ -888,6 +896,7 @@
       "paymentTermsId": 1,
       "currencyId": 1,
       "manager": "Lim Wei",
+      "departmentId": 1,
       "status": "비활성",
       "regDate": "2025/06/10"
     },
@@ -905,6 +914,7 @@
       "paymentTermsId": 1,
       "currencyId": 1,
       "manager": "Nguyen Van",
+      "departmentId": 1,
       "status": "활성",
       "regDate": "2025/06/25"
     },
@@ -922,6 +932,7 @@
       "paymentTermsId": 1,
       "currencyId": 1,
       "manager": "David Kim",
+      "departmentId": 2,
       "status": "활성",
       "regDate": "2025/07/01"
     },
@@ -939,6 +950,7 @@
       "paymentTermsId": 2,
       "currencyId": 2,
       "manager": "Lukas Weber",
+      "departmentId": 2,
       "status": "활성",
       "regDate": "2025/07/05"
     },
@@ -956,6 +968,7 @@
       "paymentTermsId": 1,
       "currencyId": 3,
       "manager": "Suzuki Ichiro",
+      "departmentId": 2,
       "status": "활성",
       "regDate": "2025/07/10"
     },
@@ -973,6 +986,7 @@
       "paymentTermsId": 3,
       "currencyId": 4,
       "manager": "Li Fang",
+      "departmentId": 2,
       "status": "활성",
       "regDate": "2025/07/15"
     },
@@ -990,6 +1004,7 @@
       "paymentTermsId": 2,
       "currencyId": 6,
       "manager": "Emma Wilson",
+      "departmentId": 2,
       "status": "활성",
       "regDate": "2025/07/20"
     },
@@ -1007,6 +1022,7 @@
       "paymentTermsId": 4,
       "currencyId": 2,
       "manager": "Sophie Martin",
+      "departmentId": 2,
       "status": "활성",
       "regDate": "2025/07/25"
     },
@@ -1024,6 +1040,7 @@
       "paymentTermsId": 1,
       "currencyId": 1,
       "manager": "Tan Ah Kow",
+      "departmentId": 2,
       "status": "활성",
       "regDate": "2025/08/01"
     },
@@ -1041,6 +1058,7 @@
       "paymentTermsId": 1,
       "currencyId": 1,
       "manager": "Chris Anderson",
+      "departmentId": 2,
       "status": "비활성",
       "regDate": "2025/08/05"
     },
@@ -1058,6 +1076,7 @@
       "paymentTermsId": 1,
       "currencyId": 1,
       "manager": "Mark Johnson",
+      "departmentId": 2,
       "status": "활성",
       "regDate": "2025/08/10"
     },
@@ -1075,6 +1094,7 @@
       "paymentTermsId": 1,
       "currencyId": 1,
       "manager": "Pham Thi Lan",
+      "departmentId": 2,
       "status": "활성",
       "regDate": "2025/08/15"
     }

--- a/src/lib/token.js
+++ b/src/lib/token.js
@@ -24,6 +24,7 @@ export function generateTokens(user) {
     sub: user.id,
     email: user.email,
     role: user.role,
+    departmentId: user.departmentId,
     name: user.name,
     iat: now,
     exp: now + AT_EXPIRY_MS,

--- a/src/utils/roleAccess.js
+++ b/src/utils/roleAccess.js
@@ -47,3 +47,11 @@ export function getRoleHomePath(role) {
   if (role === 'shipping') return '/shipments'
   return '/'
 }
+
+export function canManageItems(role) {
+  return role === 'admin'
+}
+
+export function canManageClients(role) {
+  return role === 'admin' || role === 'sales'
+}

--- a/src/views/master/ClientDetailPage.vue
+++ b/src/views/master/ClientDetailPage.vue
@@ -8,6 +8,7 @@ import DetailPageHeader from '@/components/common/DetailPageHeader.vue'
 import ClientBuyerCard from '@/components/domain/master/ClientBuyerCard.vue'
 import ClientFormModal from '@/components/domain/master/ClientFormModal.vue'
 import DocumentLinkButton from '@/components/domain/master/DocumentLinkButton.vue'
+import { useAuthStore } from '@/stores/auth'
 import {
   deleteClient,
   fetchBuyersByClient,
@@ -21,6 +22,9 @@ import { useToast } from '@/composables/useToast'
 const route = useRoute()
 const router = useRouter()
 const { success, error } = useToast()
+const authStore = useAuthStore()
+const currentUser = computed(() => authStore.currentUser)
+const isAdmin = computed(() => currentUser.value?.role === 'admin')
 
 const { countries, ports, currencies, paymentTerms, loadReferenceData, getCountryName, getPortName, getPaymentTermsLabel, getCurrencyLabel } = useMasterLookup()
 
@@ -93,6 +97,15 @@ async function loadData() {
       return
     }
     client.value = clientData
+
+    // 영업 사용자가 타부서 거래처에 접근 시 리다이렉트
+    if (!isAdmin.value && currentUser.value?.role === 'sales' &&
+        clientData.departmentId !== Number(currentUser.value?.departmentId)) {
+      error('접근 권한이 없는 거래처입니다.')
+      router.push({ name: 'client-list' })
+      return
+    }
+
     allClients.value = clientsData
     buyers.value = buyersData.map((b) => ({
       name: b.name,

--- a/src/views/master/ClientListPage.vue
+++ b/src/views/master/ClientListPage.vue
@@ -11,6 +11,7 @@ import StatusBadge from '@/components/common/StatusBadge.vue'
 import TableActions from '@/components/common/TableActions.vue'
 import PageHeader from '@/components/common/PageHeader.vue'
 import ClientFormModal from '@/components/domain/master/ClientFormModal.vue'
+import { useAuthStore } from '@/stores/auth'
 import {
   createClient,
   deleteClient,
@@ -21,6 +22,9 @@ import { useMasterLookup } from '@/composables/useMasterLookup'
 import { useToast } from '@/composables/useToast'
 
 const router = useRouter()
+const authStore = useAuthStore()
+const currentUser = computed(() => authStore.currentUser)
+const isAdmin = computed(() => currentUser.value?.role === 'admin')
 const { success, error } = useToast()
 
 const { countries, ports, currencies, paymentTerms, loadReferenceData, getCountryName, getPortName, getPaymentTermsLabel, getCurrencyLabel } = useMasterLookup()
@@ -73,6 +77,11 @@ const enrichedClients = computed(() =>
 
 const filteredClients = computed(() => {
   let result = enrichedClients.value
+
+  // 영업 사용자는 자기 부서 거래처만 표시
+  if (!isAdmin.value && currentUser.value?.role === 'sales') {
+    result = result.filter((c) => c.departmentId === Number(currentUser.value.departmentId))
+  }
 
   if (searchKeyword.value) {
     const kw = searchKeyword.value.toLowerCase()
@@ -158,7 +167,8 @@ async function handleSave(formData) {
   saving.value = true
   try {
     if (formMode.value === 'create') {
-      await createClient({ ...formData, regDate: new Date().toISOString().slice(0, 10) })
+      const deptId = isAdmin.value ? undefined : Number(currentUser.value?.departmentId)
+      await createClient({ ...formData, regDate: new Date().toISOString().slice(0, 10), ...(deptId && { departmentId: deptId }) })
       success('거래처가 등록되었습니다.')
     } else {
       await updateClient(selectedClient.value.id, formData)

--- a/src/views/master/ItemDetailPage.vue
+++ b/src/views/master/ItemDetailPage.vue
@@ -9,10 +9,14 @@ import DocumentLinkButton from '@/components/domain/master/DocumentLinkButton.vu
 import ItemFormModal from '@/components/domain/master/ItemFormModal.vue'
 import { deleteItem, fetchItem, fetchItems, updateItem } from '@/api/master'
 import { useToast } from '@/composables/useToast'
+import { useAuthStore } from '@/stores/auth'
+import { canManageItems } from '@/utils/roleAccess'
 
 const route = useRoute()
 const router = useRouter()
 const { success, error } = useToast()
+const authStore = useAuthStore()
+const isItemAdmin = computed(() => canManageItems(authStore.currentUser?.role))
 
 const item = ref(null)
 const allItems = ref([]) // used for code uniqueness check in edit modal
@@ -132,7 +136,7 @@ function goBack() {
 
   <div v-else-if="item" class="space-y-6">
     <DetailPageHeader :title="`${item.code} · ${item.name}`" :status="item.status" @back="goBack">
-      <template #actions>
+      <template v-if="isItemAdmin" #actions>
         <BaseButton variant="secondary" size="sm" @click="openEditModal">수정</BaseButton>
         <BaseButton variant="ghost" size="sm" @click="showConfirmModal = true">삭제</BaseButton>
       </template>

--- a/src/views/master/ItemListPage.vue
+++ b/src/views/master/ItemListPage.vue
@@ -13,9 +13,13 @@ import PageHeader from '@/components/common/PageHeader.vue'
 import ItemFormModal from '@/components/domain/master/ItemFormModal.vue'
 import { createItem, deleteItem, fetchItems, updateItem } from '@/api/master'
 import { useToast } from '@/composables/useToast'
+import { useAuthStore } from '@/stores/auth'
+import { canManageItems } from '@/utils/roleAccess'
 
 const router = useRouter()
 const { success, error } = useToast()
+const authStore = useAuthStore()
+const isItemAdmin = computed(() => canManageItems(authStore.currentUser?.role))
 
 const items = ref([])
 const loading = ref(false)
@@ -40,18 +44,23 @@ const categoryOptions = computed(() => {
   return [{ label: '전체 카테고리', value: '' }, ...cats.map((c) => ({ label: c, value: c }))]
 })
 
-const columns = [
-  { key: 'code', label: '코드', width: '100px' },
-  { key: 'name', label: '품목명' },
-  { key: 'spec', label: '규격', width: '200px' },
-  { key: 'packUnit', label: '포장단위', width: '100px', align: 'center' },
-  { key: 'unit', label: '단위', width: '80px', align: 'center' },
-  { key: 'unitPrice', label: '단가 (KRW)', width: '140px', align: 'right' },
-  { key: 'weight', label: '중량 (kg)', width: '110px', align: 'right' },
-  { key: 'hsCode', label: 'HS Code', width: '100px', align: 'center' },
-  { key: 'status', label: '상태', width: '80px', align: 'center' },
-  { key: 'actions', label: '액션', width: '120px', align: 'center' },
-]
+const columns = computed(() => {
+  const base = [
+    { key: 'code', label: '코드', width: '100px' },
+    { key: 'name', label: '품목명' },
+    { key: 'spec', label: '규격', width: '200px' },
+    { key: 'packUnit', label: '포장단위', width: '100px', align: 'center' },
+    { key: 'unit', label: '단위', width: '80px', align: 'center' },
+    { key: 'unitPrice', label: '단가 (KRW)', width: '140px', align: 'right' },
+    { key: 'weight', label: '중량 (kg)', width: '110px', align: 'right' },
+    { key: 'hsCode', label: 'HS Code', width: '100px', align: 'center' },
+    { key: 'status', label: '상태', width: '80px', align: 'center' },
+  ]
+  if (isItemAdmin.value) {
+    base.push({ key: 'actions', label: '액션', width: '120px', align: 'center' })
+  }
+  return base
+})
 
 const filteredItems = computed(() => {
   let result = items.value
@@ -161,7 +170,7 @@ function goToDetail(row) {
   <div class="space-y-6">
     <PageHeader title="품목 관리" icon-class="fas fa-cube">
       <template #actions>
-        <BaseButton variant="primary" @click="openCreateModal">신규등록</BaseButton>
+        <BaseButton v-if="isItemAdmin" variant="primary" @click="openCreateModal">신규등록</BaseButton>
       </template>
     </PageHeader>
 


### PR DESCRIPTION
## 📋 작업 내용

Master 영역(거래처/품목)에 RBAC 기반 접근 권한을 적용합니다.

### 거래처
- 거래처 데이터에 `departmentId` 추가 (CLI001~010 → 영업1팀, CLI011~020 → 영업2팀)
- 영업 사용자는 자기 부서 할당 거래처만 조회/CRUD 가능
- admin은 전체 거래처 접근 가능
- 타부서 거래처 상세 접근 시 에러 토스트 + 목록으로 리다이렉트
- 거래처 신규 생성 시 영업 사용자의 departmentId 자동 할당

### 품목
- admin(경영지원)만 등록/수정/삭제 가능
- 영업 사용자는 조회만 가능 (신규등록 버튼, 액션 컬럼, 수정/삭제 버튼 숨김)

### 권한 매트릭스

| 역할 | 거래처 조회 | 거래처 CUD | 품목 조회 | 품목 CUD |
|------|-----------|-----------|----------|---------|
| admin | 전체 | 전체 | 전체 | 전체 |
| sales | 자기 부서만 | 자기 부서만 | 전체 | 불가 |
| production/shipping | 라우터 차단 | 라우터 차단 | 라우터 차단 | 라우터 차단 |

## 🔗 관련 이슈

- closes #188

## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료
- [x] admin/sales 역할별 거래처 필터링 검증
- [x] 품목 admin 전용 CUD 검증
- [x] 타부서 거래처 접근 차단 검증
- [x] common/ 컴포넌트 미수정

## 💬 리뷰어에게

- AT 페이로드에 `departmentId` 추가하여 부서 정보를 토큰에서 활용 가능합니다
- `roleAccess.js`에 `canManageItems`, `canManageClients` 헬퍼 추가 — 향후 권한 체크 재사용 가능
- admin이 생성한 거래처는 departmentId 미할당 상태로, admin만 조회 가능합니다 (필요 시 후속 작업으로 부서 배정 UI 추가 가능)