### PR TITLE
feat: Master 목록 화면 코드 열 가운데 정렬 및 상세검색 섹션 추가

### DIFF
--- a/src/views/master/ClientListPage.vue
+++ b/src/views/master/ClientListPage.vue
@@ -3,10 +3,13 @@ import { computed, onMounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import BaseButton from '@/components/common/BaseButton.vue'
 import BasePagination from '@/components/common/BasePagination.vue'
-import BaseSelect from '@/components/common/BaseSelect.vue'
 import BaseTable from '@/components/common/BaseTable.vue'
+import BaseTextField from '@/components/common/BaseTextField.vue'
+import CollapsibleFilterCard from '@/components/common/CollapsibleFilterCard.vue'
 import ConfirmModal from '@/components/common/ConfirmModal.vue'
-import SearchInput from '@/components/common/SearchInput.vue'
+import FilterToolbarCard from '@/components/common/FilterToolbarCard.vue'
+import FormField from '@/components/common/FormField.vue'
+import SearchableCombobox from '@/components/common/SearchableCombobox.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
 import TableActions from '@/components/common/TableActions.vue'
 import PageHeader from '@/components/common/PageHeader.vue'
@@ -34,8 +37,22 @@ const loading = ref(false)
 const saving = ref(false)
 const deleting = ref(false)
 
-const searchKeyword = ref('')
-const statusFilter = ref('')
+const isAdvancedOpen = ref(false)
+
+const filters = ref({
+  keyword: '',
+  code: '',
+  name: '',
+  country: '',
+  manager: '',
+  status: '',
+})
+
+const statusOptions = [
+  { label: '전체', value: '' },
+  { label: '활성', value: '활성' },
+  { label: '비활성', value: '비활성' },
+]
 
 const PAGE_SIZE = 10
 const currentPage = ref(1)
@@ -47,14 +64,8 @@ const selectedClient = ref(null)
 const showConfirmModal = ref(false)
 const clientToDelete = ref(null)
 
-const statusFilterOptions = [
-  { label: '전체 상태', value: '' },
-  { label: '활성', value: '활성' },
-  { label: '비활성', value: '비활성' },
-]
-
 const columns = [
-  { key: 'code', label: '코드', width: '100px' },
+  { key: 'code', label: '코드', width: '100px', align: 'center' },
   { key: 'name', label: '거래처명' },
   { key: 'location', label: '국가·도시', width: '140px' },
   { key: 'port', label: '도착항', width: '120px' },
@@ -75,16 +86,31 @@ const enrichedClients = computed(() =>
   })),
 )
 
