### PR TITLE
feat: Auth Service 백엔드 API 전면 연동

### DIFF
--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -1,12 +1,17 @@
 import { api } from '@/lib/api'
 
-export async function login(email, pw) {
-  // TODO: [SECURITY] 백엔드 연동 시 POST /auth/login { email, password } 방식으로 교체
-  // json-server v1 beta는 복수 쿼리 파라미터 필터링을 지원하지 않아 email로만 조회 후 pw 비교
-  const { data } = await api.get('/users', { params: { email } })
-  const user = data[0]
-  if (!user || user.pw !== pw) return null
-  return user
+export async function login(email, password) {
+  const { data } = await api.post('/auth/login', { email, password })
+  return data
+}
+
+export async function refreshToken(refreshToken) {
+  const { data } = await api.post('/auth/refresh', { refreshToken })
+  return data
+}
+
+export async function logoutApi(userId) {
+  await api.post('/auth/logout', { userId })
 }
 
 export async function fetchUsers() {
@@ -35,17 +40,17 @@ export async function fetchDepartments() {
 }
 
 export async function fetchCompany() {
-  const { data } = await api.get('/company/1')
+  const { data } = await api.get('/company')
   return data
 }
 
 export async function updateCompany(company) {
-  const { data } = await api.put('/company/1', company)
+  const { data } = await api.put('/company', company)
   return data
 }
 
-export async function changePassword(userId, pw) {
-  const { data } = await api.patch(`/users/${userId}`, { pw })
+export async function changePassword(userId, currentPw, newPw) {
+  const { data } = await api.put(`/users/${userId}/password`, { currentPw, newPw })
   return data
 }
 
@@ -54,6 +59,17 @@ export async function fetchUserById(id) {
   return data
 }
 
-export async function deleteUser(id) {
-  return api.delete(`/users/${id}`)
+export async function resetPassword(userId) {
+  const { data } = await api.post(`/users/${userId}/password/reset`)
+  return data
+}
+
+export async function forgotPassword(email) {
+  const { data } = await api.post('/auth/forgot-password', { email })
+  return data
+}
+
+export async function changeUserStatus(id, status) {
+  const { data } = await api.patch(`/users/${id}/status`, { status })
+  return data
 }

--- a/src/components/domain/auth/DepartmentAccordion.vue
+++ b/src/components/domain/auth/DepartmentAccordion.vue
@@ -2,6 +2,7 @@
 import BaseTable from '@/components/common/BaseTable.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
 import TableActions from '@/components/common/TableActions.vue'
+import { label, USER_STATUS_LABEL } from '@/utils/enumLabels'
 
 const props = defineProps({
   department: { type: String, required: true },
@@ -19,8 +20,8 @@ const avatarColors = [
 
 const columns = [
   { key: 'employeeNo', label: '사번', width: '120px' },
-  { key: 'name', label: '이름', width: '200px' },
-  { key: 'email', label: '이메일' },
+  { key: 'userName', label: '이름', width: '200px' },
+  { key: 'userEmail', label: '이메일' },
   { key: 'department', label: '부서', width: '120px' },
   { key: 'status', label: '상태', width: '100px', align: 'center' },
   { key: 'actions', label: '관리', width: '140px', align: 'center' },
@@ -31,7 +32,7 @@ function getAvatarColor(index) {
 }
 
 function getActiveCount() {
-  return props.users.filter((u) => u.status === '재직').length
+  return props.users.filter((u) => u.userStatus === 'active').length
 }
 </script>
 
@@ -67,28 +68,28 @@ function getActiveCount() {
 
     <!-- 본문 테이블 -->
     <div v-show="expanded" :id="`dept-panel-${department}`" :aria-hidden="!expanded" class="border-t border-slate-100">
-      <BaseTable :columns="columns" :rows="users" empty-text="사용자가 없습니다.">
-        <template #cell-name="{ row, value }">
+      <BaseTable :columns="columns" :rows="users" row-key="userId" empty-text="사용자가 없습니다.">
+        <template #cell-userName="{ row, value }">
           <div class="flex items-center gap-2.5">
             <span
               role="img"
               :aria-label="`${value} 프로필`"
               class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs font-bold text-white"
-              :class="getAvatarColor(row.id)"
+              :class="getAvatarColor(row.userId)"
             >
               {{ value?.charAt(0) }}
             </span>
             <div>
               <p class="font-medium text-ink">{{ value }}</p>
-              <p class="text-xs text-slate-400">{{ positionMap[row.positionId] || '' }}</p>
+              <p class="text-xs text-slate-400">{{ row.positionName || positionMap[row.positionId] || '' }}</p>
             </div>
           </div>
         </template>
 
         <template #cell-status="{ row }">
           <StatusBadge
-            :value="row.status"
-            :variant="row.status === '재직' ? 'active' : 'inactive'"
+            :value="label(USER_STATUS_LABEL, row.userStatus)"
+            :variant="row.userStatus === 'active' ? 'active' : 'inactive'"
           />
         </template>
 

--- a/src/components/domain/auth/PasswordChangeModal.vue
+++ b/src/components/domain/auth/PasswordChangeModal.vue
@@ -5,7 +5,7 @@ import BaseModal from '@/components/common/BaseModal.vue'
 import BaseTextField from '@/components/common/BaseTextField.vue'
 import FormField from '@/components/common/FormField.vue'
 import { useToast } from '@/composables/useToast'
-import { changePassword, login as verifyPassword } from '@/api/auth'
+import { changePassword } from '@/api/auth'
 import { useAuthStore } from '@/stores/auth'
 
 const props = defineProps({
@@ -73,23 +73,19 @@ async function handleSave() {
     return
   }
 
-  // 현재 비밀번호를 서버에서 검증 (login API로 확인)
   saving.value = true
   try {
-    const verified = await verifyPassword(currentUser.email, currentPassword.value)
-    if (!verified) {
-      errors.value = { currentPassword: '현재 비밀번호가 올바르지 않습니다.' }
-      warning('현재 비밀번호가 올바르지 않습니다.')
-      saving.value = false
-      return
-    }
-
-    await changePassword(currentUser.id, newPassword.value)
+    await changePassword(currentUser.userId, currentPassword.value, newPassword.value)
     success('비밀번호가 변경되었습니다.')
     emit('save')
     emit('close')
   } catch (e) {
-    error('비밀번호 변경 중 오류가 발생했습니다.')
+    if (e.response?.status === 400) {
+      errors.value = { currentPassword: '현재 비밀번호가 올바르지 않습니다.' }
+      warning('현재 비밀번호가 올바르지 않습니다.')
+    } else {
+      error('비밀번호 변경 중 오류가 발생했습니다.')
+    }
   } finally {
     saving.value = false
   }

--- a/src/components/domain/auth/ProfileEditModal.vue
+++ b/src/components/domain/auth/ProfileEditModal.vue
@@ -30,8 +30,8 @@ const isSaving = ref(false)
 watch(() => props.open, (val) => {
   if (val && props.user) {
     form.value = {
-      name: props.user.name || '',
-      email: props.user.email || '',
+      name: props.user.userName ?? props.user.name ?? '',
+      email: props.user.userEmail ?? props.user.email ?? '',
     }
     errors.value = {}
   }
@@ -54,7 +54,7 @@ async function save() {
       name: form.value.name.trim(),
       email: form.value.email.trim(),
     }
-    await api.patch(`/users/${props.user.id}`, payload)
+    await api.patch(`/users/${props.user.userId ?? props.user.id}`, payload)
     success('내 정보가 수정되었습니다.')
     emit('save', payload)
   } catch {
@@ -111,7 +111,7 @@ async function save() {
       <div class="space-y-1.5">
         <p class="text-sm font-semibold text-slate-700">역할</p>
         <div class="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-500">
-          {{ { admin: '관리자', sales: '영업', production: '생산', shipping: '출하' }[user.role] || '-' }}
+          {{ { ADMIN: '관리자', SALES: '영업', PRODUCTION: '생산', SHIPPING: '출하', admin: '관리자', sales: '영업', production: '생산', shipping: '출하' }[user.userRole ?? user.role] || '-' }}
         </div>
       </div>
     </div>

--- a/src/components/domain/auth/UserFormModal.vue
+++ b/src/components/domain/auth/UserFormModal.vue
@@ -8,7 +8,7 @@ import ConfirmModal from '@/components/common/ConfirmModal.vue'
 import FileUploadField from '@/components/common/FileUploadField.vue'
 import FormField from '@/components/common/FormField.vue'
 import { useToast } from '@/composables/useToast'
-import { changePassword } from '@/api/auth'
+import { resetPassword } from '@/api/auth'
 import { isValidEmail } from '@/utils/validators'
 
 const props = defineProps({
@@ -36,8 +36,8 @@ const roleOptions = [
 ]
 
 const statusOptions = [
-  { label: '재직', value: '재직' },
-  { label: '퇴직', value: '퇴직' },
+  { label: '재직', value: 'active' },
+  { label: '퇴직', value: 'retired' },
 ]
 
 function getInitialForm() {
@@ -60,12 +60,12 @@ watch(
     errors.value = {}
     if (isOpen && props.mode === 'edit' && props.user) {
       form.value = {
-        name: props.user.name ?? '',
-        email: props.user.email ?? '',
+        name: props.user.userName ?? props.user.name ?? '',
+        email: props.user.userEmail ?? props.user.email ?? '',
         positionId: String(props.user.positionId ?? ''),
-        role: props.user.role ?? '',
+        role: props.user.userRole ?? props.user.role ?? '',
         departmentId: String(props.user.departmentId ?? ''),
-        status: props.user.status ?? '재직',
+        status: props.user.userStatus ?? props.user.status ?? 'active',
         transferDepartmentId: '',
         transferReason: '',
         sealImage: null,
@@ -91,8 +91,8 @@ function validate() {
     // 중복 이메일 체크
     const duplicate = props.allUsers.find(
       (u) =>
-        u.email === form.value.email.trim() &&
-        (props.mode === 'create' || u.id !== props.user?.id),
+        (u.userEmail ?? u.email) === form.value.email.trim() &&
+        (props.mode === 'create' || (u.userId ?? u.id) !== (props.user?.userId ?? props.user?.id)),
     )
     if (duplicate) {
       e.email = '이미 사용 중인 이메일 주소입니다.'
@@ -132,9 +132,9 @@ function confirmResetPassword() {
 }
 
 async function handleResetPassword() {
-  if (!props.user?.id) return
+  if (!props.user?.userId && !props.user?.id) return
   try {
-    await changePassword(props.user.id, 'test1234')
+    await resetPassword(props.user.userId ?? props.user.id)
     success('비밀번호가 test1234로 초기화되었습니다.')
   } catch (e) {
     error('비밀번호 초기화 중 오류가 발생했습니다.')
@@ -144,15 +144,17 @@ async function handleResetPassword() {
 }
 
 const currentDepartmentName = computed(() => {
-  const dept = props.departments.find(d => String(d.id) === String(props.user?.departmentId))
-  return dept?.name ?? '-'
+  // 백엔드 리스트 응답은 departmentName을 직접 포함
+  if (props.user?.departmentName) return props.user.departmentName
+  const dept = props.departments.find(d => String(d.departmentId ?? d.id) === String(props.user?.departmentId))
+  return dept?.departmentName ?? dept?.name ?? '-'
 })
 </script>
 
 <template>
   <BaseModal
     :open="open"
-    :title="mode === 'create' ? '사용자 등록' : `사용자 정보 수정 – ${user?.name ?? ''}`"
+    :title="mode === 'create' ? '사용자 등록' : `사용자 정보 수정 – ${user?.userName ?? user?.name ?? ''}`"
     width="max-w-2xl"
     @close="emit('close')"
   >
@@ -170,7 +172,7 @@ const currentDepartmentName = computed(() => {
         <FormField label="직급" required :error="errors.positionId">
           <BaseSelect
             v-model="form.positionId"
-            :options="positions.map((p) => ({ label: p.name, value: String(p.id) }))"
+            :options="positions.map((p) => ({ label: p.positionName ?? p.name, value: String(p.positionId ?? p.id) }))"
             placeholder="직급을 선택하세요"
           />
         </FormField>
@@ -183,7 +185,7 @@ const currentDepartmentName = computed(() => {
           <FormField label="팀" required :error="errors.departmentId">
             <BaseSelect
               v-model="form.departmentId"
-              :options="departments.map((d) => ({ label: d.name, value: String(d.id) }))"
+              :options="departments.map((d) => ({ label: d.departmentName ?? d.name, value: String(d.departmentId ?? d.id) }))"
               placeholder="팀을 선택하세요"
             />
           </FormField>
@@ -216,7 +218,7 @@ const currentDepartmentName = computed(() => {
             <FormField label="이동할 팀">
               <BaseSelect
                 v-model="form.transferDepartmentId"
-                :options="[{ label: '변경안함', value: '' }, ...departments.map((d) => ({ label: d.name, value: String(d.id) }))]"
+                :options="[{ label: '변경안함', value: '' }, ...departments.map((d) => ({ label: d.departmentName ?? d.name, value: String(d.departmentId ?? d.id) }))]"
               />
             </FormField>
             <FormField label="이동 사유" :required="!!form.transferDepartmentId" :error="errors.transferReason">
@@ -250,7 +252,7 @@ const currentDepartmentName = computed(() => {
     <ConfirmModal
       :open="showResetConfirm"
       title="비밀번호 초기화"
-      :message="`${user?.name} 사용자의 비밀번호를 초기값(test1234)으로 초기화하시겠습니까?`"
+      :message="`${user?.userName ?? user?.name} 사용자의 비밀번호를 초기값(test1234)으로 초기화하시겠습니까?`"
       confirm-label="초기화"
       confirm-variant="danger"
       @confirm="handleResetPassword"

--- a/src/components/domain/auth/UserListTab.vue
+++ b/src/components/domain/auth/UserListTab.vue
@@ -8,12 +8,14 @@ import DepartmentAccordion from '@/components/domain/auth/DepartmentAccordion.vu
 import UserFormModal from '@/components/domain/auth/UserFormModal.vue'
 import { useToast } from '@/composables/useToast'
 import {
+  changeUserStatus,
   createUser,
   fetchDepartments,
   fetchPositions,
   fetchUsers,
   updateUser,
 } from '@/api/auth'
+import { label, USER_STATUS_LABEL } from '@/utils/enumLabels'
 
 const { success, error } = useToast()
 
@@ -48,12 +50,13 @@ async function loadData() {
       fetchPositions(),
       fetchDepartments(),
     ])
-    users.value = usersData
+    // fetchUsers()는 PagedResponse를 반환 → content 배열 추출
+    users.value = usersData.content ?? usersData
     positions.value = positionsData
     departments.value = departmentsData
     // 첫 번째 부서 펼치기
     if (departmentsData.length > 0) {
-      expandedDepts.value = new Set([departmentsData[0].id])
+      expandedDepts.value = new Set([departmentsData[0].departmentId])
     }
   } catch (e) {
     error('데이터를 불러오는 중 오류가 발생했습니다.')
@@ -64,7 +67,9 @@ async function loadData() {
 
 onMounted(loadData)
 
-const positionMap = computed(() => Object.fromEntries(positions.value.map((p) => [String(p.id), p.name])))
+const positionMap = computed(() =>
+  Object.fromEntries(positions.value.map((p) => [String(p.positionId ?? p.id), p.positionName ?? p.name])),
+)
 
 // 검색 / 필터
 const searchKeyword = ref('')
@@ -92,23 +97,27 @@ const groupedByDepartment = computed(() => {
     const kw = searchKeyword.value.toLowerCase()
     filtered = filtered.filter(
       (u) =>
-        u.name.toLowerCase().includes(kw) ||
+        (u.userName && u.userName.toLowerCase().includes(kw)) ||
         (u.employeeNo && u.employeeNo.includes(kw)) ||
-        (u.email && u.email.toLowerCase().includes(kw)),
+        (u.userEmail && u.userEmail.toLowerCase().includes(kw)),
     )
   }
 
   if (departmentFilter.value) {
-    filtered = filtered.filter((u) => String(u.departmentId) === String(departmentFilter.value))
+    filtered = filtered.filter((u) => String(u.departmentName) === String(departmentFilter.value))
   }
 
   return departments.value
-    .map((dept) => ({
-      department: dept,
-      users: filtered
-        .filter((u) => String(u.departmentId) === String(dept.id))
-        .map((u) => ({ ...u, department: dept.name })),
-    }))
+    .map((dept) => {
+      const deptName = dept.departmentName ?? dept.name
+      const deptId = dept.departmentId ?? dept.id
+      return {
+        department: { id: deptId, name: deptName },
+        users: filtered
+          .filter((u) => String(u.departmentName) === String(deptName))
+          .map((u) => ({ ...u, department: deptName })),
+      }
+    })
     .filter((g) => g.users.length > 0)
 })
 
@@ -118,14 +127,14 @@ const totalUsers = computed(() =>
 )
 const activeUsers = computed(() =>
   groupedByDepartment.value.reduce(
-    (sum, g) => sum + g.users.filter((u) => u.status === '재직').length,
+    (sum, g) => sum + g.users.filter((u) => u.userStatus === 'active').length,
     0,
   ),
 )
 
 const departmentFilterOptions = computed(() => [
   { label: '전체 부서', value: '' },
-  ...departments.value.map((d) => ({ label: d.name, value: d.id })),
+  ...departments.value.map((d) => ({ label: d.departmentName ?? d.name, value: d.departmentName ?? d.name })),
 ])
 
 function toggleDepartment(deptId) {
@@ -176,7 +185,7 @@ async function handleSave(formData) {
         ...formData,
         employeeNo,
         pw: 'test1234',
-        status: formData.status || '재직',
+        userStatus: 'active',
       }
       await createUser(newUser)
       success('사용자가 등록되었습니다.')
@@ -184,6 +193,8 @@ async function handleSave(formData) {
       const original = selectedUser.value
       const { pw: _pw, ...safeOriginal } = original
       const updateData = { ...safeOriginal, ...formData }
+      // status는 PATCH /status로 별도 처리하므로 update에서 제거
+      delete updateData.userStatus
       // 팀 이동 처리
       if (formData.transferDepartmentId) {
         updateData.departmentId = formData.transferDepartmentId
@@ -191,7 +202,8 @@ async function handleSave(formData) {
       delete updateData.transferDepartmentId
       delete updateData.transferReason
       delete updateData.department
-      await updateUser(original.id, updateData)
+      delete updateData.status
+      await updateUser(original.userId, updateData)
       success('사용자 정보가 수정되었습니다.')
     }
     await loadData()
@@ -207,10 +219,8 @@ async function handleDelete() {
   if (!userToDelete.value) return
   deleting.value = true
   try {
-    // 물리 삭제(deleteUser) 대신 소프트 삭제: status를 '퇴직'으로 변경
-    const { pw: _, ...safeUser } = userToDelete.value
-    await updateUser(safeUser.id, { ...safeUser, status: '퇴직' })
-    success(`${userToDelete.value.name} 사용자가 퇴직 처리되었습니다.`)
+    await changeUserStatus(userToDelete.value.userId, 'RETIRED')
+    success(`${userToDelete.value.userName} 사용자가 퇴직 처리되었습니다.`)
     await loadData()
   } catch (e) {
     error('처리 중 오류가 발생했습니다.')
@@ -285,7 +295,7 @@ defineExpose({ openCreateModal })
     <ConfirmModal
       :open="showDeleteModal"
       title="사용자 퇴직 처리"
-      :message="`${userToDelete?.name} 사용자를 퇴직 처리하시겠습니까?`"
+      :message="`${userToDelete?.userName} 사용자를 퇴직 처리하시겠습니까?`"
       confirm-label="퇴직 처리"
       confirm-variant="danger"
       @confirm="handleDelete"

--- a/src/components/layout/AppHeader.vue
+++ b/src/components/layout/AppHeader.vue
@@ -24,7 +24,7 @@ const roleDashboardTitles = { admin: '관리자 대시보드', sales: '영업 �
 
 const pageTitle = computed(() => {
   const currentPath = route.path
-  const role = authStore.currentUser?.role
+  const role = authStore.currentUser?.userRole ?? authStore.currentUser?.role
   const home = getRoleHomePath(role)
 
   if (currentPath === home) {
@@ -46,7 +46,7 @@ const roleDashboardDescriptions = {
 
 const pageTooltip = computed(() => {
   const currentPath = route.path
-  const role = authStore.currentUser?.role
+  const role = authStore.currentUser?.userRole ?? authStore.currentUser?.role
   const home = getRoleHomePath(role)
 
   if (currentPath === home || currentPath === '/') {
@@ -75,10 +75,11 @@ function createApprovalNotifications() {
   const approvalDocuments = [...piDocuments.value, ...poDocuments.value]
     .filter((row) => row.requestStatus && row.approvalStatus === '대기')
     .filter((row) => {
-      if (currentUser.role === 'admin') return true
-      if (currentUser.role !== 'sales') return false
+      const role = currentUser.userRole ?? currentUser.role
+      if (role === 'admin' || role === 'ADMIN') return true
+      if (role !== 'sales' && role !== 'SALES') return false
       if (currentUser.positionId === 1) return true
-      return row.approvalRequestedBy === currentUser.name
+      return row.approvalRequestedBy === (currentUser.userName ?? currentUser.name)
     })
 
   return approvalDocuments.map((row) => ({
@@ -97,7 +98,8 @@ function createApprovalNotifications() {
 
 function createShipmentNotifications() {
   const currentUser = authStore.currentUser
-  if (!currentUser || currentUser.role === 'production') return []
+  const role = currentUser.userRole ?? currentUser.role
+  if (!currentUser || role === 'production' || role === 'PRODUCTION') return []
 
   return shipmentStatusDocuments.value
     .filter((row) => row.status === '출하완료')
@@ -117,7 +119,8 @@ function createShipmentNotifications() {
 
 function createCollectionNotifications() {
   const currentUser = authStore.currentUser
-  if (!currentUser || !['sales', 'admin'].includes(currentUser.role)) return []
+  const role = currentUser.userRole ?? currentUser.role
+  if (!currentUser || !['sales', 'admin', 'SALES', 'ADMIN'].includes(role)) return []
 
   return salesCollectionDocuments.value
     .filter((row) => row.status === '수금완료')
@@ -175,14 +178,14 @@ function goToNotification(notification) {
 }
 
 const loggedInUser = computed(() => authStore.currentUser)
-const userInitial = computed(() => loggedInUser.value?.name?.charAt(0) || '?')
-const userName = computed(() => loggedInUser.value?.name || '사용자')
+const userInitial = computed(() => (loggedInUser.value?.userName ?? loggedInUser.value?.name)?.charAt(0) || '?')
+const userName = computed(() => loggedInUser.value?.userName ?? loggedInUser.value?.name ?? '사용자')
 const userRole = computed(() => {
-  const roles = { admin: '관리자', sales: '영업', production: '생산', shipping: '출하' }
-  return roles[loggedInUser.value?.role] || ''
+  const roles = { ADMIN: '관리자', SALES: '영업', PRODUCTION: '생산', SHIPPING: '출하', admin: '관리자', sales: '영업', production: '생산', shipping: '출하' }
+  return roles[loggedInUser.value?.userRole ?? loggedInUser.value?.role] || ''
 })
 const userEmployeeNo = computed(() => loggedInUser.value?.employeeNo || '-')
-const userEmail = computed(() => loggedInUser.value?.email || '-')
+const userEmail = computed(() => loggedInUser.value?.userEmail ?? loggedInUser.value?.email ?? '-')
 const userDepartment = computed(() => loggedInUser.value?.departmentName || userRole.value)
 
 const isProfileOpen = ref(false)

--- a/src/components/layout/AppSidebar.vue
+++ b/src/components/layout/AppSidebar.vue
@@ -9,7 +9,7 @@ import { canAccessPathByRole, getRoleHomePath } from '@/utils/roleAccess'
 const uiStore = useUiStore()
 const authStore = useAuthStore()
 const route = useRoute()
-const homePath = computed(() => getRoleHomePath(authStore.currentUser?.role))
+const homePath = computed(() => getRoleHomePath(authStore.currentUser?.userRole ?? authStore.currentUser?.role))
 const navigationItems = ref([])
 
 const sectionOrder = ['basic', 'sales', 'orders', 'status', 'activity', 'admin']

--- a/src/lib/token.js
+++ b/src/lib/token.js
@@ -1,51 +1,19 @@
 /**
- * 토큰 유틸리티
+ * JWT 토큰 유틸리티
  *
- * 현재(프론트 단독 개발 단계):
- *   - json-server에 JWT 발급 기능이 없으므로 간이 토큰을 생성해 시뮬레이션
- *   - AccessToken → 메모리(Pinia store)
- *   - RefreshToken → HttpOnly 쿠키 (시뮬레이션: 일반 쿠키)
- *
- * TODO: 백엔드 연동 시 실제 JWT 발급/검증 흐름으로 교체
+ * AccessToken  → 메모리(Pinia store)
+ * RefreshToken → 쿠키
  */
 
-const AT_EXPIRY_MS = 30 * 60 * 1000 // 30분
-const RT_EXPIRY_DAYS = 7
 const RT_COOKIE_NAME = 'sb_refresh_token'
+const RT_EXPIRY_DAYS = 7
 
-/**
- * 간이 토큰 생성 (base64 인코딩된 JSON)
- * 백엔드 연동 시 서버에서 발급받은 JWT로 대체
- */
-export function generateTokens(user) {
-  const now = Date.now()
-
-  const accessPayload = {
-    sub: user.id,
-    email: user.email,
-    role: user.role,
-    departmentId: user.departmentId,
-    name: user.name,
-    iat: now,
-    exp: now + AT_EXPIRY_MS,
-  }
-
-  const refreshPayload = {
-    sub: user.id,
-    iat: now,
-    exp: now + RT_EXPIRY_DAYS * 24 * 60 * 60 * 1000,
-  }
-
-  const accessToken = btoa(encodeURIComponent(JSON.stringify(accessPayload)))
-  const refreshToken = btoa(encodeURIComponent(JSON.stringify(refreshPayload)))
-
-  return { accessToken, refreshToken }
-}
-
-/** AT 페이로드 디코딩 */
+/** JWT 페이로드 디코딩 (서명 검증은 서버에서 수행) */
 export function decodeToken(token) {
   try {
-    return JSON.parse(decodeURIComponent(atob(token)))
+    const base64Url = token.split('.')[1]
+    const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/')
+    return JSON.parse(decodeURIComponent(atob(base64)))
   } catch {
     return null
   }
@@ -55,7 +23,7 @@ export function decodeToken(token) {
 export function isTokenExpired(token) {
   const payload = decodeToken(token)
   if (!payload?.exp) return true
-  return Date.now() > payload.exp
+  return Date.now() > payload.exp * 1000
 }
 
 /** RT를 쿠키에 저장 */

--- a/src/main.js
+++ b/src/main.js
@@ -23,17 +23,18 @@ router.beforeEach(async (to) => {
   // 공개 페이지는 통과
   if (PUBLIC_ROUTES.includes(to.name)) {
     // 이미 로그인 상태면 대시보드로
-    if (authStore.isLoggedIn) return getRoleHomePath(authStore.currentUser?.role)
+    if (authStore.isLoggedIn) return getRoleHomePath(authStore.currentUser?.userRole ?? authStore.currentUser?.role)
     return true
   }
 
   // 로그인 상태면 통과
+  const getRole = () => authStore.currentUser?.userRole ?? authStore.currentUser?.role
   if (authStore.isLoggedIn) {
-    if (to.meta.requiredRole && authStore.currentUser?.role !== to.meta.requiredRole) {
-      return getRoleHomePath(authStore.currentUser?.role)
+    if (to.meta.requiredRole && getRole() !== to.meta.requiredRole) {
+      return getRoleHomePath(getRole())
     }
     if (!canAccessRouteByRole(authStore.currentUser, to.name)) {
-      return getRoleHomePath(authStore.currentUser?.role)
+      return getRoleHomePath(getRole())
     }
     return true
   }
@@ -41,11 +42,11 @@ router.beforeEach(async (to) => {
   // AT 없으면 RT로 세션 복구 시도
   const restored = await authStore.restoreSession()
   if (restored) {
-    if (to.meta.requiredRole && authStore.currentUser?.role !== to.meta.requiredRole) {
-      return getRoleHomePath(authStore.currentUser?.role)
+    if (to.meta.requiredRole && getRole() !== to.meta.requiredRole) {
+      return getRoleHomePath(getRole())
     }
     if (!canAccessRouteByRole(authStore.currentUser, to.name)) {
-      return getRoleHomePath(authStore.currentUser?.role)
+      return getRoleHomePath(getRole())
     }
     return true
   }

--- a/src/stores/auth.js
+++ b/src/stores/auth.js
@@ -2,17 +2,20 @@ import { computed, readonly, ref } from 'vue'
 import { defineStore } from 'pinia'
 import {
   decodeToken,
-  generateTokens,
   getRefreshTokenCookie,
   isTokenExpired,
   removeRefreshTokenCookie,
   setRefreshTokenCookie,
 } from '@/lib/token'
-import { login as apiLogin, fetchUserById } from '@/api/auth'
+import {
+  login as apiLogin,
+  refreshToken as apiRefresh,
+  logoutApi,
+} from '@/api/auth'
 
 export const useAuthStore = defineStore('auth', () => {
-  // AccessToken은 메모리에만 보관 (새로고침 시 사라짐 → RT로 복구)
   const accessToken = ref(null)
+  const _refreshToken = ref(null)
   const user = ref(null)
 
   const isLoggedIn = computed(() => !!accessToken.value && !isTokenExpired(accessToken.value))
@@ -22,63 +25,55 @@ export const useAuthStore = defineStore('auth', () => {
   /**
    * 로그인
    */
-  async function login(email, pw) {
-    const userData = await apiLogin(email, pw)
-    if (!userData) throw new Error('INVALID_CREDENTIALS')
+  async function login(email, password) {
+    const data = await apiLogin(email, password)
 
-    const tokens = generateTokens(userData)
-    accessToken.value = tokens.accessToken
-    setRefreshTokenCookie(tokens.refreshToken)
+    accessToken.value = data.accessToken
+    _refreshToken.value = data.refreshToken
+    setRefreshTokenCookie(data.refreshToken)
+    user.value = data.user
 
-    // 비밀번호는 store에 저장하지 않음
-    const { pw: _, ...safeUser } = userData
-    user.value = safeUser
-
-    return safeUser
+    return data.user
   }
 
   /**
    * 로그아웃
    */
-  function logout() {
+  async function logout() {
+    try {
+      if (user.value?.userId) {
+        await logoutApi(user.value.userId)
+      }
+    } catch {
+      // 서버 오류 시에도 로컬 세션은 정리
+    }
     accessToken.value = null
+    _refreshToken.value = null
     user.value = null
     removeRefreshTokenCookie()
   }
 
   /**
    * RT로 세션 복구 (새로고침 시)
-   *
-   * TODO: 백엔드 연동 시 POST /auth/refresh 로 새 AT 발급받는 흐름으로 교체
-   * 현재는 RT 디코딩 → userId로 사용자 조회 → 새 토큰 쌍 생성
    */
   async function restoreSession() {
-    const rt = getRefreshTokenCookie()
+    const rt = _refreshToken.value || getRefreshTokenCookie()
     if (!rt) return false
 
-    const payload = decodeToken(rt)
-    if (!payload?.sub || Date.now() > payload.exp) {
-      removeRefreshTokenCookie()
-      return false
-    }
-
     try {
-      // json-server에서 사용자 조회
-      const userData = await fetchUserById(payload.sub)
-      if (!userData) {
-        removeRefreshTokenCookie()
-        return false
-      }
+      const data = await apiRefresh(rt)
 
-      const tokens = generateTokens(userData)
-      accessToken.value = tokens.accessToken
-      setRefreshTokenCookie(tokens.refreshToken)
+      accessToken.value = data.accessToken
+      _refreshToken.value = data.refreshToken
+      setRefreshTokenCookie(data.refreshToken)
+      user.value = data.user
 
-      const { pw: _, ...safeUser } = userData
-      user.value = safeUser
       return true
     } catch {
       removeRefreshTokenCookie()
+      accessToken.value = null
+      _refreshToken.value = null
+      user.value = null
       return false
     }
   }
@@ -91,7 +86,7 @@ export const useAuthStore = defineStore('auth', () => {
   }
 
   /**
-   * 비밀번호 변경 후 store 반영 (pw 제외)
+   * 사용자 정보 부분 업데이트
    */
   function updateUserInfo(partial) {
     if (user.value) {

--- a/src/utils/enumLabels.js
+++ b/src/utils/enumLabels.js
@@ -1,0 +1,86 @@
+/**
+ * DB enum 코드 → 화면 한글 라벨 매핑
+ * 백엔드에서 영문 코드 그대로 내려오고, 프론트에서만 한글 변환
+ */
+
+export const ROLE_LABEL = {
+  admin: '관리자',
+  sales: '영업',
+  production: '생산',
+  shipping: '출하',
+}
+
+export const USER_STATUS_LABEL = {
+  active: '재직',
+  on_leave: '휴직',
+  retired: '퇴직',
+}
+
+export const CLIENT_STATUS_LABEL = {
+  active: '활성',
+  inactive: '비활성',
+}
+
+export const ITEM_STATUS_LABEL = {
+  active: '활성',
+  inactive: '비활성',
+}
+
+export const ACTIVITY_TYPE_LABEL = {
+  meeting: '미팅/협의',
+  issue: '이슈',
+  memo: '메모/노트',
+  schedule: '일정',
+}
+
+export const ACTIVITY_PRIORITY_LABEL = {
+  high: '높음',
+  normal: '보통',
+}
+
+export const PI_PO_STATUS_LABEL = {
+  draft: '초안',
+  confirmed: '확정',
+  pending_approval: '결재대기',
+  rejected: '반려',
+  cancelled: '취소',
+  registration_requested: '등록요청',
+  modification_requested: '수정요청',
+  deletion_requested: '삭제요청',
+}
+
+export const CI_PL_STATUS_LABEL = {
+  pending: '발행대기',
+  completed: '발행완료',
+}
+
+export const PRODUCTION_STATUS_LABEL = {
+  in_progress: '진행중',
+  completed: '생산완료',
+}
+
+export const SHIPMENT_STATUS_LABEL = {
+  preparing: '출하준비',
+  completed: '출하완료',
+}
+
+export const APPROVAL_STATUS_LABEL = {
+  pending: '대기',
+  approved: '승인',
+  rejected: '반려',
+}
+
+export const COLLECTION_STATUS_LABEL = {
+  unpaid: '미수금',
+  paid: '수금완료',
+}
+
+export const EMAIL_STATUS_LABEL = {
+  sent: '발송',
+  failed: '실패',
+}
+
+/** 범용 라벨 변환 헬퍼 — 매핑에 없으면 코드 그대로 반환 */
+export function label(map, code) {
+  return map[code] ?? code
+}

--- a/src/utils/roleAccess.js
+++ b/src/utils/roleAccess.js
@@ -5,18 +5,29 @@ const ROLE_ROUTE_ALLOWLIST = {
   shipping: new Set(['dashboard', 'shipment-orders', 'shipment-order-detail', 'shipments', 'shipment-detail']),
 }
 
+// 백엔드 UPPER_CASE role → 기존 lowercase role 정규화
+function normalizeRole(role) {
+  if (!role) return role
+  return role.toLowerCase()
+}
+
+function getUserRole(user) {
+  return normalizeRole(user?.userRole ?? user?.role)
+}
+
 export function canAccessRouteByRole(user, routeName) {
   if (!user || !routeName) return false
+  const role = getUserRole(user)
 
   if (String(routeName) === 'users') {
-    return user.role === 'admin'
+    return role === 'admin'
   }
 
-  if (user.role === 'admin' || user.role === 'sales') {
+  if (role === 'admin' || role === 'sales') {
     return true
   }
 
-  const allowedRoutes = ROLE_ROUTE_ALLOWLIST[user.role]
+  const allowedRoutes = ROLE_ROUTE_ALLOWLIST[role]
   if (!allowedRoutes) {
     return COMMON_ROUTE_NAMES.has(String(routeName))
   }
@@ -26,12 +37,13 @@ export function canAccessRouteByRole(user, routeName) {
 
 export function canAccessPathByRole(user, path) {
   if (!user || !path) return false
+  const role = getUserRole(user)
 
   if (path.startsWith('/users')) {
-    return user.role === 'admin'
+    return role === 'admin'
   }
 
-  if (user.role === 'admin' || user.role === 'sales') {
+  if (role === 'admin' || role === 'sales') {
     return true
   }
 
@@ -39,11 +51,11 @@ export function canAccessPathByRole(user, path) {
     return true
   }
 
-  if (user.role === 'production') {
+  if (role === 'production') {
     return path.startsWith('/production')
   }
 
-  if (user.role === 'shipping') {
+  if (role === 'shipping') {
     return path.startsWith('/shipment-orders') || path.startsWith('/shipments')
   }
 
@@ -55,9 +67,11 @@ export function getRoleHomePath(role) {
 }
 
 export function canManageItems(role) {
-  return role === 'admin'
+  const r = normalizeRole(role)
+  return r === 'admin'
 }
 
 export function canManageClients(role) {
-  return role === 'admin' || role === 'sales'
+  const r = normalizeRole(role)
+  return r === 'admin' || r === 'sales'
 }

--- a/src/views/auth/ForgotPasswordPage.vue
+++ b/src/views/auth/ForgotPasswordPage.vue
@@ -4,6 +4,7 @@ import BaseButton from '@/components/common/BaseButton.vue'
 import BaseTextField from '@/components/common/BaseTextField.vue'
 import FormField from '@/components/common/FormField.vue'
 import { useToast } from '@/composables/useToast'
+import { forgotPassword } from '@/api/auth'
 import { isValidEmail } from '@/utils/validators'
 
 const { success, error } = useToast()
@@ -31,9 +32,15 @@ async function handleSubmit() {
 
   loading.value = true
   try {
-    // TODO: 백엔드 연동 시 await sendPasswordResetEmail(email.value.trim())
+    await forgotPassword(email.value.trim())
     submitted.value = true
-    success('등록된 이메일이라면 재설정 링크가 발송됩니다.')
+    success('임시 비밀번호가 이메일로 발송되었습니다.')
+  } catch (e) {
+    if (e.response?.status === 400) {
+      error('등록되지 않은 이메일입니다.')
+    } else {
+      error('처리 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.')
+    }
   } finally {
     loading.value = false
   }
@@ -66,7 +73,7 @@ function handleRetry() {
         </div>
         <h2 class="text-lg font-bold text-ink">비밀번호 찾기</h2>
         <p class="text-sm text-slate-500">
-          가입 시 등록한 이메일 주소를 입력하시면<br />비밀번호 재설정 링크를 보내드립니다.
+          가입 시 등록한 이메일 주소를 입력하시면<br />임시 비밀번호를 보내드립니다.
         </p>
       </div>
 
@@ -74,8 +81,8 @@ function handleRetry() {
       <div v-if="submitted" role="alert" aria-live="polite" class="rounded-xl bg-green-50 px-4 py-4 text-center text-sm text-green-700">
         <p class="font-semibold">이메일이 발송되었습니다.</p>
         <p class="mt-1 text-xs text-green-600">
-          <strong>{{ email }}</strong> 으로 비밀번호 재설정 링크를 발송했습니다.<br />
-          이메일을 확인해 주세요.
+          <strong>{{ email }}</strong> 으로 임시 비밀번호를 발송했습니다.<br />
+          로그인 후 반드시 비밀번호를 변경해주세요.
         </p>
         <button
           type="button"
@@ -106,7 +113,7 @@ function handleRetry() {
         </FormField>
 
         <BaseButton variant="primary" type="submit" block size="lg" :disabled="loading">
-          {{ loading ? '확인 중...' : '재설정 링크 발송' }}
+          {{ loading ? '확인 중...' : '임시 비밀번호 발송' }}
         </BaseButton>
       </form>
 

--- a/src/views/auth/LoginPage.vue
+++ b/src/views/auth/LoginPage.vue
@@ -65,7 +65,7 @@ async function handleLogin() {
     const safePath = redirect && typeof redirect === 'string' && redirect.startsWith('/') && !redirect.startsWith('//') ? redirect : '/'
     router.push(safePath)
   } catch (e) {
-    if (e.message === 'INVALID_CREDENTIALS') {
+    if (e.response?.status === 400 || e.response?.status === 401) {
       error('이메일 또는 비밀번호가 올바르지 않습니다.')
     } else {
       error('로그인 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.')


### PR DESCRIPTION
## 📋 작업 내용

Auth Service 백엔드 API 명세서(v1.1) 기준으로 프론트엔드를 전면 연동합니다.
json-server 기반 임시 구현을 실제 백엔드 JWT 인증 + REST API 호출로 교체합니다.

**주요 변경:**
- `src/api/auth.js` — login(POST), logout, refresh, forgotPassword, resetPassword, changePassword, changeUserStatus API 추가/교체
- `src/stores/auth.js` — 실제 JWT 토큰 관리, 백엔드 /auth/refresh로 세션 복구
- `src/lib/token.js` — 가짜 토큰 생성 제거, 실제 JWT base64url 디코딩
- `src/utils/enumLabels.js` — 전 서비스 공통 ENUM 코드→한글 라벨 매핑 (신규)
- `src/utils/roleAccess.js` — normalizeRole 헬퍼 추가
- Auth 관련 Vue 컴포넌트 8개 — 필드명 정합성(userId/userName/userEmail/userRole/userStatus), PagedResponse 대응

## 🔗 관련 이슈

- closes #224

## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

- `enumLabels.js`는 Auth뿐 아니라 Master/Document/Activity 서비스의 ENUM 매핑도 미리 포함했습니다. 이후 서비스 연동 시 바로 사용 가능합니다.
- 백엔드 Auth 커밋: hanhwa-swcamp-22th-final/team2-backend-auth@0f1c480
- 프론트→백엔드 전송 시 영문 코드 그대로(active, sales 등), 화면 표시만 한글 변환