### PR TITLE
[refactor] 컨택 리스트 접근 권한을 등록자 본인 및 관리자로 제한

### DIFF
--- a/db.json
+++ b/db.json
@@ -4073,6 +4073,16 @@
       "email": "thanh.le@hanoidigital.vn",
       "tel": "+84-24-3999-2002",
       "signImageUrl": null
+    },
+    {
+      "id": "2441",
+      "clientId": "2",
+      "name": "정진호",
+      "position": "Team Leader",
+      "email": "wjswldh@naver.com",
+      "tel": "010-1234-1234",
+      "signImageUrl": null,
+      "createdBy": "5"
     }
   ],
   "activityPOs": [

--- a/src/views/contacts/ContactListPage.vue
+++ b/src/views/contacts/ContactListPage.vue
@@ -3,6 +3,7 @@ import { computed, onMounted, ref, watch } from 'vue'
 import { useToast } from '@/composables/useToast'
 import { fetchBuyers, createBuyer, updateBuyer, deleteBuyer } from '@/api/contacts'
 import { fetchActivityClients } from '@/api/activity'
+import { useAuthStore } from '@/stores/auth'
 import BaseButton from '@/components/common/BaseButton.vue'
 import FormField from '@/components/common/FormField.vue'
 import BaseModal from '@/components/common/BaseModal.vue'
@@ -16,9 +17,19 @@ import TableActions from '@/components/common/TableActions.vue'
 
 const { warning, error } = useToast()
 
+const authStore = useAuthStore()
+const currentUser = computed(() => authStore.currentUser)
+const isAdmin = computed(() => currentUser.value?.role === 'admin')
+
 // ── 데이터 ─────────────────────────────────────────────────
 const clients = ref([])
 const contacts = ref([])
+
+// 관리자는 전체, 일반 사용자는 본인 등록 연락처만
+const myContacts = computed(() => {
+  if (isAdmin.value) return contacts.value
+  return contacts.value.filter((c) => c.createdBy === currentUser.value?.id)
+})
 
 onMounted(async () => {
   try {
@@ -46,14 +57,17 @@ function applySearch() {
   searchKeyword.value = searchInput.value
 }
 
-const filteredClients = computed(() => {
-  if (!searchKeyword.value) return clients.value
-  return clients.value.filter((c) => String(c.id) === String(searchKeyword.value))
-})
-
 function getContactsByClient(clientId) {
-  return contacts.value.filter((c) => String(c.clientId) === String(clientId))
+  return myContacts.value.filter((c) => String(c.clientId) === String(clientId))
 }
+
+const filteredClients = computed(() => {
+  let result = clients.value
+  if (searchKeyword.value) {
+    result = result.filter((c) => String(c.id) === String(searchKeyword.value))
+  }
+  return result.filter((c) => getContactsByClient(c.id).length > 0)
+})
 
 // ── 상세 모달 ──────────────────────────────────────────────
 const selectedContact = ref(null)
@@ -144,6 +158,7 @@ async function handleFormSubmit() {
     email:       formEmail.value,
     tel:         formTel.value,
     signImageUrl: null,
+    createdBy:   currentUser.value?.id,
   }
   try {
     if (isEditMode.value) {


### PR DESCRIPTION
## 📋 작업 내용

<!-- 이 PR에서 작업한 내용을 간단히 설명해주세요 -->

컨택 리스트(`/contacts`)에서 로그인한 사용자가 직접 등록한 연락처에 대해서만 조회·수정·삭제가 가능하도록 접근 제한 로직을 적용합니다.
시스템 관리자(`role: admin`)는 모든 연락처에 대해 전체 권한을 가집니다.

  - `useAuthStore`에서 `currentUser`, `role` 조회
  - `myContacts` computed — admin이면 전체, 일반 사용자면 `createdBy === currentUser.id` 필터링
  - 연락처 없는 거래처 그룹은 목록에서 자동 숨김
  - 연락처 등록 시 `createdBy: currentUser.id` 저장


## 🔗 관련 이슈

<!-- 관련 이슈 번호를 적어주세요 (자동으로 이슈가 닫힙니다) -->
- closes #212  

## 📸 스크린샷 (선택)

<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->



## ✅ 체크리스트

- [ ] 정상 동작 확인
- [ ] 불필요한 코드/주석 제거
- [ ] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

<!-- 리뷰할 때 중점적으로 봐줬으면 하는 부분이 있다면 적어주세요 -->

- 기존 db.json buyers 데이터에는 `createdBy` 필드가 없어 로그인 후 신규 등록한 연락처만 표시됩니다. 기존 데이터 마이그레이션이 필요하면 논의 부탁드립니다.
