### PR TITLE
[hotfix] AppHeader 중복 import 인한 대시보드 화면 진입 오류 수정

### DIFF
--- a/src/components/layout/AppHeader.vue
+++ b/src/components/layout/AppHeader.vue
@@ -10,7 +10,6 @@ import { usePiDocuments } from '@/stores/piDocuments'
 import { usePoDocuments } from '@/stores/poDocuments'
 import { useSalesCollectionDocuments } from '@/stores/salesCollectionDocuments'
 import { useShipmentStatusDocuments } from '@/stores/shipmentStatusDocuments'
-import { getRoleHomePath } from '@/utils/roleAccess'
 
 const uiStore = useUiStore()
 const authStore = useAuthStore()


### PR DESCRIPTION
## 📋 작업 내용

<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->


  - `AppHeader.vue`에 중복 선언되어 있던 `getRoleHomePath` import를 제거했습니다.
  - 중복 import로 인해 발생하던 Vue 컴파일 에러를 해결했습니다.
  - 대시보드와 헤더가 포함된 주요 화면이 다시 정상 렌더링되도록 복구했습니다.

## 🔗 관련 이슈

<!-- 관련 이슈 번호를 적어주세요 (자동으로 이슈가 닫힙니다) -->
- closes #

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->



## ✅ 체크리스트

  - [x] 정상 동작 확인
  - [x] 불필요한 코드/주석 제거
  - [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

<!-- 리뷰할 때 중점적으로 봐줬으면 하는 부분이 있다면 적어주세요 -->
  - 기능 변경이 아니라 병합 과정에서 남은 중복 import를 제거하는 hotfix입니다.
  - `AppHeader`가 공통 레이아웃이라 영향 범위가 넓어 우선 복구했습니다.