+const countryOptions = computed(() => {
+  const countrySet = [...new Set(enrichedClients.value.map((c) => c.countryName).filter(Boolean))]
+  return [{ label: '전체', value: '' }, ...countrySet.map((name) => ({ label: name, value: name }))]
+})
+
+function resetFilters() {
+  filters.value = { keyword: '', code: '', name: '', country: '', manager: '', status: '' }
+}
+
+function searchRows() {
+  currentPage.value = 1
+}
+
 const filteredClients = computed(() => {
   let result = enrichedClients.value
 
-  // 영업 사용자는 자기 부서 거래처만 표시
+  // RBAC: 영업 사용자는 자기 부서 거래처만 표시
   if (!isAdmin.value && currentUser.value?.role === 'sales') {
     result = result.filter((c) => c.departmentId === Number(currentUser.value.departmentId))
   }
 
-  if (searchKeyword.value) {
-    const kw = searchKeyword.value.toLowerCase()
+  const f = filters.value
+
+  if (f.keyword) {
+    const kw = f.keyword.toLowerCase()
     result = result.filter(
       (c) =>
         c.name.toLowerCase().includes(kw) ||
@@ -93,8 +119,25 @@ const filteredClients = computed(() => {
     )
   }
 
-  if (statusFilter.value) {
-    result = result.filter((c) => c.status === statusFilter.value)
+  if (f.code) {
+    result = result.filter((c) => c.code.toLowerCase().includes(f.code.toLowerCase()))
+  }
+
+  if (f.name) {
+    const kw = f.name.toLowerCase()
+    result = result.filter((c) => c.name.toLowerCase().includes(kw) || (c.nameKr && c.nameKr.includes(kw)))
+  }
+
+  if (f.country) {
+    result = result.filter((c) => c.countryName === f.country)
+  }
+
+  if (f.manager) {
+    result = result.filter((c) => c.manager && c.manager.includes(f.manager))
+  }
+
+  if (f.status) {
+    result = result.filter((c) => c.status === f.status)
   }
 
   return result
@@ -108,9 +151,9 @@ const paginatedClients = computed(() => {
 })
 
 // Reset to page 1 when filters change
-watch([searchKeyword, statusFilter], () => {
+watch(filters, () => {
   currentPage.value = 1
-})
+}, { deep: true })
 
 async function loadData() {
   loading.value = true
@@ -196,21 +239,67 @@ function goToDetail(row) {
       </template>
     </PageHeader>
 
-    <div class="flex flex-wrap items-center gap-3">
-      <div class="min-w-0 flex-1">
-        <SearchInput v-model="searchKeyword" placeholder="코드, 거래처명으로 검색" />
+    <FilterToolbarCard
+      v-model="filters.keyword"
+      :advanced-open="isAdvancedOpen"
+      placeholder="코드, 거래처명으로 검색"
+      @toggle-advanced="isAdvancedOpen = !isAdvancedOpen"
+    />
+
+    <CollapsibleFilterCard :open="isAdvancedOpen">
+      <div class="grid grid-cols-2 gap-3 text-sm md:grid-cols-3">
+        <FormField label="코드">
+          <BaseTextField v-model="filters.code" placeholder="코드 입력..." />
+        </FormField>
+
+        <FormField label="거래처명">
+          <BaseTextField v-model="filters.name" placeholder="영문 또는 한글명..." />
+        </FormField>
+
+        <FormField label="국가">
+          <SearchableCombobox
+            v-model="filters.country"
+            :options="countryOptions"
+            placeholder="국가 검색..."
+          />
+        </FormField>
+
+        <FormField label="담당자">
+          <BaseTextField v-model="filters.manager" placeholder="담당자명..." />
+        </FormField>
+
+        <FormField label="상태">
+          <SearchableCombobox
+            v-model="filters.status"
+            :options="statusOptions"
+            placeholder="상태 선택..."
+          />
+        </FormField>
       </div>
-      <div class="w-40">
-        <BaseSelect v-model="statusFilter" :options="statusFilterOptions" placeholder="전체 상태" />
+
+      <div class="mt-2 flex items-center justify-end gap-2 border-t border-slate-100 pt-3">
+        <BaseButton variant="secondary" size="sm" @click="resetFilters">
+          <template #leading>
+            <i class="fas fa-undo text-xs" aria-hidden="true"></i>
+          </template>
+          초기화
+        </BaseButton>
+
+        <BaseButton size="sm" @click="searchRows">
+          <template #leading>
+            <i class="fas fa-search text-xs" aria-hidden="true"></i>
+          </template>
+          검색
+        </BaseButton>
       </div>
-    </div>
+    </CollapsibleFilterCard>
 
     <div v-if="loading" class="flex items-center justify-center py-20 text-slate-400">
       데이터를 불러오는 중입니다...
     </div>
 
     <BaseTable v-else :columns="columns" :rows="paginatedClients" row-key="id"
-      :empty-text="searchKeyword || statusFilter ? '검색 결과가 없습니다.' : '등록된 거래처가 없습니다.'"
+      :empty-text="filters.keyword || filters.code || filters.name || filters.country || filters.manager || filters.status ? '검색 결과가 없습니다.' : '등록된 거래처가 없습니다.'"
       :footer-text="`총 ${filteredClients.length}건`"
       clickable-rows
       @row-click="goToDetail"

--- a/src/views/master/ItemListPage.vue
+++ b/src/views/master/ItemListPage.vue
@@ -3,10 +3,13 @@ import { computed, onMounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import BaseButton from '@/components/common/BaseButton.vue'
 import BasePagination from '@/components/common/BasePagination.vue'
-import BaseSelect from '@/components/common/BaseSelect.vue'
 import BaseTable from '@/components/common/BaseTable.vue'
+import BaseTextField from '@/components/common/BaseTextField.vue'
+import CollapsibleFilterCard from '@/components/common/CollapsibleFilterCard.vue'
 import ConfirmModal from '@/components/common/ConfirmModal.vue'
-import SearchInput from '@/components/common/SearchInput.vue'
+import FilterToolbarCard from '@/components/common/FilterToolbarCard.vue'
+import FormField from '@/components/common/FormField.vue'
+import SearchableCombobox from '@/components/common/SearchableCombobox.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
 import TableActions from '@/components/common/TableActions.vue'
 import PageHeader from '@/components/common/PageHeader.vue'
@@ -26,8 +29,35 @@ const loading = ref(false)
 const saving = ref(false)
 const deleting = ref(false)
 
-const searchKeyword = ref('')
-const categoryFilter = ref('')
+const isAdvancedOpen = ref(false)
+
+const filters = ref({
+  keyword: '',
+  code: '',
+  name: '',
+  category: '',
+  unit: '',
+  status: '',
+})
+
+const statusOptions = [
+  { label: '전체', value: '' },
+  { label: '활성', value: '활성' },
+  { label: '비활성', value: '비활성' },
+]
+
+const unitOptions = computed(() => {
+  const units = [...new Set(items.value.map((i) => i.unit).filter(Boolean))]
+  return [{ label: '전체', value: '' }, ...units.map((u) => ({ label: u, value: u }))]
+})
+
+function resetFilters() {
+  filters.value = { keyword: '', code: '', name: '', category: '', unit: '', status: '' }
+}
+
+function searchRows() {
+  currentPage.value = 1
+}
 
 const PAGE_SIZE = 10
 const currentPage = ref(1)
@@ -41,12 +71,12 @@ const itemToDelete = ref(null)
 
 const categoryOptions = computed(() => {
   const cats = [...new Set(items.value.map((i) => i.category).filter(Boolean))]
-  return [{ label: '전체 카테고리', value: '' }, ...cats.map((c) => ({ label: c, value: c }))]
+  return [{ label: '전체', value: '' }, ...cats.map((c) => ({ label: c, value: c }))]
 })
 
 const columns = computed(() => {
   const base = [
-    { key: 'code', label: '코드', width: '100px' },
+    { key: 'code', label: '코드', width: '100px', align: 'center' },
     { key: 'name', label: '품목명' },
     { key: 'spec', label: '규격', width: '200px' },
     { key: 'packUnit', label: '포장단위', width: '100px', align: 'center' },
@@ -64,9 +94,10 @@ const columns = computed(() => {
 
 const filteredItems = computed(() => {
   let result = items.value
+  const f = filters.value
 
-  if (searchKeyword.value) {
-    const kw = searchKeyword.value.toLowerCase()
+  if (f.keyword) {
+    const kw = f.keyword.toLowerCase()
     result = result.filter(
       (item) =>
         item.name.toLowerCase().includes(kw) ||
@@ -75,8 +106,25 @@ const filteredItems = computed(() => {
     )
   }
 
-  if (categoryFilter.value) {
-    result = result.filter((item) => item.category === categoryFilter.value)
+  if (f.code) {
+    result = result.filter((item) => item.code.toLowerCase().includes(f.code.toLowerCase()))
+  }
+
+  if (f.name) {
+    const kw = f.name.toLowerCase()
+    result = result.filter((item) => item.name.toLowerCase().includes(kw) || (item.nameKr && item.nameKr.includes(kw)))
+  }
+
+  if (f.category) {
+    result = result.filter((item) => item.category === f.category)
+  }
+
+  if (f.unit) {
+    result = result.filter((item) => item.unit === f.unit)
+  }
+
+  if (f.status) {
+    result = result.filter((item) => item.status === f.status)
   }
 
   return result
@@ -90,9 +138,9 @@ const paginatedItems = computed(() => {
 })
 
 // Reset to page 1 when filters change
-watch([searchKeyword, categoryFilter], () => {
+watch(filters, () => {
   currentPage.value = 1
-})
+}, { deep: true })
 
 async function loadData() {
   loading.value = true
@@ -174,21 +222,71 @@ function goToDetail(row) {
       </template>
     </PageHeader>
 
-    <div class="flex flex-wrap items-center gap-3">
-      <div class="min-w-0 flex-1">
-        <SearchInput v-model="searchKeyword" placeholder="코드, 품목명으로 검색" />
+    <FilterToolbarCard
+      v-model="filters.keyword"
+      :advanced-open="isAdvancedOpen"
+      placeholder="코드, 품목명으로 검색"
+      @toggle-advanced="isAdvancedOpen = !isAdvancedOpen"
+    />
+
+    <CollapsibleFilterCard :open="isAdvancedOpen">
+      <div class="grid grid-cols-2 gap-3 text-sm md:grid-cols-3">
+        <FormField label="코드">
+          <BaseTextField v-model="filters.code" placeholder="코드 입력..." />
+        </FormField>
+
+        <FormField label="품목명">
+          <BaseTextField v-model="filters.name" placeholder="영문 또는 한글명..." />
+        </FormField>
+
+        <FormField label="카테고리">
+          <SearchableCombobox
+            v-model="filters.category"
+            :options="categoryOptions"
+            placeholder="카테고리 선택..."
+          />
+        </FormField>
+
+        <FormField label="단위">
+          <SearchableCombobox
+            v-model="filters.unit"
+            :options="unitOptions"
+            placeholder="단위 선택..."
+          />
+        </FormField>
+
+        <FormField label="상태">
+          <SearchableCombobox
+            v-model="filters.status"
+            :options="statusOptions"
+            placeholder="상태 선택..."
+          />
+        </FormField>
       </div>
-      <div class="w-40">
-        <BaseSelect v-model="categoryFilter" :options="categoryOptions" placeholder="전체 카테고리" />
+
+      <div class="mt-2 flex items-center justify-end gap-2 border-t border-slate-100 pt-3">
+        <BaseButton variant="secondary" size="sm" @click="resetFilters">
+          <template #leading>
+            <i class="fas fa-undo text-xs" aria-hidden="true"></i>
+          </template>
+          초기화
+        </BaseButton>
+
+        <BaseButton size="sm" @click="searchRows">
+          <template #leading>
+            <i class="fas fa-search text-xs" aria-hidden="true"></i>
+          </template>
+          검색
+        </BaseButton>
       </div>
-    </div>
+    </CollapsibleFilterCard>
 
     <div v-if="loading" class="flex items-center justify-center py-20 text-slate-400">
       데이터를 불러오는 중입니다...
     </div>
 
     <BaseTable v-else :columns="columns" :rows="paginatedItems" row-key="id"
-      :empty-text="searchKeyword || categoryFilter ? '검색 결과가 없습니다.' : '등록된 품목이 없습니다.'"
+      :empty-text="filters.keyword || filters.code || filters.name || filters.category || filters.unit || filters.status ? '검색 결과가 없습니다.' : '등록된 품목이 없습니다.'"
       clickable-rows
       :footer-text="`총 ${filteredItems.length}건`"
       @row-click="goToDetail"


### PR DESCRIPTION
## 📋 작업 내용

거래처/품목 목록 화면의 UX를 PI/PO 등 문서 관리 화면과 동일한 수준으로 개선합니다.

- 코드(code) 컬럼 가운데 정렬
- 기존 SearchInput + BaseSelect → FilterToolbarCard + CollapsibleFilterCard 상세검색 패턴으로 교체
- **거래처 상세검색**: 코드, 거래처명, 국가, 담당자, 상태
- **품목 상세검색**: 코드, 품목명, 카테고리, 단위, 상태
- 초기화/검색 버튼, 상세검색 토글 접기/펴기 지원

## 🔗 관련 이슈

- closes #192

## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료
- [x] 거래처/품목 코드 열 가운데 정렬 확인
- [x] FilterToolbarCard 키워드 검색 동작 확인
- [x] 상세검색 토글 및 필터 필드 동작 확인
- [x] 초기화/검색 버튼 동작 확인
- [x] 기존 RBAC 부서별 필터링 유지 확인
- [x] common/ 컴포넌트 미수정

## 💬 리뷰어에게

- PI/PO 페이지의 FilterToolbarCard + CollapsibleFilterCard 패턴을 그대로 적용했습니다
- 기존 RBAC 로직(영업 부서별 거래처 필터링)은 그대로 유지됩니다
- 상세검색 필터는 실시간 적용 + 검색 버튼으로 페이지 리셋