### PR TITLE
feat: PI/PO 팀장 바이패스 구현 - 결재 없이 즉시 처리

### DIFF
--- a/src/views/documents/PIPage.vue
+++ b/src/views/documents/PIPage.vue
@@ -112,6 +112,8 @@ const { filters, filteredRows, resetFilters, applyFilters } = useDocumentFilter(
 })
 const { currentPage, totalPages, paginatedRows } = usePagination(filteredRows)
 
+const isTeamLeader = computed(() => Number(authStore.currentUser?.positionId) === 1)
+
 const managerOptions = computed(() => buildSelectOptionsFromRows(rowsData.value, 'manager'))
 const countryOptions = computed(() => buildSelectOptionsFromRows(rowsData.value, 'country'))
 const statusOptions = computed(() => buildSelectOptionsFromRows(rowsData.value, 'status'))
@@ -788,11 +790,29 @@ function handleSave(formValue) {
   const { nextRow } = buildRowPayload(formValue)
 
   if (formMode.value === 'create') {
+    if (isTeamLeader.value) {
+      const newId = buildNextPiId()
+      rowsData.value = [{ id: newId, ...nextRow, manager: authStore.currentUser?.name || '', status: '확정' }, ...rowsData.value]
+      formOpen.value = false
+      selectedClient.value = null
+      success('PI가 등록되었습니다.')
+      return
+    }
     pendingCreateFormValue.value = {
       ...formValue,
       items: (formValue.items ?? []).map((item) => ({ ...item })),
     }
     createApprovalRequestOpen.value = true
+    return
+  }
+
+  if (isTeamLeader.value) {
+    rowsData.value = rowsData.value.map((r) =>
+      r.id === selectedRow.value?.id ? { ...r, ...nextRow } : r
+    )
+    formOpen.value = false
+    selectedClient.value = null
+    success('PI가 수정되었습니다.')
     return
   }
 
@@ -823,6 +843,12 @@ function openDeleteApprovalRequest(row) {
   const shipmentLockInfo = shipmentLockInfoByPiId.value.get(row.id)
   if (shipmentLockInfo?.locked) {
     warning(formatPiShipmentLockMessage(shipmentLockInfo))
+    return
+  }
+
+  if (isTeamLeader.value) {
+    rowsData.value = rowsData.value.filter((r) => r.id !== row.id)
+    success(`${row.id} PI가 삭제되었습니다.`)
     return
   }
 

--- a/src/views/documents/POPage.vue
+++ b/src/views/documents/POPage.vue
@@ -138,6 +138,8 @@ const { filters, filteredRows, resetFilters, applyFilters } = useDocumentFilter(
 })
 const { currentPage, totalPages, paginatedRows } = usePagination(filteredRows)
 
+const isTeamLeader = computed(() => Number(authStore.currentUser?.positionId) === 1)
+
 const managerOptions = computed(() => buildSelectOptionsFromRows(rowsData.value, 'manager'))
 const countryOptions = computed(() => buildSelectOptionsFromRows(rowsData.value, 'country'))
 const statusOptions = computed(() => buildSelectOptionsFromRows(rowsData.value, 'status'))
@@ -862,6 +864,60 @@ function handleSave(formValue) {
   }
 
   if (formMode.value === 'create') {
+    if (isTeamLeader.value) {
+      const nextPoId = buildNextPoId()
+      const nextRow = buildRowPayload(formValue)
+      const requesterName = getCurrentRequesterName()
+
+      const createdPoRow = {
+        id: nextPoId,
+        ...nextRow,
+        manager: requesterName,
+        status: '확정',
+      }
+
+      const { ciDocument, plDocument, ciCreated, plCreated } = ensureCommercialDocumentsForPo(
+        createdPoRow,
+        ciDocuments.value,
+        plDocuments.value,
+      )
+      const nextShipmentOrder = createShipmentOrderFromPo(
+        createdPoRow,
+        shipmentOrderDocuments.value,
+        requesterName,
+        createdPoRow.piId ? [{ id: createdPoRow.piId, status: getLinkedPiById(createdPoRow.piId)?.status || '-' }] : [],
+      )
+      const nextShipmentStatus = createShipmentStatusFromOrder(
+        nextShipmentOrder,
+        shipmentStatusDocuments.value,
+        createdPoRow.status,
+      )
+      createdPoRow.linkedDocuments = [
+        ...(createdPoRow.piId ? [{ id: createdPoRow.piId, status: getLinkedPiById(createdPoRow.piId)?.status || '-' }] : []),
+        { id: nextShipmentOrder.id, status: nextShipmentOrder.status },
+      ]
+
+      poRowsData.value = [createdPoRow, ...poRowsData.value]
+      shipmentOrderDocuments.value = [nextShipmentOrder, ...shipmentOrderDocuments.value]
+      shipmentStatusDocuments.value = [nextShipmentStatus, ...shipmentStatusDocuments.value]
+
+      if (ciCreated) {
+        ciDocuments.value = [ciDocument, ...ciDocuments.value]
+      }
+      if (plCreated) {
+        plDocuments.value = [plDocument, ...plDocuments.value]
+      }
+
+      ciDocuments.value = applyShipmentOrderToCommercialDocuments(ciDocuments.value, createdPoRow.id, nextShipmentOrder.id)
+      plDocuments.value = applyShipmentOrderToCommercialDocuments(plDocuments.value, createdPoRow.id, nextShipmentOrder.id)
+
+      formOpen.value = false
+      selectedPi.value = null
+      selectedClient.value = null
+      success('PO가 즉시 확정 등록되었습니다.')
+      return
+    }
+
     pendingCreateFormValue.value = { ...formValue }
     createApprovalRequestOpen.value = true
     return
@@ -884,6 +940,20 @@ function handleSave(formValue) {
     return
   }
 
+  if (isTeamLeader.value) {
+    poRowsData.value = poRowsData.value.map((row) => (
+      row.id === selectedRow.value?.id
+        ? { ...row, ...nextRow }
+        : row
+    ))
+
+    formOpen.value = false
+    selectedPi.value = null
+    selectedClient.value = null
+    success('PO가 즉시 수정되었습니다.')
+    return
+  }
+
   pendingEditRequest.value = {
     id: selectedRow.value?.id,
     approver: formValue.approver || '',
@@ -898,6 +968,14 @@ function openDeleteApprovalRequest(row) {
   const shipmentLockInfo = shipmentLockInfoByPoId.value.get(row.id)
   if (shipmentLockInfo?.locked) {
     warning(formatPoShipmentLockMessage(shipmentLockInfo))
+    return
+  }
+
+  if (isTeamLeader.value) {
+    poRowsData.value = poRowsData.value.map((r) => (
+      r.id === row.id ? { ...r, status: '취소' } : r
+    ))
+    success(`${row.id} PO가 즉시 삭제(취소) 처리되었습니다.`)
     return
   }
 


### PR DESCRIPTION
## 📋 작업 내용

팀장급(positionId:1) 사용자가 PI/PO를 등록/수정/삭제할 때 결재 모달 없이 즉시 처리되도록 바이패스를 구현합니다.

### 동작 매트릭스

| 액션 | 팀장 (positionId:1) | 팀원 (positionId:2) |
|------|---------------------|---------------------|
| PI/PO 등록 | 즉시 확정 | 결재 요청 → 팀장 승인 |
| PI/PO 수정 | 즉시 반영 | 결재 요청 → 팀장 승인 |
| PI/PO 삭제 | 즉시 삭제/취소 | 결재 요청 → 팀장 승인 |

- PO 팀장 등록 시 연결 문서(CI/PL/출하지시서/출하현황)도 동시 생성
- shipment lock 체크는 팀장에게도 동일하게 적용

## 🔗 관련 이슈

- closes #210

## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료
- [x] PI 팀장 등록/수정/삭제 즉시 처리 확인
- [x] PO 팀장 등록/수정/삭제 즉시 처리 확인
- [x] 팀원 기존 결재 플로우 유지 확인
- [x] shipment lock 체크 유지 확인
- [x] common/ 컴포넌트 미수정

## 💬 리뷰어에게

- `isTeamLeader` computed를 PI/PO 각각에 추가하여 `positionId === 1` 여부를 판별합니다
- 팀장 바이패스 로직은 기존 결재 승인 시 실행되는 로직과 동일한 패턴을 따릅니다
- `documentApproval.js`는 변경하지 않았으며, 팀원용 결재 메타 생성은 기존 그대로입니다