### PR TITLE
feat: Master Service 백엔드 API 연동

### DIFF
--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -73,3 +73,8 @@ export async function changeUserStatus(id, status) {
   const { data } = await api.patch(`/users/${id}/status`, { status })
   return data
 }
+
+export async function fetchAllUsers() {
+  const { data } = await api.get('/users')
+  return data.content ?? data
+}

--- a/src/api/master.js
+++ b/src/api/master.js
@@ -5,26 +5,29 @@ export const fetchClients = () => api.get('/clients').then((r) => r.data)
 export const fetchClient = (id) => api.get(`/clients/${id}`).then((r) => r.data)
 export const createClient = (client) => api.post('/clients', client).then((r) => r.data)
 export const updateClient = (id, client) => api.put(`/clients/${id}`, client).then((r) => r.data)
-export const deleteClient = (id) => api.delete(`/clients/${id}`).then((r) => r.data)
+export async function changeClientStatus(id, status) {
+  const { data } = await api.patch(`/clients/${id}/status`, { status })
+  return data
+}
 
 // Items
 export const fetchItems = () => api.get('/items').then((r) => r.data)
 export const fetchItem = (id) => api.get(`/items/${id}`).then((r) => r.data)
 export const createItem = (item) => api.post('/items', item).then((r) => r.data)
 export const updateItem = (id, item) => api.put(`/items/${id}`, item).then((r) => r.data)
-export const deleteItem = (id) => api.delete(`/items/${id}`).then((r) => r.data)
+export async function changeItemStatus(id, status) {
+  const { data } = await api.patch(`/items/${id}/status`, { status })
+  return data
+}
 
 // Buyers
 export const fetchBuyers = () => api.get('/buyers').then((r) => r.data)
 export const fetchBuyersByClient = (clientId) =>
-  api.get('/buyers', { params: { clientId } }).then((r) => r.data)
-
-// Users
-export const fetchUsers = () => api.get('/users').then((r) => r.data)
+  api.get(`/clients/${clientId}/buyers`).then((r) => r.data)
 
 // Reference data
 export const fetchCountries = () => api.get('/countries').then((r) => r.data)
 export const fetchPorts = () => api.get('/ports').then((r) => r.data)
 export const fetchCurrencies = () => api.get('/currencies').then((r) => r.data)
 export const fetchIncoterms = () => api.get('/incoterms').then((r) => r.data)
-export const fetchPaymentTerms = () => api.get('/paymentTerms').then((r) => r.data)
+export const fetchPaymentTerms = () => api.get('/payment-terms').then((r) => r.data)

--- a/src/components/domain/document/PIFormModal.vue
+++ b/src/components/domain/document/PIFormModal.vue
@@ -15,8 +15,8 @@ import {
   fetchCurrencies,
   fetchIncoterms,
   fetchItems,
-  fetchUsers,
 } from '@/api/master'
+import { fetchAllUsers } from '@/api/auth'
 import { useToast } from '@/composables/useToast'
 import {
   fallbackIncotermsCatalog,
@@ -263,7 +263,7 @@ async function loadReferenceData() {
       fetchCountries(),
       fetchCurrencies(),
       fetchItems(),
-      fetchUsers(),
+      fetchAllUsers(),
       fetchIncoterms(),
     ])
 

--- a/src/components/domain/document/POFormModal.vue
+++ b/src/components/domain/document/POFormModal.vue
@@ -4,7 +4,7 @@ import { computed, ref, watch } from 'vue'
 import BaseButton from '@/components/common/BaseButton.vue'
 import BaseModal from '@/components/common/BaseModal.vue'
 import BaseSelect from '@/components/common/BaseSelect.vue'
