### PR TITLE
refactor: Master 목록 검색을 검색 버튼/엔터 기반으로 전환

### DIFF
--- a/src/views/master/ClientListPage.vue
+++ b/src/views/master/ClientListPage.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import BaseButton from '@/components/common/BaseButton.vue'
 import BasePagination from '@/components/common/BasePagination.vue'
@@ -47,6 +47,7 @@ const filters = ref({
   manager: '',
   status: '',
 })
+const appliedFilters = ref({ keyword: '', code: '', name: '', country: '', manager: '', status: '' })
 
 const statusOptions = [
   { label: '전체', value: '' },
@@ -93,9 +94,12 @@ const countryOptions = computed(() => {
 
 function resetFilters() {
   filters.value = { keyword: '', code: '', name: '', country: '', manager: '', status: '' }
+  appliedFilters.value = { keyword: '', code: '', name: '', country: '', manager: '', status: '' }
+  currentPage.value = 1
 }
 
 function searchRows() {
+  appliedFilters.value = { ...filters.value }
   currentPage.value = 1
 }
 
@@ -107,7 +111,7 @@ const filteredClients = computed(() => {
     result = result.filter((c) => c.departmentId === Number(currentUser.value.departmentId))
   }
 
-  const f = filters.value
+  const f = appliedFilters.value
 
   if (f.keyword) {
     const kw = f.keyword.toLowerCase()
@@ -150,10 +154,6 @@ const paginatedClients = computed(() => {
   return filteredClients.value.slice(start, start + PAGE_SIZE)
 })
 
-// Reset to page 1 when filters change
-watch(filters, () => {
-  currentPage.value = 1
-}, { deep: true })
 
 async function loadData() {
   loading.value = true
@@ -239,67 +239,69 @@ function goToDetail(row) {
       </template>
     </PageHeader>
 
-    <FilterToolbarCard
-      v-model="filters.keyword"
-      :advanced-open="isAdvancedOpen"
-      placeholder="코드, 거래처명으로 검색"
-      @toggle-advanced="isAdvancedOpen = !isAdvancedOpen"
-    />
+    <div @keyup.enter="searchRows" class="space-y-6">
+      <FilterToolbarCard
+        v-model="filters.keyword"
+        :advanced-open="isAdvancedOpen"
+        placeholder="코드, 거래처명으로 검색"
+        @toggle-advanced="isAdvancedOpen = !isAdvancedOpen"
+      />
 
-    <CollapsibleFilterCard :open="isAdvancedOpen">
-      <div class="grid grid-cols-2 gap-3 text-sm md:grid-cols-3">
-        <FormField label="코드">
-          <BaseTextField v-model="filters.code" placeholder="코드 입력..." />
-        </FormField>
+      <CollapsibleFilterCard :open="isAdvancedOpen">
+        <div class="grid grid-cols-2 gap-3 text-sm md:grid-cols-3">
+          <FormField label="코드">
+            <BaseTextField v-model="filters.code" placeholder="코드 입력..." />
+          </FormField>
 
-        <FormField label="거래처명">
-          <BaseTextField v-model="filters.name" placeholder="영문 또는 한글명..." />
-        </FormField>
+          <FormField label="거래처명">
+            <BaseTextField v-model="filters.name" placeholder="영문 또는 한글명..." />
+          </FormField>
 
-        <FormField label="국가">
-          <SearchableCombobox
-            v-model="filters.country"
-            :options="countryOptions"
-            placeholder="국가 검색..."
-          />
-        </FormField>
+          <FormField label="국가">
+            <SearchableCombobox
+              v-model="filters.country"
+              :options="countryOptions"
+              placeholder="국가 검색..."
+            />
+          </FormField>
 
-        <FormField label="담당자">
-          <BaseTextField v-model="filters.manager" placeholder="담당자명..." />
-        </FormField>
+          <FormField label="담당자">
+            <BaseTextField v-model="filters.manager" placeholder="담당자명..." />
+          </FormField>
 
-        <FormField label="상태">
-          <SearchableCombobox
-            v-model="filters.status"
-            :options="statusOptions"
-            placeholder="상태 선택..."
-          />
-        </FormField>
-      </div>
+          <FormField label="상태">
+            <SearchableCombobox
+              v-model="filters.status"
+              :options="statusOptions"
+              placeholder="상태 선택..."
+            />
+          </FormField>
+        </div>
 
-      <div class="mt-2 flex items-center justify-end gap-2 border-t border-slate-100 pt-3">
-        <BaseButton variant="secondary" size="sm" @click="resetFilters">
-          <template #leading>
-            <i class="fas fa-undo text-xs" aria-hidden="true"></i>
-          </template>
-          초기화
-        </BaseButton>
+        <div class="mt-2 flex items-center justify-end gap-2 border-t border-slate-100 pt-3">
+          <BaseButton variant="secondary" size="sm" @click="resetFilters">
+            <template #leading>
+              <i class="fas fa-undo text-xs" aria-hidden="true"></i>
+            </template>
+            초기화
+          </BaseButton>
 
-        <BaseButton size="sm" @click="searchRows">
-          <template #leading>
-            <i class="fas fa-search text-xs" aria-hidden="true"></i>
-          </template>
-          검색
-        </BaseButton>
-      </div>
-    </CollapsibleFilterCard>
+          <BaseButton size="sm" @click="searchRows">
+            <template #leading>
+              <i class="fas fa-search text-xs" aria-hidden="true"></i>
+            </template>
+            검색
+          </BaseButton>
+        </div>
+      </CollapsibleFilterCard>
+    </div>
 
     <div v-if="loading" class="flex items-center justify-center py-20 text-slate-400">
       데이터를 불러오는 중입니다...
     </div>
 
     <BaseTable v-else :columns="columns" :rows="paginatedClients" row-key="id"
-      :empty-text="filters.keyword || filters.code || filters.name || filters.country || filters.manager || filters.status ? '검색 결과가 없습니다.' : '등록된 거래처가 없습니다.'"
+      :empty-text="appliedFilters.keyword || appliedFilters.code || appliedFilters.name || appliedFilters.country || appliedFilters.manager || appliedFilters.status ? '검색 결과가 없습니다.' : '등록된 거래처가 없습니다.'"
       :footer-text="`총 ${filteredClients.length}건`"
       clickable-rows
       @row-click="goToDetail"

--- a/src/views/master/ItemListPage.vue
+++ b/src/views/master/ItemListPage.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import BaseButton from '@/components/common/BaseButton.vue'
 import BasePagination from '@/components/common/BasePagination.vue'
@@ -40,6 +40,8 @@ const filters = ref({
   status: '',
 })
 
+const appliedFilters = ref({ keyword: '', code: '', name: '', category: '', unit: '', status: '' })
+
 const statusOptions = [
   { label: '전체', value: '' },
   { label: '활성', value: '활성' },
@@ -53,9 +55,12 @@ const unitOptions = computed(() => {
 
 function resetFilters() {
   filters.value = { keyword: '', code: '', name: '', category: '', unit: '', status: '' }
+  appliedFilters.value = { keyword: '', code: '', name: '', category: '', unit: '', status: '' }
+  currentPage.value = 1
 }
 
 function searchRows() {
+  appliedFilters.value = { ...filters.value }
   currentPage.value = 1
 }
 
@@ -94,7 +99,7 @@ const columns = computed(() => {
 
 const filteredItems = computed(() => {
   let result = items.value
-  const f = filters.value
+  const f = appliedFilters.value
 
   if (f.keyword) {
     const kw = f.keyword.toLowerCase()
@@ -136,11 +141,6 @@ const paginatedItems = computed(() => {
   const start = (currentPage.value - 1) * PAGE_SIZE
   return filteredItems.value.slice(start, start + PAGE_SIZE)
 })
-
-// Reset to page 1 when filters change
-watch(filters, () => {
-  currentPage.value = 1
-}, { deep: true })
 
 async function loadData() {
   loading.value = true
@@ -222,71 +222,73 @@ function goToDetail(row) {
       </template>
     </PageHeader>
 
-    <FilterToolbarCard
-      v-model="filters.keyword"
-      :advanced-open="isAdvancedOpen"
-      placeholder="코드, 품목명으로 검색"
-      @toggle-advanced="isAdvancedOpen = !isAdvancedOpen"
-    />
+    <div @keyup.enter="searchRows" class="space-y-6">
+      <FilterToolbarCard
+        v-model="filters.keyword"
+        :advanced-open="isAdvancedOpen"
+        placeholder="코드, 품목명으로 검색"
+        @toggle-advanced="isAdvancedOpen = !isAdvancedOpen"
+      />
 
-    <CollapsibleFilterCard :open="isAdvancedOpen">
-      <div class="grid grid-cols-2 gap-3 text-sm md:grid-cols-3">
-        <FormField label="코드">
-          <BaseTextField v-model="filters.code" placeholder="코드 입력..." />
-        </FormField>
+      <CollapsibleFilterCard :open="isAdvancedOpen">
+        <div class="grid grid-cols-2 gap-3 text-sm md:grid-cols-3">
+          <FormField label="코드">
+            <BaseTextField v-model="filters.code" placeholder="코드 입력..." />
+          </FormField>
 
-        <FormField label="품목명">
-          <BaseTextField v-model="filters.name" placeholder="영문 또는 한글명..." />
-        </FormField>
+          <FormField label="품목명">
+            <BaseTextField v-model="filters.name" placeholder="영문 또는 한글명..." />
+          </FormField>
 
-        <FormField label="카테고리">
-          <SearchableCombobox
-            v-model="filters.category"
-            :options="categoryOptions"
-            placeholder="카테고리 선택..."
-          />
-        </FormField>
+          <FormField label="카테고리">
+            <SearchableCombobox
+              v-model="filters.category"
+              :options="categoryOptions"
+              placeholder="카테고리 선택..."
+            />
+          </FormField>
 
-        <FormField label="단위">
-          <SearchableCombobox
-            v-model="filters.unit"
-            :options="unitOptions"
-            placeholder="단위 선택..."
-          />
-        </FormField>
+          <FormField label="단위">
+            <SearchableCombobox
+              v-model="filters.unit"
+              :options="unitOptions"
+              placeholder="단위 선택..."
+            />
+          </FormField>
 
-        <FormField label="상태">
-          <SearchableCombobox
-            v-model="filters.status"
-            :options="statusOptions"
-            placeholder="상태 선택..."
-          />
-        </FormField>
-      </div>
+          <FormField label="상태">
+            <SearchableCombobox
+              v-model="filters.status"
+              :options="statusOptions"
+              placeholder="상태 선택..."
+            />
+          </FormField>
+        </div>
 
-      <div class="mt-2 flex items-center justify-end gap-2 border-t border-slate-100 pt-3">
-        <BaseButton variant="secondary" size="sm" @click="resetFilters">
-          <template #leading>
-            <i class="fas fa-undo text-xs" aria-hidden="true"></i>
-          </template>
-          초기화
-        </BaseButton>
+        <div class="mt-2 flex items-center justify-end gap-2 border-t border-slate-100 pt-3">
+          <BaseButton variant="secondary" size="sm" @click="resetFilters">
+            <template #leading>
+              <i class="fas fa-undo text-xs" aria-hidden="true"></i>
+            </template>
+            초기화
+          </BaseButton>
 
-        <BaseButton size="sm" @click="searchRows">
-          <template #leading>
-            <i class="fas fa-search text-xs" aria-hidden="true"></i>
-          </template>
-          검색
-        </BaseButton>
-      </div>
-    </CollapsibleFilterCard>
+          <BaseButton size="sm" @click="searchRows">
+            <template #leading>
+              <i class="fas fa-search text-xs" aria-hidden="true"></i>
+            </template>
+            검색
+          </BaseButton>
+        </div>
+      </CollapsibleFilterCard>
+    </div>
 
     <div v-if="loading" class="flex items-center justify-center py-20 text-slate-400">
       데이터를 불러오는 중입니다...
     </div>
 
     <BaseTable v-else :columns="columns" :rows="paginatedItems" row-key="id"
-      :empty-text="filters.keyword || filters.code || filters.name || filters.category || filters.unit || filters.status ? '검색 결과가 없습니다.' : '등록된 품목이 없습니다.'"
+      :empty-text="appliedFilters.keyword || appliedFilters.code || appliedFilters.name || appliedFilters.category || appliedFilters.unit || appliedFilters.status ? '검색 결과가 없습니다.' : '등록된 품목이 없습니다.'"
       clickable-rows
       :footer-text="`총 ${filteredItems.length}건`"
       @row-click="goToDetail"


### PR DESCRIPTION
## 📋 작업 내용

거래처/품목 목록 화면의 검색을 실시간 반영에서 검색 버튼/엔터 기반으로 전환합니다.

- `filters`(입력용)와 `appliedFilters`(적용용)를 분리
- 검색 버튼 클릭 또는 엔터 키 입력 시에만 필터 결과 반영
- 초기화 버튼은 입력과 결과를 동시에 초기화
- 실시간 반응 deep watch 제거

## 🔗 관련 이슈

- closes #208

## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료
- [x] 키워드 타이핑 시 결과 변경 안 됨 확인
- [x] 검색 버튼/엔터 시 결과 반영 확인
- [x] 초기화 시 입력+결과 동시 초기화 확인
- [x] RBAC 부서별 필터링 유지 확인
- [x] common/ 컴포넌트 미수정

## 💬 리뷰어에게

- `appliedFilters`는 검색 실행 시에만 `filters`로부터 복사되므로, 입력 중 결과가 흔들리지 않습니다
- 엔터 키는 FilterToolbarCard + CollapsibleFilterCard를 감싸는 wrapper div의 `@keyup.enter`로 처리됩니다