### PR TITLE
feat: 활동기록 패키지 시스템 리뉴얼 — 대시보드 공유 & 열람 권한

### DIFF
--- a/db.json
+++ b/db.json
@@ -6732,5 +6732,67 @@
       "status": "출하준비"
     }
   ],
+  "activityPackages": [
+    {
+      "id": "PKG001",
+      "title": "2025년 1월 영업활동 보고",
+      "description": "1월 주요 거래처 미팅 및 이슈 정리",
+      "poId": "PO2025001",
+      "creatorId": "1",
+      "creatorName": "김영업",
+      "createdAt": "2025/03/20",
+      "updatedAt": "2025/03/20",
+      "dateFrom": "2025-01-01",
+      "dateTo": "2025-01-31",
+      "activityIds": ["1", "2", "3"],
+      "viewers": ["2", "3", "4", "5"],
+      "viewerNames": ["이생산", "박출하", "최관리", "정영업"]
+    },
+    {
+      "id": "PKG002",
+      "title": "2025년 2월 수출 활동 패키지",
+      "description": "2월 해외 바이어 미팅 및 계약 진행 사항 정리",
+      "poId": "PO2025003",
+      "creatorId": "5",
+      "creatorName": "정영업",
+      "createdAt": "2025/03/22",
+      "updatedAt": "2025/03/23",
+      "dateFrom": "2025-02-01",
+      "dateTo": "2025-02-28",
+      "activityIds": ["4", "5", "6"],
+      "viewers": ["1", "2", "8", "9"],
+      "viewerNames": ["김영업", "이생산", "윤생산", "임출하"]
+    },
+    {
+      "id": "PKG003",
+      "title": "Q1 생산 연동 이슈 보고",
+      "description": "1분기 생산 지연 관련 영업-생산 협의 내용",
+      "poId": "PO2025005",
+      "creatorId": "7",
+      "creatorName": "조영업",
+      "createdAt": "2025/03/25",
+      "updatedAt": "2025/03/25",
+      "dateFrom": "2025-01-01",
+      "dateTo": "2025-03-31",
+      "activityIds": ["1", "4", "7"],
+      "viewers": ["2", "3", "8", "11", "12"],
+      "viewerNames": ["이생산", "박출하", "윤생산", "신생산", "오출하"]
+    },
+    {
+      "id": "PKG004",
+      "title": "3월 출하 현황 공유",
+      "description": "3월 출하 일정 및 납기 관련 이슈 공유",
+      "poId": "PO2025007",
+      "creatorId": "1",
+      "creatorName": "김영업",
+      "createdAt": "2025/03/26",
+      "updatedAt": "2025/03/26",
+      "dateFrom": "2025-03-01",
+      "dateTo": "2025-03-31",
+      "activityIds": ["2", "5", "8"],
+      "viewers": ["3", "5", "9", "12"],
+      "viewerNames": ["박출하", "정영업", "임출하", "오출하"]
+    }
+  ],
   "$schema": "./node_modules/json-server/schema.json"
 }

--- a/src/api/package.js
+++ b/src/api/package.js
@@ -1,0 +1,25 @@
+import { api } from '@/lib/api'
+
+export function fetchPackages() {
+  return api.get('/activityPackages').then((r) => r.data)
+}
+
+export function fetchPackageById(id) {
+  return api.get(`/activityPackages/${id}`).then((r) => r.data)
+}
+
+export function createPackage(data) {
+  return api.post('/activityPackages', data).then((r) => r.data)
+}
+
+export function updatePackage(id, data) {
+  return api.put(`/activityPackages/${id}`, data).then((r) => r.data)
+}
+
+export function deletePackage(id) {
+  return api.delete(`/activityPackages/${id}`)
+}
+
+export function fetchAllUsers() {
+  return api.get('/users').then((r) => r.data)
+}

