### PR TITLE
refactor: 사용자 관리 화면 접근 권한을 관리자 전용으로 정리

### DIFF
--- a/src/utils/roleAccess.js
+++ b/src/utils/roleAccess.js
@@ -8,6 +8,10 @@ const ROLE_ROUTE_ALLOWLIST = {
 export function canAccessRouteByRole(user, routeName) {
   if (!user || !routeName) return false
 
+  if (String(routeName) === 'users') {
+    return user.role === 'admin'
+  }
+
   if (user.role === 'admin' || user.role === 'sales') {
     return true
   }
@@ -22,6 +26,10 @@ export function canAccessRouteByRole(user, routeName) {
 
 export function canAccessPathByRole(user, path) {
   if (!user || !path) return false
+
+  if (path.startsWith('/users')) {
+    return user.role === 'admin'
+  }
 
   if (user.role === 'admin' || user.role === 'sales') {
     return true


### PR DESCRIPTION
## 📋 작업 내용

사용자 관리 화면의 메뉴 노출 및 접근 권한을 관리자 전용으로 일관되게 정리합니다.

- `canAccessPathByRole`: `/users` 경로를 admin/sales 전체 허용 블록보다 앞에서 admin 전용으로 체크
- `canAccessRouteByRole`: `users` 라우트를 admin/sales 전체 허용 블록보다 앞에서 admin 전용으로 체크
- 사이드바 메뉴 노출과 라우터 접근 제한 기준이 일치하도록 정리

## 🔗 관련 이슈

- closes #199

## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료
- [x] admin: 사용자 관리 메뉴 노출 + 접근 가능
- [x] sales: 사용자 관리 메뉴 숨김 + URL 직접 접근 차단
- [x] production/shipping: 기존대로 제한된 메뉴만 노출
- [x] common/ 컴포넌트 미수정

## 💬 리뷰어에게

- admin 전용 체크를 admin/sales 전체 허용 분기보다 앞에 배치하여 우선 적용합니다
- 기존 router meta의 `requiredRole: 'admin'`과 일관성을 유지합니다
- sales의 다른 모든 경로 접근 권한은 변경 없습니다