-import { fetchUsers } from '@/api/master'
+import { fetchAllUsers } from '@/api/auth'
 
 const props = defineProps({
   open: { type: Boolean, default: false },
@@ -37,7 +37,7 @@ const isDeliveryDateLocked = computed(() => isLinkedToPi.value && !form.value.de
 
 async function loadApproverOptions() {
   try {
-    const users = await fetchUsers()
+    const users = await fetchAllUsers()
     const activeUsers = users
       .filter((user) => user.status === '재직')
       .filter((user) => user.role === 'sales' && Number(user.positionId) === 1)

--- a/src/views/master/ClientDetailPage.vue
+++ b/src/views/master/ClientDetailPage.vue
@@ -10,7 +10,7 @@ import ClientFormModal from '@/components/domain/master/ClientFormModal.vue'
 import DocumentLinkButton from '@/components/domain/master/DocumentLinkButton.vue'
 import { useAuthStore } from '@/stores/auth'
 import {
-  deleteClient,
+  changeClientStatus,
   fetchBuyersByClient,
   fetchClient,
   fetchClients,
@@ -148,8 +148,8 @@ async function handleDelete() {
   deleting.value = true
   const name = client.value.name
   try {
-    await deleteClient(client.value.id)
-    success(`${name} 거래처가 삭제되었습니다.`)
+    await changeClientStatus(client.value.id, 'INACTIVE')
+    success(`${name} 거래처가 비활성화되었습니다.`)
     router.push({ name: 'client-list' })
   } catch {
     error('삭제 중 오류가 발생했습니다.')

--- a/src/views/master/ClientListPage.vue
+++ b/src/views/master/ClientListPage.vue
@@ -16,8 +16,8 @@ import PageHeader from '@/components/common/PageHeader.vue'
 import ClientFormModal from '@/components/domain/master/ClientFormModal.vue'
 import { useAuthStore } from '@/stores/auth'
 import {
+  changeClientStatus,
   createClient,
-  deleteClient,
   fetchClients,
   updateClient,
 } from '@/api/master'
@@ -193,8 +193,8 @@ async function handleDelete() {
   if (!clientToDelete.value || deleting.value) return
   deleting.value = true
   try {
-    await deleteClient(clientToDelete.value.id)
-    success(`${clientToDelete.value.name} 거래처가 삭제되었습니다.`)
+    await changeClientStatus(clientToDelete.value.id, 'INACTIVE')
+    success(`${clientToDelete.value.name} 거래처가 비활성화되었습니다.`)
     await loadData()
   } catch {
     error('삭제 중 오류가 발생했습니다.')

--- a/src/views/master/ItemDetailPage.vue
+++ b/src/views/master/ItemDetailPage.vue
@@ -7,7 +7,7 @@ import ConfirmModal from '@/components/common/ConfirmModal.vue'
 import DetailPageHeader from '@/components/common/DetailPageHeader.vue'
 import DocumentLinkButton from '@/components/domain/master/DocumentLinkButton.vue'
 import ItemFormModal from '@/components/domain/master/ItemFormModal.vue'
-import { deleteItem, fetchItem, fetchItems, updateItem } from '@/api/master'
+import { changeItemStatus, fetchItem, fetchItems, updateItem } from '@/api/master'
 import { useToast } from '@/composables/useToast'
 import { useAuthStore } from '@/stores/auth'
 import { canManageItems } from '@/utils/roleAccess'
@@ -112,8 +112,8 @@ async function handleDelete() {
   deleting.value = true
   const name = item.value.name
   try {
-    await deleteItem(item.value.id)
-    success(`${name} 품목이 삭제되었습니다.`)
+    await changeItemStatus(item.value.id, 'INACTIVE')
+    success(`${name} 품목이 비활성화되었습니다.`)
     router.push({ name: 'item-list' })
   } catch {
     error('삭제 중 오류가 발생했습니다.')

--- a/src/views/master/ItemListPage.vue
+++ b/src/views/master/ItemListPage.vue
@@ -14,7 +14,7 @@ import StatusBadge from '@/components/common/StatusBadge.vue'
 import TableActions from '@/components/common/TableActions.vue'
 import PageHeader from '@/components/common/PageHeader.vue'
 import ItemFormModal from '@/components/domain/master/ItemFormModal.vue'
-import { createItem, deleteItem, fetchItems, updateItem } from '@/api/master'
+import { changeItemStatus, createItem, fetchItems, updateItem } from '@/api/master'
 import { useToast } from '@/composables/useToast'
 import { useAuthStore } from '@/stores/auth'
 import { canManageItems } from '@/utils/roleAccess'
@@ -176,8 +176,8 @@ async function handleDelete() {
   if (!itemToDelete.value || deleting.value) return
   deleting.value = true
   try {
-    await deleteItem(itemToDelete.value.id)
-    success(`${itemToDelete.value.name} 품목이 삭제되었습니다.`)
+    await changeItemStatus(itemToDelete.value.id, 'INACTIVE')
+    success(`${itemToDelete.value.name} 품목이 비활성화되었습니다.`)
     await loadData()
   } catch {
     error('삭제 중 오류가 발생했습니다.')


### PR DESCRIPTION
## 📋 작업 내용

Master Service 백엔드 API 명세서 기준으로 프론트엔드 API 호출을 수정합니다.

**주요 변경:**
- `src/api/master.js` — payment-terms 경로 수정, buyer nested 경로, DELETE→PATCH/status 교체, fetchUsers 제거
- `src/api/auth.js` — `fetchAllUsers()` 헬퍼 추가 (PagedResponse 언래핑)
- `PIFormModal.vue`, `POFormModal.vue` — fetchUsers import를 auth.js fetchAllUsers로 변경
- `ClientListPage.vue`, `ClientDetailPage.vue` — deleteClient → changeClientStatus
- `ItemListPage.vue`, `ItemDetailPage.vue` — deleteItem → changeItemStatus

## 🔗 관련 이슈

- closes #226

## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

- 백엔드 Master 커밋: hanhwa-swcamp-22th-final/team2-backend-master@36cfc87
- 거래처/품목 삭제는 이제 물리 삭제(DELETE)가 아닌 상태 변경(PATCH /status → INACTIVE)으로 처리됩니다