--- a/src/components/domain/activity/PackageDetailModal.vue
+++ b/src/components/domain/activity/PackageDetailModal.vue
@@ -1,0 +1,274 @@
+<script setup>
+import { computed } from 'vue'
+import { jsPDF } from 'jspdf'
+import BaseButton from '@/components/common/BaseButton.vue'
+import BaseModal from '@/components/common/BaseModal.vue'
+
+const props = defineProps({
+  open: {
+    type: Boolean,
+    default: false,
+  },
+  pkg: {
+    type: Object,
+    default: null,
+  },
+  isOwner: {
+    type: Boolean,
+    default: false,
+  },
+  activities: {
+    type: Array,
+    default: () => [],
+  },
+})
+
+const emit = defineEmits(['close', 'edit', 'delete'])
+
+const packageActivities = computed(() => {
+  if (!props.pkg?.activityIds?.length) return []
+  return props.activities.filter((a) => props.pkg.activityIds.includes(String(a.id)) || props.pkg.activityIds.includes(a.id))
+})
+
+const infoRows = computed(() => {
+  if (!props.pkg) return []
+  return [
+    { label: '작성자', value: props.pkg.creatorName || '-' },
+    { label: '작성일', value: props.pkg.createdAt || '-' },
+    { label: '수정일', value: props.pkg.updatedAt || '-' },
+    { label: '기간', value: `${props.pkg.dateFrom || '-'} ~ ${props.pkg.dateTo || '-'}` },
+    { label: 'PO번호', value: props.pkg.poId || '-' },
+  ]
+})
+
+function generatePdf() {
+  if (!props.pkg) return
+
+  const doc = new jsPDF({ orientation: 'portrait', unit: 'mm', format: 'a4' })
+  const pageW = doc.internal.pageSize.getWidth()
+  const margin = 20
+  let y = 20
+
+  // ── 헤더
+  doc.setFontSize(20)
+  doc.setFont('helvetica', 'bold')
+  doc.text('Activity Record Package', pageW / 2, y, { align: 'center' })
+  y += 8
+
+  doc.setFontSize(10)
+  doc.setFont('helvetica', 'normal')
+  doc.setTextColor(100)
+  doc.text(`Generated: ${new Date().toLocaleDateString('ko-KR')}`, pageW / 2, y, { align: 'center' })
+  y += 4
+
+  if (props.pkg.poId) {
+    doc.text(`PO: ${props.pkg.poId}`, pageW / 2, y, { align: 'center' })
+    y += 4
+  }
+  doc.text(`Period: ${props.pkg.dateFrom || '-'} ~ ${props.pkg.dateTo || '-'}`, pageW / 2, y, { align: 'center' })
+  y += 8
+
+  // 구분선
+  doc.setDrawColor(200)
+  doc.line(margin, y, pageW - margin, y)
+  y += 8
+
+  // ── 선택된 활동기록 목록
+  const selected = packageActivities.value
+
+  doc.setFontSize(13)
+  doc.setFont('helvetica', 'bold')
+  doc.setTextColor(0)
+  doc.text(`Activity Records (${selected.length})`, margin, y)
+  y += 7
+
+  if (selected.length === 0) {
+    doc.setFontSize(10)
+    doc.setFont('helvetica', 'normal')
+    doc.setTextColor(150)
+    doc.text('No records selected.', margin, y)
+    y += 6
+  } else {
+    const cols = [
+      { label: 'No',     x: margin,      w: 12  },
+      { label: 'Date',   x: margin + 12, w: 25  },
+      { label: 'Type',   x: margin + 37, w: 28  },
+      { label: 'Title',  x: margin + 65, w: 70  },
+      { label: 'Author', x: margin + 135, w: 30 },
+    ]
+
+    doc.setFillColor(240, 244, 255)
+    doc.rect(margin, y - 4, pageW - margin * 2, 7, 'F')
+    doc.setFontSize(9)
+    doc.setFont('helvetica', 'bold')
+    doc.setTextColor(50)
+    cols.forEach((c) => doc.text(c.label, c.x + 1, y))
+    y += 5
+
+    doc.setFont('helvetica', 'normal')
+    doc.setTextColor(30)
+
+    selected.forEach((a, i) => {
+      if (y > 270) {
+        doc.addPage()
+        y = 20
+      }
+      const bg = i % 2 === 0 ? [255, 255, 255] : [248, 250, 252]
+      doc.setFillColor(...bg)
+      doc.rect(margin, y - 4, pageW - margin * 2, 6, 'F')
+
+      doc.setFontSize(8.5)
+      doc.text(String(i + 1), cols[0].x + 1, y)
+      doc.text(a.date ?? '-',  cols[1].x + 1, y)
+      doc.text(a.type ?? '-',  cols[2].x + 1, y)
+
+      const title = doc.splitTextToSize(a.title ?? '-', cols[3].w - 2)[0]
+      doc.text(title, cols[3].x + 1, y)
+      doc.text(a.author ?? '-', cols[4].x + 1, y)
+      y += 6
+    })
+  }
+
+  y += 6
+  doc.setDrawColor(200)
+  doc.line(margin, y, pageW - margin, y)
+  y += 6
+
+  // ── 포함 항목 요약
+  const includedTypes = [...new Set(selected.map((a) => a.type))]
+  doc.setFontSize(13)
+  doc.setFont('helvetica', 'bold')
+  doc.setTextColor(0)
+  doc.text('Include Options', margin, y)
+  y += 7
+
+  doc.setFontSize(9)
+  doc.setFont('helvetica', 'normal')
+  doc.setTextColor(60)
+  if (includedTypes.length === 0) {
+    doc.text('No items selected', margin + 4, y)
+    y += 5
+  } else {
+    includedTypes.forEach((type) => {
+      doc.text(`- ${type}`, margin + 4, y)
+      y += 5
+    })
+  }
+
+  // ── 푸터
+  const totalPages = doc.internal.pages.length - 1
+  for (let p = 1; p <= totalPages; p++) {
+    doc.setPage(p)
+    doc.setFontSize(8)
+    doc.setTextColor(160)
+    doc.text(`Page ${p} / ${totalPages}`, pageW / 2, 290, { align: 'center' })
+    doc.text('SalesBoost - Activity Package', margin, 290)
+  }
+
+  const blob = doc.output('blob')
+  const url = URL.createObjectURL(blob)
+  window.open(url, '_blank')
+  setTimeout(() => URL.revokeObjectURL(url), 10000)
+}
+</script>
+
+<template>
+  <BaseModal
+    :open="open"
+    :title="pkg?.title || '패키지 상세'"
+    width="max-w-3xl"
+    @close="emit('close')"
+  >
+    <div v-if="pkg" class="space-y-5">
+      <!-- 기본 정보 -->
+      <div class="space-y-2">
+        <div
+          v-for="row in infoRows"
+          :key="row.label"
+          class="flex items-start gap-3 text-sm"
+        >
+          <span class="w-20 flex-shrink-0 font-semibold text-slate-500">{{ row.label }}</span>
+          <span class="text-slate-800">{{ row.value }}</span>
+        </div>
+      </div>
+
+      <!-- 설명 -->
+      <div v-if="pkg.description" class="space-y-1">
+        <h4 class="text-sm font-semibold text-slate-700">설명</h4>
+        <p class="rounded-lg border border-slate-100 bg-slate-50 px-3 py-2 text-sm text-slate-600">
+          {{ pkg.description }}
+        </p>
+      </div>
+
+      <!-- 포함 활동기록 -->
+      <div class="space-y-2">
+        <h4 class="text-sm font-semibold text-slate-700">
+          포함 활동기록
+          <span class="ml-1 text-xs font-normal text-slate-400">{{ packageActivities.length }}건</span>
+        </h4>
+        <div class="max-h-[200px] space-y-1.5 overflow-y-auto rounded-lg border border-slate-100 bg-slate-50 p-2">
+          <div
+            v-if="packageActivities.length === 0"
+            class="py-4 text-center text-xs text-slate-400"
+          >
+            활동기록이 없습니다.
+          </div>
+          <div
+            v-for="act in packageActivities"
+            :key="act.id"
+            class="flex items-center gap-2 rounded-md bg-white px-2.5 py-1.5 text-sm"
+          >
+            <span class="truncate font-medium text-slate-700">{{ act.title }}</span>
+            <span class="flex-shrink-0 text-xs text-slate-400">{{ act.date }}</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- 열람 권한 -->
+      <div class="space-y-2">
+        <h4 class="text-sm font-semibold text-slate-700">열람 권한</h4>
+        <div class="flex flex-wrap gap-1.5">
+          <span
+            v-for="name in (pkg.viewerNames || [])"
+            :key="name"
+            class="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-medium text-slate-600"
+          >
+            {{ name }}
+          </span>
+          <span
+            v-if="!pkg.viewerNames?.length"
+            class="text-xs text-slate-400"
+          >
+            열람 권한이 없습니다.
+          </span>
+        </div>
+      </div>
+    </div>
+
+    <template #footer>
+      <template v-if="isOwner">
+        <BaseButton variant="secondary" @click="generatePdf">
+          <template #leading>
+            <i class="fas fa-file-pdf text-xs" />
+          </template>
+          PDF 다운로드
+        </BaseButton>
+        <BaseButton variant="secondary" @click="emit('edit')">
+          <template #leading>
+            <i class="fas fa-pen text-xs" />
+          </template>
+          수정
+        </BaseButton>
+        <BaseButton variant="danger" @click="emit('delete')">
+          <template #leading>
+            <i class="fas fa-trash text-xs" />
+          </template>
+          삭제
+        </BaseButton>
+      </template>
+      <template v-else>
+        <BaseButton variant="secondary" @click="emit('close')">닫기</BaseButton>
+      </template>
+    </template>
+  </BaseModal>
+</template>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -328,6 +328,10 @@ const routes = [
       },
     ],
   },
