### PR TITLE
refactor: Master Service 필드명 정합성 + ENUM 한글변환 + PagedResponse

### DIFF
--- a/src/api/master.js
+++ b/src/api/master.js
@@ -1,7 +1,7 @@
 import { api } from '@/lib/api'
 
 // Clients
-export const fetchClients = () => api.get('/clients').then((r) => r.data)
+export const fetchClients = () => api.get('/clients').then((r) => r.data.content ?? r.data)
 export const fetchClient = (id) => api.get(`/clients/${id}`).then((r) => r.data)
 export const createClient = (client) => api.post('/clients', client).then((r) => r.data)
 export const updateClient = (id, client) => api.put(`/clients/${id}`, client).then((r) => r.data)
@@ -11,7 +11,7 @@ export async function changeClientStatus(id, status) {
 }
 
 // Items
-export const fetchItems = () => api.get('/items').then((r) => r.data)
+export const fetchItems = () => api.get('/items').then((r) => r.data.content ?? r.data)
 export const fetchItem = (id) => api.get(`/items/${id}`).then((r) => r.data)
 export const createItem = (item) => api.post('/items', item).then((r) => r.data)
 export const updateItem = (id, item) => api.put(`/items/${id}`, item).then((r) => r.data)

--- a/src/components/domain/master/ClientFormModal.vue
+++ b/src/components/domain/master/ClientFormModal.vue
@@ -50,12 +50,12 @@ const currencyOptions = computed(() => {
 })
 
 const statusOptions = [
-  { label: '활성', value: '활성' },
-  { label: '비활성', value: '비활성' },
+  { label: '활성', value: 'active' },
+  { label: '비활성', value: 'inactive' },
 ]
 
 function generateNextCode() {
-  const codes = props.allClients.map((c) => c.code)
+  const codes = props.allClients.map((c) => c.clientCode ?? c.code)
   let maxNum = 0
   for (const code of codes) {
     const match = code.match(/^CLI(\d+)$/)
@@ -78,7 +78,7 @@ function getInitialForm() {
     paymentTermsId: null,
     currencyId: null,
     manager: '',
-    status: '활성',
+    status: 'active',
     sealImage: null,
   }
 }
@@ -89,19 +89,19 @@ watch(
     errors.value = {}
     if (isOpen && props.mode === 'edit' && props.client) {
       form.value = {
-        code: props.client.code ?? '',
+        code: props.client.clientCode ?? props.client.code ?? '',
         name: props.client.name ?? '',
         nameKr: props.client.nameKr ?? '',
         countryId: props.client.countryId ?? null,
-        city: props.client.city ?? '',
+        city: props.client.clientCity ?? props.client.city ?? '',
         portId: props.client.portId ?? null,
-        address: props.client.address ?? '',
-        tel: props.client.tel ?? '',
-        email: props.client.email ?? '',
+        address: props.client.clientAddress ?? props.client.address ?? '',
+        tel: props.client.clientTel ?? props.client.tel ?? '',
+        email: props.client.clientEmail ?? props.client.email ?? '',
         paymentTermsId: props.client.paymentTermsId ?? null,
         currencyId: props.client.currencyId ?? null,
-        manager: props.client.manager ?? '',
-        status: props.client.status ?? '활성',
+        manager: props.client.clientManager ?? props.client.manager ?? '',
+        status: props.client.clientStatus ?? props.client.status ?? 'active',
         sealImage: null,
       }
     } else if (isOpen && props.mode === 'create') {
@@ -131,7 +131,7 @@ function validate() {
     e.code = '코드를 입력하세요.'
   } else if (
     props.allClients.some(
-      (c) => c.code.toLowerCase() === form.value.code.trim().toLowerCase() && c.id !== props.client?.id,
+      (c) => (c.clientCode ?? c.code).toLowerCase() === form.value.code.trim().toLowerCase() && c.id !== props.client?.id,
     )
   ) {
     e.code = '이미 사용 중인 코드입니다.'

--- a/src/components/domain/master/ItemFormModal.vue
+++ b/src/components/domain/master/ItemFormModal.vue
@@ -41,12 +41,12 @@ const categoryOptions = [
 ]
 
 const statusOptions = [
-  { label: '활성', value: '활성' },
-  { label: '비활성', value: '비활성' },
+  { label: '활성', value: 'active' },
+  { label: '비활성', value: 'inactive' },
 ]
 
 function generateNextCode() {
-  const codes = props.allItems.map((i) => i.code)
+  const codes = props.allItems.map((i) => i.itemCode ?? i.code)
   let maxNum = 0
   for (const code of codes) {
     const match = code.match(/^ITM(\d+)$/)
@@ -69,7 +69,7 @@ function getInitialForm() {
     unitPrice: '',
     weight: '',
     hsCode: '',
-    status: '활성',
+    status: 'active',
   }
 }
 
@@ -88,21 +88,21 @@ watch(
   (isOpen) => {
     errors.value = {}
     if (isOpen && props.mode === 'edit' && props.item) {
-      const spec = parseSpec(props.item.spec)
+      const spec = parseSpec(props.item.itemSpec ?? props.item.spec)
       form.value = {
-        code: props.item.code ?? '',
-        name: props.item.name ?? '',
-        nameKr: props.item.nameKr ?? '',
-        category: props.item.category ?? '',
+        code: props.item.itemCode ?? props.item.code ?? '',
+        name: props.item.itemName ?? props.item.name ?? '',
+        nameKr: props.item.itemNameKr ?? props.item.nameKr ?? '',
+        category: props.item.itemCategory ?? props.item.category ?? '',
         specWidth: spec.width,
         specDepth: spec.depth,
         specHeight: spec.height,
-        unit: props.item.unit ?? '',
-        packUnit: props.item.packUnit ?? '',
-        unitPrice: props.item.unitPrice ?? '',
-        weight: props.item.weight ?? '',
-        hsCode: props.item.hsCode ?? '',
-        status: props.item.status ?? '활성',
+        unit: props.item.itemUnit ?? props.item.unit ?? '',
+        packUnit: props.item.itemPackUnit ?? props.item.packUnit ?? '',
+        unitPrice: props.item.itemUnitPrice ?? props.item.unitPrice ?? '',
+        weight: props.item.itemWeight ?? props.item.weight ?? '',
+        hsCode: props.item.itemHsCode ?? props.item.hsCode ?? '',
+        status: props.item.itemStatus ?? props.item.status ?? 'active',
       }
     } else if (isOpen && props.mode === 'create') {
       form.value = getInitialForm()
@@ -118,7 +118,7 @@ function validate() {
     e.code = '코드를 입력하세요.'
   } else if (
     props.allItems.some(
-      (i) => i.code.toLowerCase() === form.value.code.trim().toLowerCase() && i.id !== props.item?.id,
+      (i) => (i.itemCode ?? i.code).toLowerCase() === form.value.code.trim().toLowerCase() && i.id !== props.item?.id,
     )
   ) {
     e.code = '이미 사용 중인 코드입니다.'

--- a/src/views/contacts/ContactListPage.vue
+++ b/src/views/contacts/ContactListPage.vue
@@ -100,8 +100,8 @@ const formTel = ref('')
 const formErrors = ref({})
 
 watch(formClientId, (val) => { if (val) formErrors.value.clientId = undefined })
-watch(formName,     (val) => { if (val.trim()) formErrors.value.name = undefined })
-watch(formEmail,    (val) => { if (val.trim()) formErrors.value.email = undefined })
+watch(formName,     (val) => { if (val.trim()) formErrors.value.buyerName = undefined })
+watch(formEmail,    (val) => { if (val.trim()) formErrors.value.buyerEmail = undefined })
 
 const positionOptions = [
   { label: 'Team Leader', value: 'Team Leader' },
@@ -128,10 +128,10 @@ function openEdit(contact) {
   isEditMode.value = true
   editingId.value = contact.id
   formClientId.value = contact.clientId
-  formName.value = contact.name
-  formPosition.value = contact.position
-  formEmail.value = contact.email
-  formTel.value = contact.tel
+  formName.value = contact.buyerName
+  formPosition.value = contact.buyerPosition
+  formEmail.value = contact.buyerEmail
+  formTel.value = contact.buyerTel
   formErrors.value = {}
   isDetailOpen.value = false
   isFormOpen.value = true
@@ -139,9 +139,9 @@ function openEdit(contact) {
 
 function validate() {
   const e = {}
-  if (!formClientId.value)     e.clientId = '거래처 값이 누락되었습니다.'
-  if (!formName.value.trim())  e.name     = '이름 값이 누락되었습니다.'
-  if (!formEmail.value.trim()) e.email    = '이메일 값이 누락되었습니다.'
+  if (!formClientId.value)     e.clientId  = '거래처 값이 누락되었습니다.'
+  if (!formName.value.trim())  e.buyerName  = '이름 값이 누락되었습니다.'
+  if (!formEmail.value.trim()) e.buyerEmail = '이메일 값이 누락되었습니다.'
   formErrors.value = e
   return Object.keys(e).length === 0
 }
@@ -152,13 +152,13 @@ async function handleFormSubmit() {
     return
   }
   const payload = {
-    clientId:    formClientId.value,
-    name:        formName.value,
-    position:    formPosition.value,
-    email:       formEmail.value,
-    tel:         formTel.value,
+    clientId:     formClientId.value,
+    buyerName:    formName.value,
+    buyerPosition: formPosition.value,
+    buyerEmail:   formEmail.value,
+    buyerTel:     formTel.value,
     signImageUrl: null,
-    createdBy:   currentUser.value?.id,
+    createdBy:    currentUser.value?.id,
   }
   try {
     if (isEditMode.value) {
@@ -261,8 +261,8 @@ async function handleDelete() {
           <!-- 이름 + 연락처 정보 -->
           <div class="min-w-0 flex-1">
             <div class="mb-2">
-              <p class="text-sm font-semibold text-slate-800">{{ contact.name }}</p>
-              <p class="text-xs text-slate-500">{{ contact.position }}</p>
+              <p class="text-sm font-semibold text-slate-800">{{ contact.buyerName }}</p>
+              <p class="text-xs text-slate-500">{{ contact.buyerPosition }}</p>
             </div>
             <div class="space-y-1.5 text-xs">
               <div class="flex items-start gap-2 text-slate-600">
@@ -270,13 +270,13 @@ async function handleDelete() {
                   <path d="M3 4a2 2 0 0 0-2 2v1.161l8.441 4.221a1.25 1.25 0 0 0 1.118 0L19 7.162V6a2 2 0 0 0-2-2H3Z" />
                   <path d="m19 8.839-7.77 3.885a2.75 2.75 0 0 1-2.46 0L1 8.839V14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V8.839Z" />
                 </svg>
-                <span class="break-all">{{ contact.email }}</span>
+                <span class="break-all">{{ contact.buyerEmail }}</span>
               </div>
               <div class="flex items-center gap-2 text-slate-600">
                 <svg class="h-3.5 w-3.5 shrink-0 text-slate-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                   <path fill-rule="evenodd" d="M2 3.5A1.5 1.5 0 0 1 3.5 2h1.148a1.5 1.5 0 0 1 1.465 1.175l.716 3.223a1.5 1.5 0 0 1-1.052 1.767l-.933.267c-.41.117-.643.555-.48.95a11.542 11.542 0 0 0 6.254 6.254c.395.163.833-.07.95-.48l.267-.933a1.5 1.5 0 0 1 1.767-1.052l3.223.716A1.5 1.5 0 0 1 18 16.352V17.5a1.5 1.5 0 0 1-1.5 1.5H15c-1.149 0-2.263-.15-3.326-.43A13.022 13.022 0 0 1 2.43 8.326 13.019 13.019 0 0 1 2 5V3.5Z" clip-rule="evenodd" />
                 </svg>
-                <span>{{ contact.tel }}</span>
+                <span>{{ contact.buyerTel }}</span>
               </div>
             </div>
           </div>
@@ -299,20 +299,20 @@ async function handleDelete() {
     <!-- 상세 모달 -->
     <BaseModal
       :open="isDetailOpen"
-      :title="selectedContact?.name ?? '연락처 상세'"
+      :title="selectedContact?.buyerName ?? '연락처 상세'"
       width="max-w-md"
       @close="closeDetail"
     >
       <div class="space-y-4">
         <div>
-          <p class="text-lg font-bold text-slate-900">{{ selectedContact?.name }}</p>
-          <p class="text-sm text-slate-500">{{ selectedContact?.position }}</p>
+          <p class="text-lg font-bold text-slate-900">{{ selectedContact?.buyerName }}</p>
+          <p class="text-sm text-slate-500">{{ selectedContact?.buyerPosition }}</p>
         </div>
         <div class="space-y-3">
           <InfoField label="거래처" :value="getClientName(selectedContact?.clientId)" />
-          <InfoField label="직위" :value="selectedContact?.position" />
-          <InfoField label="이메일" :value="selectedContact?.email" />
-          <InfoField label="전화" :value="selectedContact?.tel" />
+          <InfoField label="직위" :value="selectedContact?.buyerPosition" />
+          <InfoField label="이메일" :value="selectedContact?.buyerEmail" />
+          <InfoField label="전화" :value="selectedContact?.buyerTel" />
         </div>
       </div>
       <template #footer>
@@ -337,7 +337,7 @@ async function handleDelete() {
               placeholder="거래처 검색/선택..."
             />
           </FormField>
-          <FormField label="이름" :required="true" :error="formErrors.name">
+          <FormField label="이름" :required="true" :error="formErrors.buyerName">
             <BaseTextField v-model="formName" placeholder="연락처 이름" />
           </FormField>
         </div>
@@ -345,7 +345,7 @@ async function handleDelete() {
           <FormField label="직위">
             <BaseSelect v-model="formPosition" :options="positionOptions" placeholder="직위 선택" />
           </FormField>
-          <FormField label="이메일" :required="true" :error="formErrors.email">
+          <FormField label="이메일" :required="true" :error="formErrors.buyerEmail">
             <BaseTextField v-model="formEmail" placeholder="이메일" type="email" />
           </FormField>
         </div>
@@ -364,7 +364,7 @@ async function handleDelete() {
       :open="isDeleteOpen"
       title="연락처 삭제"
       message="아래 연락처를 삭제하시겠습니까?"
-      :detail="`${deleteTarget?.name} (${deleteTarget?.position})`"
+      :detail="`${deleteTarget?.buyerName} (${deleteTarget?.buyerPosition})`"
       confirm-label="삭제"
       confirm-variant="danger"
       @confirm="handleDelete"

--- a/src/views/master/ClientDetailPage.vue
+++ b/src/views/master/ClientDetailPage.vue
@@ -18,6 +18,7 @@ import {
 } from '@/api/master'
 import { useMasterLookup } from '@/composables/useMasterLookup'
 import { useToast } from '@/composables/useToast'
+import { label, CLIENT_STATUS_LABEL } from '@/utils/enumLabels'
 
 const route = useRoute()
 const router = useRouter()
@@ -44,25 +45,25 @@ const infoGroups = computed(() => {
     {
       title: '기본 정보',
       fields: [
-        { label: '코드', value: client.value.code, highlight: true },
+        { label: '코드', value: client.value.clientCode, highlight: true },
         { label: '한글명', value: client.value.nameKr },
       ],
     },
     {
       title: '위치 정보',
       fields: [
-        { label: '국가', value: getCountryName(client.value.countryId, { detailed: true }) },
-        { label: '도시', value: client.value.city },
-        { label: '도착항', value: getPortName(client.value.portId) },
-        { label: '주소', value: client.value.address, wide: true },
+        { label: '국가', value: client.value.countryName || getCountryName(client.value.countryId, { detailed: true }) },
+        { label: '도시', value: client.value.clientCity },
+        { label: '도착항', value: client.value.portName || getPortName(client.value.portId) },
+        { label: '주소', value: client.value.clientAddress, wide: true },
       ],
     },
     {
       title: '연락처',
       fields: [
-        { label: '담당자', value: client.value.manager },
-        { label: 'TEL', value: client.value.tel },
-        { label: 'Email', value: client.value.email },
+        { label: '담당자', value: client.value.clientManager },
+        { label: 'TEL', value: client.value.clientTel },
+        { label: 'Email', value: client.value.clientEmail },
       ],
     },
     {
@@ -108,10 +109,10 @@ async function loadData() {
 
     allClients.value = clientsData
     buyers.value = buyersData.map((b) => ({
-      name: b.name,
-      position: b.position,
-      email: b.email,
-      phone: b.tel,
+      name: b.buyerName,
+      position: b.buyerPosition,
+      email: b.buyerEmail,
+      phone: b.buyerTel,
     }))
   } catch {
     error('데이터를 불러오는 중 오류가 발생했습니다.')
@@ -148,7 +149,7 @@ async function handleDelete() {
   deleting.value = true
   const name = client.value.name
   try {
-    await changeClientStatus(client.value.id, 'INACTIVE')
+    await changeClientStatus(client.value.id, 'inactive')
     success(`${name} 거래처가 비활성화되었습니다.`)
     router.push({ name: 'client-list' })
   } catch {
@@ -172,7 +173,7 @@ function goBack() {
   </div>
 
   <div v-else-if="client" class="space-y-6">
-    <DetailPageHeader :title="`${client.code} · ${client.name}`" :status="client.status" @back="goBack">
+    <DetailPageHeader :title="`${client.clientCode} · ${client.name}`" :status="label(CLIENT_STATUS_LABEL, client.clientStatus)" @back="goBack">
       <template #actions>
         <BaseButton variant="secondary" size="sm" @click="openEditModal">수정</BaseButton>
         <BaseButton variant="ghost" size="sm" @click="showConfirmModal = true">삭제</BaseButton>

--- a/src/views/master/ClientListPage.vue
+++ b/src/views/master/ClientListPage.vue
@@ -23,6 +23,7 @@ import {
 } from '@/api/master'
 import { useMasterLookup } from '@/composables/useMasterLookup'
 import { useToast } from '@/composables/useToast'
+import { label, CLIENT_STATUS_LABEL } from '@/utils/enumLabels'
 
 const router = useRouter()
 const authStore = useAuthStore()
@@ -51,8 +52,8 @@ const appliedFilters = ref({ keyword: '', code: '', name: '', country: '', manag
 
 const statusOptions = [
   { label: '전체', value: '' },
-  { label: '활성', value: '활성' },
-  { label: '비활성', value: '비활성' },
+  { label: '활성', value: 'active' },
+  { label: '비활성', value: 'inactive' },
 ]
 
 const PAGE_SIZE = 10
@@ -66,22 +67,20 @@ const showConfirmModal = ref(false)
 const clientToDelete = ref(null)
 
 const columns = [
-  { key: 'code', label: '코드', width: '100px', align: 'center' },
+  { key: 'clientCode', label: '코드', width: '100px', align: 'center' },
   { key: 'name', label: '거래처명' },
   { key: 'location', label: '국가·도시', width: '140px' },
   { key: 'port', label: '도착항', width: '120px' },
   { key: 'paymentTerms', label: '결제조건', width: '100px', align: 'center' },
   { key: 'currency', label: '통화', width: '80px', align: 'center' },
-  { key: 'manager', label: '담당자', width: '120px' },
-  { key: 'status', label: '상태', width: '80px', align: 'center' },
+  { key: 'clientManager', label: '담당자', width: '120px' },
+  { key: 'clientStatus', label: '상태', width: '80px', align: 'center' },
   { key: 'actions', label: '액션', width: '120px', align: 'center' },
 ]
 
 const enrichedClients = computed(() =>
   clients.value.map((c) => ({
     ...c,
-    countryName: getCountryName(c.countryId),
-    portName: getPortName(c.portId),
     paymentTermsCode: getPaymentTermsLabel(c.paymentTermsId),
     currencyCode: getCurrencyLabel(c.currencyId),
   })),
@@ -119,12 +118,12 @@ const filteredClients = computed(() => {
       (c) =>
         c.name.toLowerCase().includes(kw) ||
         (c.nameKr && c.nameKr.includes(kw)) ||
-        c.code.toLowerCase().includes(kw),
+        c.clientCode.toLowerCase().includes(kw),
     )
   }
 
   if (f.code) {
-    result = result.filter((c) => c.code.toLowerCase().includes(f.code.toLowerCase()))
+    result = result.filter((c) => c.clientCode.toLowerCase().includes(f.code.toLowerCase()))
   }
 
   if (f.name) {
@@ -137,11 +136,11 @@ const filteredClients = computed(() => {
   }
 
   if (f.manager) {
-    result = result.filter((c) => c.manager && c.manager.includes(f.manager))
+    result = result.filter((c) => c.clientManager && c.clientManager.includes(f.manager))
   }
 
   if (f.status) {
-    result = result.filter((c) => c.status === f.status)
+    result = result.filter((c) => c.clientStatus === f.status)
   }
 
   return result
@@ -193,7 +192,7 @@ async function handleDelete() {
   if (!clientToDelete.value || deleting.value) return
   deleting.value = true
   try {
-    await changeClientStatus(clientToDelete.value.id, 'INACTIVE')
+    await changeClientStatus(clientToDelete.value.id, 'inactive')
     success(`${clientToDelete.value.name} 거래처가 비활성화되었습니다.`)
     await loadData()
   } catch {
@@ -306,8 +305,8 @@ function goToDetail(row) {
       clickable-rows
       @row-click="goToDetail"
     >
-      <template #cell-code="{ row }">
-        <span class="font-mono text-xs font-semibold text-brand-600">{{ row.code }}</span>
+      <template #cell-clientCode="{ row }">
+        <span class="font-mono text-xs font-semibold text-brand-600">{{ row.clientCode }}</span>
       </template>
 
       <template #cell-name="{ row }">
@@ -318,7 +317,7 @@ function goToDetail(row) {
       </template>
 
       <template #cell-location="{ row }">
-        {{ [row.countryName, row.city].filter(v => v && v !== '-').join(', ') || '-' }}
+        {{ [row.countryName, row.clientCity].filter(v => v && v !== '-').join(', ') || '-' }}
       </template>
 
       <template #cell-port="{ row }">
@@ -333,8 +332,8 @@ function goToDetail(row) {
         {{ row.currencyCode }}
       </template>
 
-      <template #cell-status="{ row }">
-        <StatusBadge :value="row.status" />
+      <template #cell-clientStatus="{ row }">
+        <StatusBadge :value="label(CLIENT_STATUS_LABEL, row.clientStatus)" />
       </template>
 
       <template #cell-actions="{ row }">

--- a/src/views/master/ItemDetailPage.vue
+++ b/src/views/master/ItemDetailPage.vue
@@ -11,6 +11,7 @@ import { changeItemStatus, fetchItem, fetchItems, updateItem } from '@/api/maste
 import { useToast } from '@/composables/useToast'
 import { useAuthStore } from '@/stores/auth'
 import { canManageItems } from '@/utils/roleAccess'
+import { label, ITEM_STATUS_LABEL } from '@/utils/enumLabels'
 
 const route = useRoute()
 const router = useRouter()
@@ -32,25 +33,25 @@ const infoGroups = computed(() => {
     {
       title: '기본 정보',
       fields: [
-        { label: '코드', value: item.value.code, highlight: true },
-        { label: '한글명', value: item.value.nameKr },
-        { label: '카테고리', value: item.value.category },
+        { label: '코드', value: item.value.itemCode, highlight: true },
+        { label: '한글명', value: item.value.itemNameKr },
+        { label: '카테고리', value: item.value.itemCategory },
       ],
     },
     {
       title: '규격 / 단위',
       fields: [
-        { label: '규격', value: item.value.spec, wide: true },
-        { label: '단위', value: item.value.unit },
-        { label: '포장단위', value: item.value.packUnit },
+        { label: '규격', value: item.value.itemSpec, wide: true },
+        { label: '단위', value: item.value.itemUnit },
+        { label: '포장단위', value: item.value.itemPackUnit },
       ],
     },
     {
       title: '가격 / 기타',
       fields: [
-        { label: '단가 (KRW)', value: item.value.unitPrice?.toLocaleString() ?? '-' },
-        { label: '중량 (kg)', value: item.value.weight?.toLocaleString() ?? '-' },
-        { label: 'HS Code', value: item.value.hsCode },
+        { label: '단가 (KRW)', value: item.value.itemUnitPrice?.toLocaleString() ?? '-' },
+        { label: '중량 (kg)', value: item.value.itemWeight?.toLocaleString() ?? '-' },
+        { label: 'HS Code', value: item.value.itemHsCode },
         { label: '등록일', value: item.value.regDate },
       ],
     },
@@ -110,9 +111,9 @@ const deleting = ref(false)
 async function handleDelete() {
   if (!item.value || deleting.value) return
   deleting.value = true
-  const name = item.value.name
+  const name = item.value.itemName
   try {
-    await changeItemStatus(item.value.id, 'INACTIVE')
+    await changeItemStatus(item.value.id, 'inactive')
     success(`${name} 품목이 비활성화되었습니다.`)
     router.push({ name: 'item-list' })
   } catch {
@@ -135,7 +136,7 @@ function goBack() {
   </div>
 
   <div v-else-if="item" class="space-y-6">
-    <DetailPageHeader :title="`${item.code} · ${item.name}`" :status="item.status" @back="goBack">
+    <DetailPageHeader :title="`${item.itemCode} · ${item.itemName}`" :status="label(ITEM_STATUS_LABEL, item.itemStatus)" @back="goBack">
       <template v-if="isItemAdmin" #actions>
         <BaseButton variant="secondary" size="sm" @click="openEditModal">수정</BaseButton>
         <BaseButton variant="ghost" size="sm" @click="showConfirmModal = true">삭제</BaseButton>
@@ -187,7 +188,7 @@ function goBack() {
       :open="showConfirmModal"
       title="품목 삭제"
       message="해당 품목을 삭제하시겠습니까?"
-      :detail="item?.name"
+      :detail="item?.itemName"
       confirm-label="삭제"
       confirm-variant="danger"
       @confirm="handleDelete"

--- a/src/views/master/ItemListPage.vue
+++ b/src/views/master/ItemListPage.vue
@@ -18,6 +18,7 @@ import { changeItemStatus, createItem, fetchItems, updateItem } from '@/api/mast
 import { useToast } from '@/composables/useToast'
 import { useAuthStore } from '@/stores/auth'
 import { canManageItems } from '@/utils/roleAccess'
+import { label, ITEM_STATUS_LABEL } from '@/utils/enumLabels'
 
 const router = useRouter()
 const { success, error } = useToast()
@@ -44,12 +45,12 @@ const appliedFilters = ref({ keyword: '', code: '', name: '', category: '', unit
 
 const statusOptions = [
   { label: '전체', value: '' },
-  { label: '활성', value: '활성' },
-  { label: '비활성', value: '비활성' },
+  { label: '활성', value: 'active' },
+  { label: '비활성', value: 'inactive' },
 ]
 
 const unitOptions = computed(() => {
-  const units = [...new Set(items.value.map((i) => i.unit).filter(Boolean))]
+  const units = [...new Set(items.value.map((i) => i.itemUnit).filter(Boolean))]
   return [{ label: '전체', value: '' }, ...units.map((u) => ({ label: u, value: u }))]
 })
 
@@ -75,21 +76,21 @@ const showConfirmModal = ref(false)
 const itemToDelete = ref(null)
 
 const categoryOptions = computed(() => {
-  const cats = [...new Set(items.value.map((i) => i.category).filter(Boolean))]
+  const cats = [...new Set(items.value.map((i) => i.itemCategory).filter(Boolean))]
   return [{ label: '전체', value: '' }, ...cats.map((c) => ({ label: c, value: c }))]
 })
 
 const columns = computed(() => {
   const base = [
-    { key: 'code', label: '코드', width: '100px', align: 'center' },
-    { key: 'name', label: '품목명' },
-    { key: 'spec', label: '규격', width: '200px' },
-    { key: 'packUnit', label: '포장단위', width: '100px', align: 'center' },
-    { key: 'unit', label: '단위', width: '80px', align: 'center' },
-    { key: 'unitPrice', label: '단가 (KRW)', width: '140px', align: 'right' },
-    { key: 'weight', label: '중량 (kg)', width: '110px', align: 'right' },
-    { key: 'hsCode', label: 'HS Code', width: '100px', align: 'center' },
-    { key: 'status', label: '상태', width: '80px', align: 'center' },
+    { key: 'itemCode', label: '코드', width: '100px', align: 'center' },
+    { key: 'itemName', label: '품목명' },
+    { key: 'itemSpec', label: '규격', width: '200px' },
+    { key: 'itemPackUnit', label: '포장단위', width: '100px', align: 'center' },
+    { key: 'itemUnit', label: '단위', width: '80px', align: 'center' },
+    { key: 'itemUnitPrice', label: '단가 (KRW)', width: '140px', align: 'right' },
+    { key: 'itemWeight', label: '중량 (kg)', width: '110px', align: 'right' },
+    { key: 'itemHsCode', label: 'HS Code', width: '100px', align: 'center' },
+    { key: 'itemStatus', label: '상태', width: '80px', align: 'center' },
   ]
   if (isItemAdmin.value) {
     base.push({ key: 'actions', label: '액션', width: '120px', align: 'center' })
@@ -105,31 +106,31 @@ const filteredItems = computed(() => {
     const kw = f.keyword.toLowerCase()
     result = result.filter(
       (item) =>
-        item.name.toLowerCase().includes(kw) ||
-        (item.nameKr && item.nameKr.includes(kw)) ||
-        item.code.toLowerCase().includes(kw),
+        item.itemName.toLowerCase().includes(kw) ||
+        (item.itemNameKr && item.itemNameKr.includes(kw)) ||
+        item.itemCode.toLowerCase().includes(kw),
     )
   }
 
   if (f.code) {
-    result = result.filter((item) => item.code.toLowerCase().includes(f.code.toLowerCase()))
+    result = result.filter((item) => item.itemCode.toLowerCase().includes(f.code.toLowerCase()))
   }
 
   if (f.name) {
     const kw = f.name.toLowerCase()
-    result = result.filter((item) => item.name.toLowerCase().includes(kw) || (item.nameKr && item.nameKr.includes(kw)))
+    result = result.filter((item) => item.itemName.toLowerCase().includes(kw) || (item.itemNameKr && item.itemNameKr.includes(kw)))
   }
 
   if (f.category) {
-    result = result.filter((item) => item.category === f.category)
+    result = result.filter((item) => item.itemCategory === f.category)
   }
 
   if (f.unit) {
-    result = result.filter((item) => item.unit === f.unit)
+    result = result.filter((item) => item.itemUnit === f.unit)
   }
 
   if (f.status) {
-    result = result.filter((item) => item.status === f.status)
+    result = result.filter((item) => item.itemStatus === f.status)
   }
 
   return result
@@ -176,8 +177,8 @@ async function handleDelete() {
   if (!itemToDelete.value || deleting.value) return
   deleting.value = true
   try {
-    await changeItemStatus(itemToDelete.value.id, 'INACTIVE')
-    success(`${itemToDelete.value.name} 품목이 비활성화되었습니다.`)
+    await changeItemStatus(itemToDelete.value.id, 'inactive')
+    success(`${itemToDelete.value.itemName} 품목이 비활성화되었습니다.`)
     await loadData()
   } catch {
     error('삭제 중 오류가 발생했습니다.')
@@ -193,8 +194,7 @@ async function handleSave(formData) {
   saving.value = true
   try {
     if (formMode.value === 'create') {
-      // Use formData.status as-is (set by the form); fallback to '활성' only if absent
-      await createItem({ ...formData, regDate: new Date().toISOString().slice(0, 10), status: formData.status ?? '활성' })
+      await createItem({ ...formData, regDate: new Date().toISOString().slice(0, 10), status: formData.status ?? 'active' })
       success('품목이 등록되었습니다.')
     } else {
       await updateItem(selectedItem.value.id, formData)
@@ -293,27 +293,27 @@ function goToDetail(row) {
       :footer-text="`총 ${filteredItems.length}건`"
       @row-click="goToDetail"
     >
-      <template #cell-code="{ row }">
-        <span class="font-mono text-xs font-semibold text-brand-600">{{ row.code }}</span>
+      <template #cell-itemCode="{ row }">
+        <span class="font-mono text-xs font-semibold text-brand-600">{{ row.itemCode }}</span>
       </template>
 
-      <template #cell-name="{ row }">
+      <template #cell-itemName="{ row }">
         <div>
-          <p class="font-medium text-ink">{{ row.name }}</p>
-          <p class="text-xs text-slate-500">{{ [row.nameKr, row.category].filter(Boolean).join(' · ') }}</p>
+          <p class="font-medium text-ink">{{ row.itemName }}</p>
+          <p class="text-xs text-slate-500">{{ [row.itemNameKr, row.itemCategory].filter(Boolean).join(' · ') }}</p>
         </div>
       </template>
 
-      <template #cell-unitPrice="{ row }">
-        {{ row.unitPrice?.toLocaleString() ?? '-' }}
+      <template #cell-itemUnitPrice="{ row }">
+        {{ row.itemUnitPrice?.toLocaleString() ?? '-' }}
       </template>
 
-      <template #cell-weight="{ row }">
-        {{ row.weight?.toLocaleString() ?? '-' }}
+      <template #cell-itemWeight="{ row }">
+        {{ row.itemWeight?.toLocaleString() ?? '-' }}
       </template>
 
-      <template #cell-status="{ row }">
-        <StatusBadge :value="row.status" />
+      <template #cell-itemStatus="{ row }">
+        <StatusBadge :value="label(ITEM_STATUS_LABEL, row.itemStatus)" />
       </template>
 
       <template #cell-actions="{ row }">
@@ -340,7 +340,7 @@ function goToDetail(row) {
       :open="showConfirmModal"
       title="품목 삭제"
       message="해당 품목을 삭제하시겠습니까?"
-      :detail="itemToDelete?.name"
+      :detail="itemToDelete?.itemName"
       confirm-label="삭제"
       confirm-variant="danger"
       @confirm="handleDelete"


### PR DESCRIPTION
## 📋 작업 내용

Master Service 백엔드 API 응답과 프론트엔드 컴포넌트 간 필드명/상태값/응답구조 불일치를 전면 수정합니다.

**필드명 변경 (8개 파일):**
- Client: `code`→`clientCode`, `city`→`clientCity`, `tel`→`clientTel`, `email`→`clientEmail`
- Buyer: `name`→`buyerName`, `position`→`buyerPosition`, `email`→`buyerEmail`, `tel`→`buyerTel`
- Item: `unit`→`itemUnit`, `category`→`itemCategory`, `unitPrice`→`itemUnitPrice`, `weight`→`itemWeight`, `hsCode`→`itemHsCode`, `packUnit`→`itemPackUnit`

**상태값:** `'활성'`/`'비활성'` → `'active'`/`'inactive'` + `enumLabels.js`로 한글 표시

**PagedResponse:** `fetchClients()`/`fetchItems()`에서 `.content` 추출

## 🔗 관련 이슈

- closes #228

## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

- Auth 서비스와 동일 패턴: DB는 영문 코드, 프론트 표시만 한글 (`enumLabels.js`)
- ClientListPage에서 `countryName`/`portName`을 백엔드가 직접 보내주므로 불필요한 lookup 로직 제거됨