### PR TITLE
feat: 활동기록 패키지 UX 개선 — 라우팅·모달·열람 권한·PDF

### DIFF
--- a/src/components/domain/activity/PackageDetailModal.vue
+++ b/src/components/domain/activity/PackageDetailModal.vue
@@ -1,6 +1,8 @@
 <script setup>
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { jsPDF } from 'jspdf'
+import ActivityDetailModal from '@/components/domain/activity/ActivityDetailModal.vue'
+import ActivityTypeBadge from '@/components/domain/activity/ActivityTypeBadge.vue'
 import BaseButton from '@/components/common/BaseButton.vue'
 import BaseModal from '@/components/common/BaseModal.vue'
 
@@ -24,6 +26,16 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['close', 'edit', 'delete'])
+
+const selectedActivity = ref(null)
+
+function openActivityDetail(act) {
+  selectedActivity.value = act
+}
+
+function closeActivityDetail() {
+  selectedActivity.value = null
+}
 
 const packageActivities = computed(() => {
   if (!props.pkg?.activityIds?.length) return []
@@ -173,12 +185,13 @@ function generatePdf() {
 </script>
 
 <template>
-  <BaseModal
-    :open="open"
-    :title="pkg?.title || '패키지 상세'"
-    width="max-w-3xl"
-    @close="emit('close')"
-  >
+  <div>
+    <BaseModal
+      :open="open"
+      :title="pkg?.title || '패키지 상세'"
+      width="max-w-3xl"
+      @close="emit('close')"
+    >
     <div v-if="pkg" class="space-y-5">
       <!-- 기본 정보 -->
       <div class="space-y-2">
@@ -216,8 +229,10 @@ function generatePdf() {
           <div
             v-for="act in packageActivities"
             :key="act.id"
-            class="flex items-center gap-2 rounded-md bg-white px-2.5 py-1.5 text-sm"
+            class="flex cursor-pointer items-center gap-2 rounded-md bg-white px-2.5 py-1.5 text-sm transition hover:bg-slate-100"
+            @click="openActivityDetail(act)"
           >
+            <ActivityTypeBadge :value="act.type" />
             <span class="truncate font-medium text-slate-700">{{ act.title }}</span>
             <span class="flex-shrink-0 text-xs text-slate-400">{{ act.date }}</span>
           </div>
@@ -267,8 +282,20 @@ function generatePdf() {
         </BaseButton>
       </template>
       <template v-else>
+        <BaseButton variant="secondary" @click="generatePdf">
+          <template #leading>
+            <i class="fas fa-file-pdf text-xs" />
+          </template>
+          PDF 다운로드
+        </BaseButton>
         <BaseButton variant="secondary" @click="emit('close')">닫기</BaseButton>
       </template>
     </template>
-  </BaseModal>
+    </BaseModal>
+    <ActivityDetailModal
+      :open="Boolean(selectedActivity)"
+      :activity="selectedActivity || {}"
+      @close="closeActivityDetail"
+    />
+  </div>
 </template>

--- a/src/utils/roleAccess.js
+++ b/src/utils/roleAccess.js
@@ -1,8 +1,8 @@
 const COMMON_ROUTE_NAMES = new Set(['dashboard'])
 
 const ROLE_ROUTE_ALLOWLIST = {
-  production: new Set(['dashboard', 'production', 'production-detail', 'package']),
-  shipping: new Set(['dashboard', 'shipment-orders', 'shipment-order-detail', 'shipments', 'shipment-detail', 'package']),
+  production: new Set(['dashboard', 'production', 'production-detail']),
+  shipping: new Set(['dashboard', 'shipment-orders', 'shipment-order-detail', 'shipments', 'shipment-detail']),
 }
 
 export function canAccessRouteByRole(user, routeName) {
@@ -40,19 +40,17 @@ export function canAccessPathByRole(user, path) {
   }
 
   if (user.role === 'production') {
-    return path.startsWith('/production') || path.startsWith('/package')
+    return path.startsWith('/production')
   }
 
   if (user.role === 'shipping') {
-    return path.startsWith('/shipment-orders') || path.startsWith('/shipments') || path.startsWith('/package')
+    return path.startsWith('/shipment-orders') || path.startsWith('/shipments')
   }
 
   return false
 }
 
 export function getRoleHomePath(role) {
-  if (role === 'production') return '/production'
-  if (role === 'shipping') return '/shipments'
   return '/'
 }
 

--- a/src/views/DashboardPage.vue
+++ b/src/views/DashboardPage.vue
@@ -502,11 +502,6 @@ async function confirmPackageDelete() {
           공유 활동기록 패키지
         </h3>
       </template>
-      <template #header-actions>
-        <RouterLink to="/package" class="text-xs font-medium text-brand-500 hover:text-brand-700">
-          전체보기 <i class="fas fa-chevron-right ml-0.5 text-[9px]" />
-        </RouterLink>
-      </template>
       <div class="space-y-2">
         <div
           v-for="pkg in visiblePackages"

--- a/src/views/package/ActivityPackagePage.vue
+++ b/src/views/package/ActivityPackagePage.vue
@@ -2,6 +2,7 @@
 import { computed, nextTick, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { fetchActivities, fetchAllActivityPOs } from '@/api/activity'
+import { api } from '@/lib/api'
 import { createPackage, fetchAllUsers, fetchPackageById, updatePackage } from '@/api/package'
 import { useToast } from '@/composables/useToast'
 import { useAuthStore } from '@/stores/auth'
@@ -43,18 +44,24 @@ const editId = computed(() => route.query.edit || '')
 const activities = ref([])
 const poList = ref([])
 const allUsers = ref([])
+const departments = ref([])
+const positions = ref([])
 const isSaving = ref(false)
 
 onMounted(async () => {
   try {
-    const [actData, poData, userData] = await Promise.all([
+    const [actData, poData, userData, deptData, posData] = await Promise.all([
       fetchActivities(),
       fetchAllActivityPOs(),
       fetchAllUsers(),
+      api.get('/departments').then(r => r.data),
+      api.get('/positions').then(r => r.data),
     ])
     activities.value = actData
     poList.value = poData
     allUsers.value = userData.filter((u) => u.status === '재직')
+    departments.value = deptData
+    positions.value = posData
 
     if (isEditMode.value) {
       await loadPackageForEdit()
@@ -132,6 +139,9 @@ const dateTo      = ref(todayKr())
 // ── 열람 권한 ──────────────────────────────────────────────
 const selectedViewerIds = ref([])
 const viewerSearchQuery = ref('')
+
+const departmentNameById = computed(() => new Map(departments.value.map(d => [String(d.id), d.name])))
+const positionNameById = computed(() => new Map(positions.value.map(p => [String(p.id), p.name])))
 
 const filteredUsers = computed(() => {
   const q = viewerSearchQuery.value.trim().toLowerCase()
@@ -338,7 +348,7 @@ async function savePackage() {
 
       <!-- ── 좌측: 패키지 생성 폼 ──────────────────────────── -->
       <div class="lg:col-span-2">
-        <BaseCard :title="isEditMode ? '패키지 수정' : '패키지 생성'">
+        <BaseCard :title="isEditMode ? '패키지 수정' : '패키지 작성'">
           <div class="space-y-5">
 
             <!-- 패키지 제목 -->
@@ -448,7 +458,8 @@ async function savePackage() {
                     @change="toggleViewer(user.id)"
                   />
                   <span class="text-sm text-slate-700">{{ user.name }}</span>
-                  <span class="text-xs text-slate-400">{{ user.email }}</span>
+                  <span class="text-xs text-slate-400">{{ departmentNameById.get(String(user.departmentId)) || '' }}</span>
+                  <span class="text-xs text-slate-400">{{ positionNameById.get(String(user.positionId)) || '' }}</span>
                 </label>
               </div>
               <p v-if="errors.viewers" class="mt-1 text-xs text-red-500">{{ errors.viewers }}</p>
@@ -468,7 +479,7 @@ async function savePackage() {
                   <path d="M3.5 12.75a.75.75 0 0 0-1.5 0v2.5A2.75 2.75 0 0 0 4.75 18h10.5A2.75 2.75 0 0 0 18 15.25v-2.5a.75.75 0 0 0-1.5 0v2.5c0 .69-.56 1.25-1.25 1.25H4.75c-.69 0-1.25-.56-1.25-1.25v-2.5Z" />
                 </svg>
               </template>
-              {{ isEditMode ? '패키지 수정' : '패키지 저장' }}
+              {{ isEditMode ? '패키지 수정' : '패키지 작성' }}
             </BaseButton>
 
           </div>


### PR DESCRIPTION
## 📋 작업 내용

활동기록 패키지의 UX 문제 6건을 수정합니다.

### 변경 파일 (4개, +55/-24)

| 파일 | 변경 내용 |
|---|---|
| `src/utils/roleAccess.js` | getRoleHomePath 전 역할 `/` 통일, 생산/출하 package 접근 차단 |
| `src/views/DashboardPage.vue` | 생산/출하 패키지 섹션 전체보기 링크 제거 |
| `src/components/domain/activity/PackageDetailModal.vue` | ActivityTypeBadge 추가, 활동기록 클릭→상세모달, 열람자 PDF 다운로드 |
| `src/views/package/ActivityPackagePage.vue` | 버튼 "저장"→"작성", 열람 권한에 부서·직급 표시 |

### 수정 사항

1. **대시보드 라우팅**: 생산/출하 사용자가 홈(로고) 클릭 시 대시보드(`/`)로 이동하여 공유 패키지 확인 가능
2. **작성 권한 차단**: 생산/출하는 패키지 작성 화면(`/package`)에 접근 불가 (사이드바 필터링 + 전체보기 제거)
3. **모달 활동기록 개선**: 유형 라벨(ActivityTypeBadge) 표시 + 클릭 시 ActivityDetailModal 열기
4. **열람자 PDF**: 열람 권한자도 PDF 다운로드 가능 (닫기 버튼 옆에 PDF 버튼 추가)
5. **버튼 텍스트**: "패키지 저장" → "패키지 작성"
6. **부서·직급 표시**: 열람 권한 사용자 선택 시 이름 옆에 부서명/직급명 표시

## 🔗 관련 이슈

- closes #216

## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료
- [x] QA 검증 완료 (전 항목 PASS)

## 💬 리뷰어에게

- PackageDetailModal의 template이 `<div>` root로 감싸져 있습니다 (ActivityDetailModal을 BaseModal 외부 sibling으로 배치하기 위함)
- 열람자 모달 footer: PDF 다운로드 + 닫기 / 작성자 모달 footer: PDF 다운로드 + 수정 + 삭제

🤖 Generated with [Claude Code](https://claude.com/claude-code)