+  {
+    path: '/:pathMatch(.*)*',
+    redirect: '/',
+  },
 ]
 
 const router = createRouter({

--- a/src/utils/roleAccess.js
+++ b/src/utils/roleAccess.js
@@ -1,8 +1,8 @@
 const COMMON_ROUTE_NAMES = new Set(['dashboard'])
 
 const ROLE_ROUTE_ALLOWLIST = {
-  production: new Set(['dashboard', 'production', 'production-detail']),
-  shipping: new Set(['dashboard', 'shipment-orders', 'shipment-order-detail', 'shipments', 'shipment-detail']),
+  production: new Set(['dashboard', 'production', 'production-detail', 'package']),
+  shipping: new Set(['dashboard', 'shipment-orders', 'shipment-order-detail', 'shipments', 'shipment-detail', 'package']),
 }
 
 export function canAccessRouteByRole(user, routeName) {
@@ -40,11 +40,11 @@ export function canAccessPathByRole(user, path) {
   }
 
   if (user.role === 'production') {
-    return path.startsWith('/production')
+    return path.startsWith('/production') || path.startsWith('/package')
   }
 
   if (user.role === 'shipping') {
-    return path.startsWith('/shipment-orders') || path.startsWith('/shipments')
+    return path.startsWith('/shipment-orders') || path.startsWith('/shipments') || path.startsWith('/package')
   }
 
   return false

--- a/src/views/DashboardPage.vue
+++ b/src/views/DashboardPage.vue
@@ -14,9 +14,13 @@ import { useProductionOrderDocuments } from '@/stores/productionOrderDocuments'
 import { useShipmentStatusDocuments } from '@/stores/shipmentStatusDocuments'
 import { fetchActivities } from '@/api/activity'
 import { fetchClients } from '@/api/master'
+import { fetchPackages, deletePackage as deletePackageApi } from '@/api/package'
+import { useToast } from '@/composables/useToast'
+import PackageDetailModal from '@/components/domain/activity/PackageDetailModal.vue'
 
 const router = useRouter()
 const authStore = useAuthStore()
+const { success, error: toastError } = useToast()
 const ciDocuments = useCiDocuments()
 const piDocuments = usePiDocuments()
 const plDocuments = usePlDocuments()
@@ -28,15 +32,20 @@ const decisionConfirmOpen = ref(false)
 const pendingDecision = ref('')
 const clientsData = ref([])
 const activitiesData = ref([])
+const packagesData = ref([])
+const selectedPackage = ref(null)
+const deleteConfirmOpen = ref(false)
 
 onMounted(async () => {
   try {
-    const [clients, activities] = await Promise.all([
+    const [clients, activities, packages] = await Promise.all([
       fetchClients(),
       fetchActivities(),
+      fetchPackages(),
     ])
     clientsData.value = clients
     activitiesData.value = activities
+    packagesData.value = packages
   } catch {
     // silent fail - dashboard still works with store data
   }
@@ -83,7 +92,7 @@ const summaryCards = computed(() => {
         count: String(productionOrderDocuments.value.length),
         status: inProgressCount > 0 ? '진행중' : '생산완료',
         helper: `진행중 ${inProgressCount}건`,
-        to: '/production-orders',
+        to: '/production',
         iconClass: 'fa-industry',
       },
     ]
@@ -403,6 +412,57 @@ function goToShipmentItem(item) {
     },
   })
 }
+
+// ── 패키지 섹션 ────────────────────────────────────────────
+const visiblePackages = computed(() => {
+  if (!currentUser.value) return []
+  const uid = String(currentUser.value.id)
+  return [...packagesData.value]
+    .filter((pkg) => String(pkg.creatorId) === uid || (pkg.viewers ?? []).includes(uid))
+    .sort((a, b) => parseSlashDate(b.createdAt) - parseSlashDate(a.createdAt))
+    .slice(0, 5)
+})
+
+const isPackageOwner = computed(() => {
+  if (!selectedPackage.value || !currentUser.value) return false
+  return String(selectedPackage.value.creatorId) === String(currentUser.value.id)
+})
+
+function openPackageDetail(pkg) {
+  selectedPackage.value = pkg
+}
+
+function closePackageDetail() {
+  selectedPackage.value = null
+}
+
+function handlePackageEdit() {
+  if (!selectedPackage.value) return
+  router.push({ path: '/package', query: { edit: selectedPackage.value.id } })
+  closePackageDetail()
+}
+
+function handlePackageDeleteRequest() {
+  deleteConfirmOpen.value = true
+}
+
+function closeDeleteConfirm() {
+  deleteConfirmOpen.value = false
+}
+
+async function confirmPackageDelete() {
+  if (!selectedPackage.value) return
+  try {
+    await deletePackageApi(selectedPackage.value.id)
+    packagesData.value = packagesData.value.filter((p) => p.id !== selectedPackage.value.id)
+    success('패키지가 삭제되었습니다.')
+    closeDeleteConfirm()
+    closePackageDetail()
+  } catch {
+    toastError('패키지 삭제에 실패했습니다.')
+    closeDeleteConfirm()
+  }
+}
 </script>
 
 <template>
@@ -433,6 +493,38 @@ function goToShipmentItem(item) {
         <div class="mt-3 truncate text-xs text-slate-400">{{ card.helper }}</div>
       </RouterLink>
     </section>
+
+    <!-- 공유 활동기록 패키지 (생산/출하: 요약카드 바로 뒤) -->
+    <BaseCard v-if="visiblePackages.length > 0 && (isProductionUser || isShippingUser)">
+      <template #title>
+        <h3 class="flex items-center gap-2 font-bold text-slate-800">
+          <i class="fas fa-cube text-brand-500" />
+          공유 활동기록 패키지
+        </h3>
+      </template>
+      <template #header-actions>
+        <RouterLink to="/package" class="text-xs font-medium text-brand-500 hover:text-brand-700">
+          전체보기 <i class="fas fa-chevron-right ml-0.5 text-[9px]" />
+        </RouterLink>
+      </template>
+      <div class="space-y-2">
+        <div
+          v-for="pkg in visiblePackages"
+          :key="pkg.id"
+          class="group flex cursor-pointer items-start gap-3 rounded-lg px-1 py-2 text-sm transition hover:bg-slate-50/70"
+          @click="openPackageDetail(pkg)"
+        >
+          <div class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-slate-50 text-xs text-slate-500">
+            <i class="fas fa-cube" />
+          </div>
+          <div class="min-w-0 flex-1">
+            <div class="truncate font-medium text-slate-800 transition group-hover:text-brand-600">{{ pkg.title }}</div>
+            <div class="truncate text-xs text-slate-400 sm:whitespace-normal">{{ pkg.creatorName }} · {{ pkg.createdAt }}</div>
+          </div>
+          <i class="fas fa-chevron-right text-xs text-slate-300 self-center" />
+        </div>
+      </div>
+    </BaseCard>
 
     <BaseCard
       v-if="showApprovalSection"
@@ -487,6 +579,38 @@ function goToShipmentItem(item) {
           </span>
           <StatusBadge :value="item.status" />
           <i class="fas fa-chevron-right text-xs text-slate-300" />
+        </div>
+      </div>
+    </BaseCard>
+
+    <!-- 공유 활동기록 패키지 (생산/출하: 요약카드 바로 뒤에 표시됨, 영업: 결재 뒤에 표시) -->
+    <BaseCard v-if="visiblePackages.length > 0 && !isProductionUser && !isShippingUser">
+      <template #title>
+        <h3 class="flex items-center gap-2 font-bold text-slate-800">
+          <i class="fas fa-cube text-brand-500" />
+          공유 활동기록 패키지
+        </h3>
+      </template>
+      <template #header-actions>
+        <RouterLink to="/package" class="text-xs font-medium text-brand-500 hover:text-brand-700">
+          전체보기 <i class="fas fa-chevron-right ml-0.5 text-[9px]" />
+        </RouterLink>
+      </template>
+      <div class="space-y-2">
+        <div
+          v-for="pkg in visiblePackages"
+          :key="pkg.id"
+          class="group flex cursor-pointer items-start gap-3 rounded-lg px-1 py-2 text-sm transition hover:bg-slate-50/70"
+          @click="openPackageDetail(pkg)"
+        >
+          <div class="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-slate-50 text-xs text-slate-500">
+            <i class="fas fa-cube" />
+          </div>
+          <div class="min-w-0 flex-1">
+            <div class="truncate font-medium text-slate-800 transition group-hover:text-brand-600">{{ pkg.title }}</div>
+            <div class="truncate text-xs text-slate-400 sm:whitespace-normal">{{ pkg.creatorName }} · {{ pkg.createdAt }}</div>
+          </div>
+          <i class="fas fa-chevron-right text-xs text-slate-300 self-center" />
         </div>
       </div>
     </BaseCard>
@@ -585,6 +709,28 @@ function goToShipmentItem(item) {
       :z-index="90"
       @confirm="confirmDecision"
       @cancel="closeDecisionConfirm"
+    />
+
+    <PackageDetailModal
+      :open="Boolean(selectedPackage)"
+      :pkg="selectedPackage"
+      :is-owner="isPackageOwner"
+      :activities="activitiesData"
+      @close="closePackageDetail"
+      @edit="handlePackageEdit"
+      @delete="handlePackageDeleteRequest"
+    />
+
+    <ConfirmModal
+      :open="deleteConfirmOpen"
+      title="패키지 삭제"
+      :message="selectedPackage ? `'${selectedPackage.title}' 패키지를 삭제하시겠습니까?` : ''"
+      confirm-label="삭제"
+      confirm-variant="danger"
+      helper-text="삭제 후 복구할 수 없습니다."
+      :z-index="90"
+      @confirm="confirmPackageDelete"
+      @cancel="closeDeleteConfirm"
     />
   </div>
 </template>

--- a/src/views/package/ActivityPackagePage.vue
+++ b/src/views/package/ActivityPackagePage.vue
@@ -1,19 +1,25 @@
 <script setup>
 import { computed, nextTick, onMounted, ref, watch } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { fetchActivities, fetchAllActivityPOs } from '@/api/activity'
+import { createPackage, fetchAllUsers, fetchPackageById, updatePackage } from '@/api/package'
 import { useToast } from '@/composables/useToast'
-import { jsPDF } from 'jspdf'
+import { useAuthStore } from '@/stores/auth'
 import ActivityTypeBadge from '@/components/domain/activity/ActivityTypeBadge.vue'
 import BaseButton from '@/components/common/BaseButton.vue'
 import BaseCard from '@/components/common/BaseCard.vue'
 import BaseTextField from '@/components/common/BaseTextField.vue'
+import BaseTextarea from '@/components/common/BaseTextarea.vue'
 import DateField from '@/components/common/DateField.vue'
 import DocumentPageHeader from '@/components/common/DocumentPageHeader.vue'
 import SearchModal from '@/components/common/SearchModal.vue'
 
 const router = useRouter()
-const { warning, error } = useToast()
+const route = useRoute()
+const { success, warning, error } = useToast()
+const authStore = useAuthStore()
+
+const currentUser = computed(() => authStore.currentUser ?? null)
 
 function todayKr() {
   const d = new Date()
@@ -22,20 +28,58 @@ function todayKr() {
   return `${d.getFullYear()}-${m}-${day}`
 }
 
+function nowSlash() {
+  const d = new Date()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${d.getFullYear()}/${m}/${day}`
+}
+
+// ── 편집 모드 ──────────────────────────────────────────────
+const isEditMode = computed(() => !!route.query.edit)
+const editId = computed(() => route.query.edit || '')
+
 // ── 데이터 ─────────────────────────────────────────────────
 const activities = ref([])
 const poList = ref([])
+const allUsers = ref([])
+const isSaving = ref(false)
 
 onMounted(async () => {
   try {
-    const [actData, poData] = await Promise.all([fetchActivities(), fetchAllActivityPOs()])
+    const [actData, poData, userData] = await Promise.all([
+      fetchActivities(),
+      fetchAllActivityPOs(),
+      fetchAllUsers(),
+    ])
     activities.value = actData
     poList.value = poData
+    allUsers.value = userData.filter((u) => u.status === '재직')
+
+    if (isEditMode.value) {
+      await loadPackageForEdit()
+    }
   } catch (e) {
     console.error('데이터 로드 실패', e)
     error('데이터를 불러오지 못했습니다. 페이지를 새로고침해주세요.')
   }
 })
+
+async function loadPackageForEdit() {
+  try {
+    const pkg = await fetchPackageById(editId.value)
+    packageTitle.value = pkg.title || ''
+    packageDescription.value = pkg.description || ''
+    selectedPoId.value = pkg.poId || ''
+    poDisplay.value = pkg.poId || ''
+    dateFrom.value = pkg.dateFrom || ''
+    dateTo.value = pkg.dateTo || ''
+    selectedActivityIds.value = [...(pkg.activityIds || [])]
+    selectedViewerIds.value = [...(pkg.viewers || [])]
+  } catch {
+    error('패키지 정보를 불러오지 못했습니다.')
+  }
+}
 
 const poColumns = [
   { key: 'id',           label: 'PO번호'  },
@@ -78,23 +122,49 @@ function clearPo() {
 }
 
 // ── 패키지 생성 폼 상태 ────────────────────────────────────
+const packageTitle = ref('')
+const packageDescription = ref('')
 const keyword     = ref('')
 const poDisplay   = ref('')
 const dateFrom    = ref('')
 const dateTo      = ref(todayKr())
 
+// ── 열람 권한 ──────────────────────────────────────────────
+const selectedViewerIds = ref([])
+const viewerSearchQuery = ref('')
+
+const filteredUsers = computed(() => {
+  const q = viewerSearchQuery.value.trim().toLowerCase()
+  const userList = allUsers.value.filter((u) => String(u.id) !== String(currentUser.value?.id))
+  if (!q) return userList
+  return userList.filter((u) => u.name.toLowerCase().includes(q) || (u.email ?? '').toLowerCase().includes(q))
+})
+
+function toggleViewer(userId) {
+  const id = String(userId)
+  if (selectedViewerIds.value.includes(id)) {
+    selectedViewerIds.value = selectedViewerIds.value.filter((v) => v !== id)
+  } else {
+    selectedViewerIds.value = [...selectedViewerIds.value, id]
+  }
+}
+
 // ── 유효성 검사 ────────────────────────────────────────────
 const errors = ref({})
 
+watch(packageTitle, (val) => { if (val) errors.value.title = undefined })
 watch(poDisplay,  (val) => { if (val) errors.value.po       = undefined })
 watch(dateFrom,   (val) => { if (val) errors.value.dateFrom = undefined })
 watch(dateTo,     (val) => { if (val) errors.value.dateTo   = undefined })
 
 function validate() {
   const e = {}
+  if (!packageTitle.value.trim()) e.title = '패키지 제목을 입력해주세요.'
   if (!poDisplay.value)  e.po       = '수주건 값이 누락되었습니다.'
   if (!dateFrom.value)   e.dateFrom = '기간 시작일 값이 누락되었습니다.'
   if (!dateTo.value)     e.dateTo   = '기간 종료일 값이 누락되었습니다.'
+  if (selectedViewerIds.value.length === 0) e.viewers = '열람 권한을 1명 이상 선택해주세요.'
+  if (selectedActivityIds.value.length === 0) e.activities = '활동기록을 1건 이상 선택해주세요.'
   errors.value = e
   return Object.keys(e).length === 0
 }
@@ -142,14 +212,26 @@ const filteredActivities = computed(() => {
   return list
 })
 
-// 활동기록 기간 변경 시 필터 결과 전체 선택
+// 활동기록 기간 변경 시 필터 결과 전체 선택 (편집 모드에서는 초기 로드 시 건너뜀)
+const initialLoadDone = ref(false)
+
 watch([actDateFrom, actDateTo], async () => {
+  if (isEditMode.value && !initialLoadDone.value) {
+    initialLoadDone.value = true
+    return
+  }
   await nextTick()
   selectedActivityIds.value = filteredActivities.value.map((a) => a.id)
 })
 
-// PO 변경 시 전체 선택으로 리셋
+// PO 변경 시 전체 선택으로 리셋 (편집 모드 초기 로드 제외)
+const poInitialLoadDone = ref(false)
+
 watch(selectedPoId, async () => {
+  if (isEditMode.value && !poInitialLoadDone.value) {
+    poInitialLoadDone.value = true
+    return
+  }
   await nextTick()
   selectedActivityIds.value = filteredActivities.value.map((a) => a.id)
 })
@@ -187,138 +269,51 @@ const summaryText = computed(() => {
   return `미리보기: ${parts.join(', ')}이 포함됩니다.`
 })
 
-function generatePdf() {
+// ── 저장 ───────────────────────────────────────────────────
+async function savePackage() {
   if (!validate()) {
     warning('입력 내용을 확인해주세요.')
     return
   }
-  const doc = new jsPDF({ orientation: 'portrait', unit: 'mm', format: 'a4' })
-  const pageW = doc.internal.pageSize.getWidth()
-  const margin = 20
-  let y = 20
 
-  // ── 헤더 ──────────────────────────────────────────────────
-  doc.setFontSize(20)
-  doc.setFont('helvetica', 'bold')
-  doc.text('Activity Record Package', pageW / 2, y, { align: 'center' })
-  y += 8
+  isSaving.value = true
 
-  doc.setFontSize(10)
-  doc.setFont('helvetica', 'normal')
-  doc.setTextColor(100)
-  doc.text(`Generated: ${new Date().toLocaleDateString('ko-KR')}`, pageW / 2, y, { align: 'center' })
-  y += 4
+  const viewerNames = selectedViewerIds.value.map((vid) => {
+    const u = allUsers.value.find((u) => String(u.id) === String(vid))
+    return u?.name || '-'
+  })
 
-  if (poDisplay.value) {
-    doc.text(`PO: ${poDisplay.value}`, pageW / 2, y, { align: 'center' })
-    y += 4
-  }
-  doc.text(`Period: ${dateFrom.value || '전체'} ~ ${dateTo.value || '전체'}`, pageW / 2, y, { align: 'center' })
-  y += 8
-
-  // 구분선
-  doc.setDrawColor(200)
-  doc.line(margin, y, pageW - margin, y)
-  y += 8
-
-  // ── 선택된 활동기록 목록 ───────────────────────────────────
-  const selected = selectedActivities.value
-
-  doc.setFontSize(13)
-  doc.setFont('helvetica', 'bold')
-  doc.setTextColor(0)
-  doc.text(`Activity Records (${selected.length})`, margin, y)
-  y += 7
-
-  if (selected.length === 0) {
-    doc.setFontSize(10)
-    doc.setFont('helvetica', 'normal')
-    doc.setTextColor(150)
-    doc.text('No records selected.', margin, y)
-    y += 6
-  } else {
-    // 테이블 헤더
-    const cols = [
-      { label: 'No',     x: margin,      w: 12  },
-      { label: 'Date',   x: margin + 12, w: 25  },
-      { label: 'Type',   x: margin + 37, w: 28  },
-      { label: 'Title',  x: margin + 65, w: 70  },
-      { label: 'Author', x: margin + 135, w: 30 },
-    ]
-
-    doc.setFillColor(240, 244, 255)
-    doc.rect(margin, y - 4, pageW - margin * 2, 7, 'F')
-    doc.setFontSize(9)
-    doc.setFont('helvetica', 'bold')
-    doc.setTextColor(50)
-    cols.forEach((c) => doc.text(c.label, c.x + 1, y))
-    y += 5
-
-    doc.setFont('helvetica', 'normal')
-    doc.setTextColor(30)
-
-    selected.forEach((a, i) => {
-      if (y > 270) {
-        doc.addPage()
-        y = 20
-      }
-      const bg = i % 2 === 0 ? [255, 255, 255] : [248, 250, 252]
-      doc.setFillColor(...bg)
-      doc.rect(margin, y - 4, pageW - margin * 2, 6, 'F')
-
-      doc.setFontSize(8.5)
-      doc.text(String(i + 1), cols[0].x + 1, y)
-      doc.text(a.date ?? '-',  cols[1].x + 1, y)
-      doc.text(a.type ?? '-',  cols[2].x + 1, y)
-
-      // 제목 말줄임
-      const title = doc.splitTextToSize(a.title ?? '-', cols[3].w - 2)[0]
-      doc.text(title, cols[3].x + 1, y)
-      doc.text(a.author ?? '-', cols[4].x + 1, y)
-      y += 6
-    })
+  const payload = {
+    title: packageTitle.value.trim(),
+    description: packageDescription.value.trim(),
+    poId: selectedPoId.value,
+    creatorId: String(currentUser.value?.id),
+    creatorName: currentUser.value?.name || '-',
+    createdAt: isEditMode.value ? undefined : nowSlash(),
+    updatedAt: nowSlash(),
+    dateFrom: dateFrom.value,
+    dateTo: dateTo.value,
+    activityIds: [...selectedActivityIds.value],
+    viewers: [...selectedViewerIds.value],
+    viewerNames,
   }
 
-  y += 6
-  doc.setDrawColor(200)
-  doc.line(margin, y, pageW - margin, y)
-  y += 6
-
-  // ── 포함 항목 요약 ─────────────────────────────────────────
-  doc.setFontSize(13)
-  doc.setFont('helvetica', 'bold')
-  doc.setTextColor(0)
-  doc.text('Include Options', margin, y)
-  y += 7
-
-  doc.setFontSize(9)
-  doc.setFont('helvetica', 'normal')
-  doc.setTextColor(60)
-  if (includedTypes.value.length === 0) {
-    doc.text('• 선택된 항목 없음', margin + 4, y)
-    y += 5
-  } else {
-    includedTypes.value.forEach((type) => {
-      doc.text(`• ${type}`, margin + 4, y)
-      y += 5
-    })
+  try {
+    if (isEditMode.value) {
+      delete payload.createdAt
+      await updatePackage(editId.value, payload)
+      success('패키지가 수정되었습니다.')
+    } else {
+      payload.id = `PKG${String(Date.now()).slice(-6)}`
+      await createPackage(payload)
+      success('패키지가 저장되었습니다.')
+    }
+    router.push('/')
+  } catch {
+    error('패키지 저장에 실패했습니다.')
+  } finally {
+    isSaving.value = false
   }
-
-  // ── 푸터 ──────────────────────────────────────────────────
-  const totalPages = doc.internal.pages.length - 1
-  for (let p = 1; p <= totalPages; p++) {
-    doc.setPage(p)
-    doc.setFontSize(8)
-    doc.setTextColor(160)
-    doc.text(`Page ${p} / ${totalPages}`, pageW / 2, 290, { align: 'center' })
-    doc.text('SalesBoost - Activity Package', margin, 290)
-  }
-
-  // 새 탭에서 PDF 미리보기
-  const blob = doc.output('blob')
-  const url = URL.createObjectURL(blob)
-  window.open(url, '_blank')
-  setTimeout(() => URL.revokeObjectURL(url), 10000)
 }
 </script>
 
@@ -343,8 +338,31 @@ function generatePdf() {
 
       <!-- ── 좌측: 패키지 생성 폼 ──────────────────────────── -->
       <div class="lg:col-span-2">
-        <BaseCard title="패키지 생성">
+        <BaseCard :title="isEditMode ? '패키지 수정' : '패키지 생성'">
           <div class="space-y-5">
+
+            <!-- 패키지 제목 -->
+            <div class="space-y-1.5">
+              <p class="text-sm font-semibold text-slate-700">
+                패키지 제목 <span class="text-red-500">*</span>
+              </p>
+              <BaseTextField
+                v-model="packageTitle"
+                placeholder="패키지 제목을 입력하세요"
+                :class="errors.title ? 'border-red-400' : ''"
+              />
+              <p v-if="errors.title" class="mt-1 text-xs text-red-500">{{ errors.title }}</p>
+            </div>
+
+            <!-- 설명 -->
+            <div class="space-y-1.5">
+              <p class="text-sm font-semibold text-slate-700">설명</p>
+              <BaseTextarea
+                v-model="packageDescription"
+                placeholder="패키지에 대한 설명을 입력하세요 (선택)"
+                :rows="3"
+              />
+            </div>
 
             <!-- 키워드 검색 -->
             <div class="space-y-1.5">
@@ -399,20 +417,58 @@ function generatePdf() {
               </div>
             </div>
 
+            <!-- 열람 권한 -->
+            <div class="space-y-2">
+              <p class="text-sm font-semibold text-slate-700">
+                열람 권한 <span class="text-red-500">*</span>
+                <span v-if="selectedViewerIds.length > 0" class="ml-2 text-xs font-normal text-brand-600">
+                  {{ selectedViewerIds.length }}명 선택됨
+                </span>
+              </p>
+              <BaseTextField
+                v-model="viewerSearchQuery"
+                placeholder="사용자 이름 또는 이메일로 검색"
+              />
+              <div class="max-h-[200px] space-y-1 overflow-y-auto rounded-lg border border-slate-200 bg-slate-50 p-2">
+                <div
+                  v-if="filteredUsers.length === 0"
+                  class="py-4 text-center text-xs text-slate-400"
+                >
+                  검색 결과가 없습니다.
+                </div>
+                <label
+                  v-for="user in filteredUsers"
+                  :key="user.id"
+                  class="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 transition hover:bg-slate-100"
+                >
+                  <input
+                    type="checkbox"
+                    class="rounded border-slate-300 text-brand-500"
+                    :checked="selectedViewerIds.includes(String(user.id))"
+                    @change="toggleViewer(user.id)"
+                  />
+                  <span class="text-sm text-slate-700">{{ user.name }}</span>
+                  <span class="text-xs text-slate-400">{{ user.email }}</span>
+                </label>
+              </div>
+              <p v-if="errors.viewers" class="mt-1 text-xs text-red-500">{{ errors.viewers }}</p>
+            </div>
+
             <!-- 미리보기 요약 -->
             <div class="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 text-xs text-slate-600">
               {{ summaryText }}
             </div>
+            <p v-if="errors.activities" class="text-xs text-red-500">{{ errors.activities }}</p>
 
-            <!-- 생성 버튼 -->
-            <BaseButton :block="true" @click="generatePdf">
+            <!-- 저장 버튼 -->
+            <BaseButton :block="true" :disabled="isSaving" @click="savePackage">
               <template #leading>
                 <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                   <path d="M10.75 2.75a.75.75 0 0 0-1.5 0v8.614L6.295 8.235a.75.75 0 1 0-1.09 1.03l4.25 4.5a.75.75 0 0 0 1.09 0l4.25-4.5a.75.75 0 0 0-1.09-1.03l-2.955 3.129V2.75Z" />
                   <path d="M3.5 12.75a.75.75 0 0 0-1.5 0v2.5A2.75 2.75 0 0 0 4.75 18h10.5A2.75 2.75 0 0 0 18 15.25v-2.5a.75.75 0 0 0-1.5 0v2.5c0 .69-.56 1.25-1.25 1.25H4.75c-.69 0-1.25-.56-1.25-1.25v-2.5Z" />
                 </svg>
               </template>
-              패키지(PDF) 생성
+              {{ isEditMode ? '패키지 수정' : '패키지 저장' }}
             </BaseButton>
 
           </div>


### PR DESCRIPTION
## 📋 작업 내용

활동기록 패키지 시스템을 전면 리뉴얼하여 패키지 생성/공유/열람 기능을 구현하고, 대시보드 라우팅 버그를 수정합니다.

### 변경 파일 (7개, +707/-140)

| 파일 | 변경 내용 |
|---|---|
| `src/views/DashboardPage.vue` | 공유 패키지 목록 섹션 추가 (영업: 결재란 아래, 생산/출하: 카드 아래), PackageDetailModal 연동 |
| `src/views/package/ActivityPackagePage.vue` | PDF 전용 → 패키지 생성/수정 화면으로 개편, 제목/설명/열람권한 UI 추가 |
| `src/components/domain/activity/PackageDetailModal.vue` | **신규** — 패키지 상세 모달 (작성자: PDF/수정/삭제, 열람자: 조회 전용) |
| `src/api/package.js` | **신규** — 패키지 CRUD + 사용자 목록 API 모듈 |
| `src/utils/roleAccess.js` | 생산/출하 역할에 package 라우트 접근 권한 추가 |
| `src/router/index.js` | catch-all 라우트 추가 (미정의 경로 → 대시보드 리다이렉트) |
| `db.json` | activityPackages 리소스 및 샘플 데이터 4건 추가 |

### 주요 기능

1. **홈 라우팅 수정**: 생산 카드 링크 `/production-orders` → `/production`, catch-all 라우트 추가
2. **패키지 작성 화면**: PO 선택 + 활동기록 체크 + N명 사용자 열람 권한 부여 + 제목/설명 입력
3. **패키지 수정 모드**: URL `?edit={id}`로 기존 패키지 불러와서 수정 (PUT)
4. **대시보드 공유 목록**: 본인 생성 + 열람 권한 있는 패키지 최대 5건 표시
5. **상세 모달**: 작성자는 PDF 다운로드/수정/삭제, 열람자는 조회만 가능

## 🔗 관련 이슈

- closes #213

## ✅ 체크리스트

- [x] 정상 동작 확인 (빌드 478 모듈 transform 성공)
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료
- [x] QA 검증 완료 (라우팅/API/모달/권한 전 항목 PASS)

## 💬 리뷰어에게

- DashboardPage에서 패키지 섹션이 역할별로 다른 위치에 렌더링됩니다 (영업: 결재란 아래, 생산/출하: summary 카드 바로 아래)
- PackageDetailModal에서 jsPDF로 PDF 생성하는 로직은 기존 ActivityPackagePage에서 이동시킨 것입니다
- 열람 권한 선택 UI는 전체 사용자 목록에서 이름으로 검색/필터하여 체크박스로 선택하는 방식입니다

🤖 Generated with [Claude Code](https://claude.com/claude-code)