### PR TITLE
feat: 로그인 데모 계정에 영업팀별 계정 추가

### DIFF
--- a/src/views/auth/LoginPage.vue
+++ b/src/views/auth/LoginPage.vue
@@ -22,7 +22,9 @@ const loading = ref(false)
 
 const demoAccounts = [
   { label: '관리자', email: 'admin@salesboost.com', pw: 'test1234' },
-  { label: '영업', email: 'kim@salesboost.com', pw: 'test1234' },
+  { label: '영업1팀 팀장', email: 'kim@salesboost.com', pw: 'test1234' },
+  { label: '영업1팀 팀원', email: 'jo@salesboost.com', pw: 'test1234' },
+  { label: '영업2팀', email: 'jung@salesboost.com', pw: 'test1234' },
   { label: '생산', email: 'lee@salesboost.com', pw: 'test1234' },
   { label: '출하', email: 'park@salesboost.com', pw: 'test1234' },
 ]
@@ -142,7 +144,7 @@ async function handleLogin() {
     <!-- Demo 계정 안내 -->
     <div v-if="isDev" class="w-full rounded-2xl bg-white p-4 shadow-panel">
       <p class="mb-2 text-xs font-semibold text-slate-600">Demo 계정 (클릭하면 자동 입력)</p>
-      <div class="grid grid-cols-2 gap-2">
+      <div class="grid grid-cols-2 gap-2 sm:grid-cols-3">
         <button
           v-for="account in demoAccounts"
           :key="account.email"


### PR DESCRIPTION
## 📋 작업 내용

로그인 화면의 Demo 계정을 영업팀별로 분리하여 RBAC 동작 확인이 용이하도록 개선합니다.

- 기존 영업 단일 계정 → 영업1팀 팀장, 영업1팀 팀원, 영업2팀 3개로 분리
- 데모 계정 그리드를 `sm:grid-cols-3` 반응형으로 조정 (모바일 2열, 데스크톱 3열)

| 라벨 | 이메일 | 부서 | 직급 |
|------|--------|------|------|
| 관리자 | admin@salesboost.com | 경영지원 | - |
| 영업1팀 팀장 | kim@salesboost.com | 영업1팀 | 팀장 |
| 영업1팀 팀원 | jo@salesboost.com | 영업1팀 | 팀원 |
| 영업2팀 | jung@salesboost.com | 영업2팀 | 팀원 |
| 생산 | lee@salesboost.com | 생산팀 | - |
| 출하 | park@salesboost.com | 출하팀 | - |

## 🔗 관련 이슈

- closes #203

## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료
- [x] 6개 데모 계정 db.json 사용자 매칭 확인
- [x] 반응형 그리드 레이아웃 확인
- [x] common/ 컴포넌트 미수정

## 💬 리뷰어에게

- 부서별 RBAC(거래처 필터링, 품목 권한 등) 테스트 시 영업팀별로 로그인하여 확인 가능합니다