### PR TITLE
refactor: 매출·수금 현황의 PO 코드 표기 형식을 문서 기준으로 통일

### DIFF
--- a/src/stores/salesCollectionDocuments.js
+++ b/src/stores/salesCollectionDocuments.js
@@ -2,9 +2,14 @@ import { ref } from 'vue'
 
 import masterData from '../../db.json'
 
+function normalizeDocumentCode(value = '') {
+  return String(value ?? '').replace(/[^A-Za-z0-9]/g, '')
+}
+
 function normalizeCollectionRow(row) {
   return {
     ...row,
+    poId: normalizeDocumentCode(row.poId),
     collectionDate: row.status === '수금완료' ? row.collectionDate || null : null,
   }
 }


### PR DESCRIPTION
## 📋 작업 내용

<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
  - 매출·수금 현황의 PO 코드 표기 형식을 다른 문서 화면과 동일한 기준으로 정리했습니다.
  - `salesCollections` 데이터의 `poId`를 화면에서 바로 쓰지 않고, 문서 화면 기준 코드 형식으로 정규화하도록 수정했습니다.
  - 화면 표시뿐 아니라 검색 / 필터 / PDF 출력에서도 같은 코드 형식을 사용하도록 맞췄습니다.


## 🔗 관련 이슈

<!-- 관련 이슈 번호를 적어주세요 (자동으로 이슈가 닫힙니다) -->
- closes #

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->



## ✅ 체크리스트

  - [x] 정상 동작 확인
  - [x] 불필요한 코드/주석 제거
  - [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

<!-- 리뷰할 때 중점적으로 봐줬으면 하는 부분이 있다면 적어주세요 -->
  - 이번 작업은 매출·수금 현황만 `PO-2025-001`처럼 하이픈이 포함된 형식을 그대로 보여주던 문제를 정리하는 리팩토링입니다.
  - 문서 목록 / 상세 / 참조 문서와 같은 기준인 `PO2025001` 형식으로 통일했습니다.

