### PR TITLE
refactor: PO 등록용 PI 선택 기준과 더미데이터 정합성 정리

### DIFF
--- a/db.json
+++ b/db.json
@@ -5180,6 +5180,42 @@
       "manager": "김영업",
       "status": "발송",
       "deliveryDate": "2025/08/20"
+    },
+    {
+      "id": "PI2025021",
+      "issueDate": "2025/07/15",
+      "clientName": "Berlin Digital AG",
+      "country": "Germany",
+      "itemName": "Wireless Presenter",
+      "amount": 7800,
+      "currency": "EUR",
+      "manager": "정영업",
+      "status": "확정",
+      "deliveryDate": "2025/08/28"
+    },
+    {
+      "id": "PI2025022",
+      "issueDate": "2025/07/18",
+      "clientName": "Singapore Electronics Pte",
+      "country": "Singapore",
+      "itemName": "USB-C Hub 7-in-1",
+      "amount": 11800,
+      "currency": "USD",
+      "manager": "황영업",
+      "status": "확정",
+      "deliveryDate": "2025/09/02"
+    },
+    {
+      "id": "PI2025023",
+      "issueDate": "2025/07/22",
+      "clientName": "Paris Digital SAS",
+      "country": "France",
+      "itemName": "Mechanical Keyboard",
+      "amount": 9600,
+      "currency": "EUR",
+      "manager": "강영업",
+      "status": "확정",
+      "deliveryDate": "2025/09/05"
     }
   ],
   "po": [

--- a/src/utils/documentShipmentLock.js
+++ b/src/utils/documentShipmentLock.js
@@ -101,3 +101,83 @@ export function formatPiShipmentLockMessage(lockInfo) {
   const reference = lockInfo.references[0]
   return `출하완료된 ${reference.type} ${reference.id}가 연결된 PO ${reference.poId}가 있어 이 PI는 수정/삭제할 수 없습니다.`
 }
+
+export function getPiPoSelectionInfo(
+  piRow,
+  poDocuments = [],
+  shipmentOrderDocuments = [],
+  shipmentStatusDocuments = [],
+  productionDocuments = [],
+  ciDocuments = [],
+  plDocuments = [],
+  currentPoId = '',
+) {
+  const shipmentLockInfo = getPiShipmentLockInfo(
+    piRow?.id,
+    poDocuments,
+    shipmentOrderDocuments,
+    shipmentStatusDocuments,
+  )
+  const canceled = String(piRow?.status ?? '').trim() === '취소'
+  const approvalPending = String(piRow?.status ?? '').trim() === '결재대기'
+  const activeLinkedPoRows = poDocuments.filter((row) => {
+    const linkedPiId = row?.piId || row?.linkedPiId || ''
+    const samePo = String(row?.id ?? '') === String(currentPoId ?? '')
+    const canceledPo = String(row?.status ?? '').trim() === '취소'
+    return linkedPiId === piRow?.id && !samePo && !canceledPo
+  })
+  const activeLinkedPoIds = activeLinkedPoRows.map((row) => row.id)
+  const issuedReferences = [
+    ...productionDocuments
+      .filter((row) => activeLinkedPoIds.includes(row.poId))
+      .map((row) => ({ type: '생산지시서', id: row.id, poId: row.poId, status: row.status })),
+    ...shipmentOrderDocuments
+      .filter((row) => activeLinkedPoIds.includes(row.poId))
+      .map((row) => ({ type: '출하지시서', id: row.id, poId: row.poId, status: row.status })),
+    ...shipmentStatusDocuments
+      .filter((row) => activeLinkedPoIds.includes(row.poId))
+      .map((row) => ({ type: '출하현황', id: row.id, poId: row.poId, status: row.status })),
+    ...ciDocuments
+      .filter((row) => activeLinkedPoIds.includes(row.poId))
+      .map((row) => ({ type: 'CI', id: row.id, poId: row.poId, status: row.status })),
+    ...plDocuments
+      .filter((row) => activeLinkedPoIds.includes(row.poId))
+      .map((row) => ({ type: 'PL', id: row.id, poId: row.poId, status: row.status })),
+  ]
+
+  return {
+    selectable: !canceled && !approvalPending && !shipmentLockInfo.locked && activeLinkedPoRows.length === 0,
+    canceled,
+    approvalPending,
+    shipmentLockInfo,
+    activeLinkedPoRows,
+    issuedReferences,
+  }
+}
+
+export function formatPiPoSelectionMessage(selectionInfo, piId = '') {
+  if (selectionInfo?.canceled) {
+    return `${piId || '선택한 PI'}는 취소 상태라 PO 등록 기준 문서로 사용할 수 없습니다.`
+  }
+
+  if (selectionInfo?.approvalPending) {
+    return `${piId || '선택한 PI'}는 결재대기 상태라 PO 등록 기준 문서로 사용할 수 없습니다.`
+  }
+
+  if (selectionInfo?.activeLinkedPoRows?.length) {
+    const linkedPo = selectionInfo.activeLinkedPoRows[0]
+    const issuedReference = selectionInfo.issuedReferences?.[0]
+
+    if (issuedReference) {
+      return `${piId || '선택한 PI'}는 이미 PO ${linkedPo.id}에 연결되어 있고 ${issuedReference.type} ${issuedReference.id}까지 발행되어 재사용할 수 없습니다.`
+    }
+
+    return `${piId || '선택한 PI'}는 이미 PO ${linkedPo.id}에 연결되어 있어 재사용할 수 없습니다.`
+  }
+
+  if (selectionInfo?.shipmentLockInfo?.locked) {
+    return formatPiShipmentLockMessage(selectionInfo.shipmentLockInfo)
+  }
+
+  return ''
+}

--- a/src/views/documents/PODetailPage.vue
+++ b/src/views/documents/PODetailPage.vue
@@ -14,7 +14,9 @@ import POFormModal from '@/components/domain/document/POFormModal.vue'
 import { useSearchModalLookups } from '@/composables/useSearchModalLookups'
 import { useToast } from '@/composables/useToast'
 import { useAuthStore } from '@/stores/auth'
+import { useCiDocuments } from '@/stores/ciDocuments'
 import { usePiDocuments } from '@/stores/piDocuments'
+import { usePlDocuments } from '@/stores/plDocuments'
 import { usePoDocuments } from '@/stores/poDocuments'
 import { useProductionOrderDocuments } from '@/stores/productionOrderDocuments'
 import { useShipmentOrderDocuments } from '@/stores/shipmentOrderDocuments'
@@ -32,7 +34,9 @@ import {
 import { recordDocumentEmailActivities } from '@/utils/documentActivityEmail'
 import { openDocumentOutputByType } from '@/utils/documentOutput'
 import {
+  formatPiPoSelectionMessage,
   formatPoShipmentLockMessage,
+  getPiPoSelectionInfo,
   getPoShipmentLockInfo,
   resolvePoShipmentDocumentStatus,
 } from '@/utils/documentShipmentLock'
@@ -57,7 +61,9 @@ const clientSearchKeyword = ref('')
 const selectedPi = ref(null)
 const selectedClient = ref(null)
 const pendingEditRequest = ref(null)
+const ciDocuments = useCiDocuments()
 const piDocuments = usePiDocuments()
+const plDocuments = usePlDocuments()
 const poDocuments = usePoDocuments()
 const productionOrderDocuments = useProductionOrderDocuments()
 const shipmentOrderDocuments = useShipmentOrderDocuments()
@@ -80,10 +86,28 @@ const approvalChangeColumns = [
   { key: 'after', label: '변경값', align: 'left' },
 ]
 
+const availablePiRows = computed(() => (
+  piDocuments.value.filter((row) => (
+    getPiPoSelectionInfo(
+      row,
+      poDocuments.value,
+      shipmentOrderDocuments.value,
+      shipmentStatusDocuments.value,
+      productionOrderDocuments.value,
+      ciDocuments.value,
+      plDocuments.value,
+      String(route.params.id ?? ''),
+    ).selectable
+  ))
+))
+
 const piRows = computed(() => {
   const keyword = piSearchKeyword.value.trim().toLowerCase()
-  if (!keyword) return piDocuments.value
-  return piDocuments.value.filter((row) => [row.id, row.clientName, row.currency, row.deliveryDate].some((value) => String(value ?? '').toLowerCase().includes(keyword)))
+  if (!keyword) return availablePiRows.value
+  return availablePiRows.value.filter((row) => (
+    [row.id, row.clientName, row.currency, row.deliveryDate]
+      .some((value) => String(value ?? '').toLowerCase().includes(keyword))
+  ))
 })
 
 const clientRows = createClientRows(clientSearchKeyword)
@@ -618,6 +642,22 @@ function openClientSearch() {
 }
 
 function handlePiSelect(pi) {
+  const selectionInfo = getPiPoSelectionInfo(
+    pi,
+    poDocuments.value,
+    shipmentOrderDocuments.value,
+    shipmentStatusDocuments.value,
+    productionOrderDocuments.value,
+    ciDocuments.value,
+    plDocuments.value,
+    String(route.params.id ?? ''),
+  )
+
+  if (!selectionInfo.selectable) {
+    warning(formatPiPoSelectionMessage(selectionInfo, pi?.id))
+    return
+  }
+
   selectedPi.value = pi
   piSearchOpen.value = false
   piSearchKeyword.value = ''

--- a/src/views/documents/POPage.vue
+++ b/src/views/documents/POPage.vue
@@ -25,6 +25,7 @@ import { useCiDocuments } from '@/stores/ciDocuments'
 import { usePiDocuments } from '@/stores/piDocuments'
 import { usePlDocuments } from '@/stores/plDocuments'
 import { usePoDocuments } from '@/stores/poDocuments'
+import { useProductionOrderDocuments } from '@/stores/productionOrderDocuments'
 import { useShipmentOrderDocuments } from '@/stores/shipmentOrderDocuments'
 import { useShipmentStatusDocuments } from '@/stores/shipmentStatusDocuments'
 import { useToast } from '@/composables/useToast'
@@ -49,7 +50,9 @@ import {
   recordDocumentEmailActivities,
 } from '@/utils/documentActivityEmail'
 import {
+  formatPiPoSelectionMessage,
   formatPoShipmentLockMessage,
+  getPiPoSelectionInfo,
   getPoShipmentLockInfo,
   resolvePoShipmentDocumentStatus,
 } from '@/utils/documentShipmentLock'
@@ -83,6 +86,7 @@ const pendingEditRequest = ref(null)
 const ciDocuments = useCiDocuments()
 const piRowsSource = usePiDocuments()
 const plDocuments = usePlDocuments()
+const productionOrderDocuments = useProductionOrderDocuments()
 const shipmentOrderDocuments = useShipmentOrderDocuments()
 const shipmentStatusDocuments = useShipmentStatusDocuments()
 const { clientRowsSource, createClientRows, createProductRows } = useSearchModalLookups()
@@ -151,10 +155,28 @@ const shipmentLockInfoByPoId = computed(() => (
   )
 ))
 
+const availablePiRows = computed(() => (
+  piRowsSource.value.filter((row) => (
+    getPiPoSelectionInfo(
+      row,
+      poRowsData.value,
+      shipmentOrderDocuments.value,
+      shipmentStatusDocuments.value,
+      productionOrderDocuments.value,
+      ciDocuments.value,
+      plDocuments.value,
+      formMode.value === 'edit' ? selectedRow.value?.id || '' : '',
+    ).selectable
+  ))
+))
+
 const piRows = computed(() => {
   const keyword = piSearchKeyword.value.trim().toLowerCase()
-  if (!keyword) return piRowsSource.value
-  return piRowsSource.value.filter((row) => [row.id, row.clientName, row.currency, row.deliveryDate].some((value) => value.toLowerCase().includes(keyword)))
+  if (!keyword) return availablePiRows.value
+  return availablePiRows.value.filter((row) => (
+    [row.id, row.clientName, row.currency, row.deliveryDate]
+      .some((value) => String(value ?? '').toLowerCase().includes(keyword))
+  ))
 })
 
 const clientRows = createClientRows(clientSearchKeyword)
@@ -938,6 +960,22 @@ function goToDetail(id) {
 }
 
 function handlePiSelect(pi) {
+  const selectionInfo = getPiPoSelectionInfo(
+    pi,
+    poRowsData.value,
+    shipmentOrderDocuments.value,
+    shipmentStatusDocuments.value,
+    productionOrderDocuments.value,
+    ciDocuments.value,
+    plDocuments.value,
+    formMode.value === 'edit' ? selectedRow.value?.id || '' : '',
+  )
+
+  if (!selectionInfo.selectable) {
+    warning(formatPiPoSelectionMessage(selectionInfo, pi?.id))
+    return
+  }
+
   selectedPi.value = pi
   piSearchOpen.value = false
   piSearchKeyword.value = ''


### PR DESCRIPTION
## 📋 작업 내용

<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->
  - PO 등록/수정 시 선택 가능한 PI 기준을 실제 문서 정합성에 맞게 정리했습니다.
  - 취소, 결재대기, 이미 다른 유효한 PO에 연결된 PI, 후속 문서가 발행된 PI는 PO 기준 문서 후보에서 제외되도록 수정했습니다.
  - 선택 가능한 PI가 전혀 없던 문제를 해결하기 위해 `db.json`에 후속 문서가 없는 신규 PI 더미데이터를 추가했습니다.


## 🔗 관련 이슈

<!-- 관련 이슈 번호를 적어주세요 (자동으로 이슈가 닫힙니다) -->
- closes #

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->



## ✅ 체크리스트
  - [x] 정상 동작 확인
  - [x] 불필요한 코드/주석 제거
  - [x] 충돌(conflict) 해결 완료
## 💬 리뷰어에게

<!-- 리뷰할 때 중점적으로 봐줬으면 하는 부분이 있다면 적어주세요 -->


  - 이번 작업은 PO 생성/수정 시 PI를 재사용하는 기준이 느슨해서 생기던 정합성 문제를 정리하는 데 초점을 맞췄습니다.
  - 단순히 `출하완료`만 막는 수준이 아니라, 이미 다른 유효한 PO에 연결돼 있거나 생산/출하/CI/PL까지 이어진 PI도 재선택되지 않도록 막았습니다.
  - 기존 더미데이터는 모든 PI가 이미 PO와 1:1로 연결돼 있어 테스트가 어려워, 후속 문서가 없는 신규 PI 3건을 `db.json`에 추가했습니다.
