### PR TITLE
refactor: 크로스 서비스 API 원본 서비스 직접 호출 통일 + 필드명 정합성

### DIFF
--- a/src/components/domain/document/PIFormModal.vue
+++ b/src/components/domain/document/PIFormModal.vue
@@ -272,24 +272,24 @@ async function loadReferenceData() {
     )
 
     clientCatalog.value = clientsData.map((client) => ({
-      id: String(client.id),
-      name: client.name,
-      country: countryMap.get(String(client.countryId)) ?? '-',
-      address: client.address ?? '',
+      id: String(client.clientId),
+      name: client.clientName,
+      country: client.countryName ?? countryMap.get(String(client.countryId)) ?? '-',
+      address: client.clientCity ?? '',
       tel: client.tel ?? '',
       email: client.email ?? '',
     }))
 
     currencyOptions.value = currenciesData.map((currency) => currency.code).filter(Boolean)
     productCatalog.value = itemsData
-      .filter((item) => item.status !== '비활성')
+      .filter((item) => item.itemStatus === 'active')
       .map((item) => ({
-        id: item.id,
-        code: item.code ?? '',
-        name: item.name ?? '',
-        spec: item.spec ?? '',
-        unit: item.unit ?? '',
-        unitPrice: Number(item.unitPrice ?? 0),
+        id: item.itemId,
+        code: item.itemCode ?? '',
+        name: item.itemName ?? '',
+        spec: item.itemSpec ?? '',
+        unit: item.itemUnit ?? '',
+        unitPrice: Number(item.itemUnitPrice ?? 0),
       }))
       .filter((item) => item.name)
 
@@ -298,22 +298,22 @@ async function loadReferenceData() {
     }
     incotermCatalog.value = incotermsData
       .map((item) => ({
-        id: String(item.id),
-        code: item.code,
-        name: item.name,
-        nameKr: item.nameKr,
-        description: item.description,
-        transportMode: item.transportMode,
-        sellerSegments: Number(item.sellerSegments ?? 6),
-        defaultNamedPlace: item.defaultNamedPlace ?? '',
+        id: String(item.incotermId),
+        code: item.incotermCode,
+        name: item.incotermName,
+        nameKr: item.incotermNameKr,
+        description: item.incotermDescription,
+        transportMode: item.incotermTransportMode,
+        sellerSegments: Number(item.incotermSellerSegments ?? 6),
+        defaultNamedPlace: item.incotermDefaultNamedPlace ?? '',
         namedPlacePlaceholder: item.namedPlacePlaceholder ?? '',
       }))
       .filter((item) => item.code)
 
     const activeUsers = usersData
-      .filter((user) => user.status === '재직')
-      .filter((user) => user.role === 'sales' && Number(user.positionId) === 1)
-      .map((user) => user.name)
+      .filter((user) => user.userStatus === 'active')
+      .filter((user) => user.userRole === 'sales' && user.positionName === '사원')
+      .map((user) => user.userName)
       .filter(Boolean)
 
     if (activeUsers.length) {

--- a/src/components/domain/document/POFormModal.vue
+++ b/src/components/domain/document/POFormModal.vue
@@ -39,9 +39,9 @@ async function loadApproverOptions() {
   try {
     const users = await fetchAllUsers()
     const activeUsers = users
-      .filter((user) => user.status === '재직')
-      .filter((user) => user.role === 'sales' && Number(user.positionId) === 1)
-      .map((user) => user.name)
+      .filter((user) => user.userStatus === 'active')
+      .filter((user) => user.userRole === 'sales' && user.positionName === '사원')
+      .map((user) => user.userName)
       .filter(Boolean)
 
     if (activeUsers.length) {

--- a/src/composables/useDocumentItemCatalog.js
+++ b/src/composables/useDocumentItemCatalog.js
@@ -37,8 +37,8 @@ function findMasterItem(name) {
   if (!normalizedName) return null
 
   return itemCatalog.value.find((item) => (
-    normalizeText(item.name) === normalizedName
-    || normalizeText(item.nameKr) === normalizedName
+    normalizeText(item.itemName) === normalizedName
+    || normalizeText(item.itemNameKr) === normalizedName
   )) ?? null
 }
 
@@ -51,14 +51,14 @@ function enrichDocumentItems(items = []) {
   return items.map((item) => {
     const masterItem = findMasterItem(item.name)
     const quantityValue = parseNumericValue(item.quantity ?? item.qty)
-    const unitWeight = Number.parseFloat(masterItem?.weight)
+    const unitWeight = Number.parseFloat(masterItem?.itemWeight)
     const rowWeight = Number.isFinite(unitWeight) ? unitWeight * quantityValue : null
 
     return {
       ...item,
-      spec: masterItem?.spec ?? '',
-      hsCode: masterItem?.hsCode ?? '',
-      unit: item.unit || masterItem?.unit || '',
+      spec: masterItem?.itemSpec ?? '',
+      hsCode: masterItem?.itemHsCode ?? '',
+      unit: item.unit || masterItem?.itemUnit || '',
       unitWeight: Number.isFinite(unitWeight) ? unitWeight : null,
       rowWeight,
     }

--- a/src/composables/useMasterLookup.js
+++ b/src/composables/useMasterLookup.js
@@ -21,26 +21,26 @@ export function useMasterLookup() {
   }
 
   function getCountryName(countryId, { detailed = false } = {}) {
-    const found = countries.value.find((c) => String(c.id) === String(countryId))
+    const found = countries.value.find((c) => String(c.countryId) === String(countryId))
     if (!found) return '-'
-    return detailed ? `${found.nameKr} (${found.name})` : found.name
+    return detailed ? `${found.countryNameKr} (${found.countryName})` : found.countryName
   }
 
   function getPortName(portId) {
     const found = ports.value.find((p) => String(p.id) === String(portId))
-    return found ? found.name : '-'
+    return found ? found.portName : '-'
   }
 
   function getPaymentTermsLabel(paymentTermsId, { detailed = false } = {}) {
-    const found = paymentTerms.value.find((p) => String(p.id) === String(paymentTermsId))
+    const found = paymentTerms.value.find((p) => String(p.paymentTermId) === String(paymentTermsId))
     if (!found) return '-'
-    return detailed ? `${found.code} (${found.description})` : found.code
+    return detailed ? `${found.paymentTermCode} (${found.paymentTermDescription})` : found.paymentTermCode
   }
 
   function getCurrencyLabel(currencyId, { detailed = false } = {}) {
-    const found = currencies.value.find((c) => String(c.id) === String(currencyId))
+    const found = currencies.value.find((c) => String(c.currencyId) === String(currencyId))
     if (!found) return '-'
-    return detailed ? `${found.code} (${found.symbol})` : found.code
+    return detailed ? `${found.currencyCode} (${found.currencySymbol})` : found.currencyCode
   }
 
   return {

--- a/src/composables/useSearchModalLookups.js
+++ b/src/composables/useSearchModalLookups.js
@@ -1,27 +1,6 @@
 import { computed, onMounted, ref } from 'vue'
 
-import { fetchClients, fetchCountries, fetchCurrencies, fetchItems } from '@/api/master'
-import masterData from '../../db.json'
-import { createDocumentClientRows } from '@/utils/documentClientRows'
-
-function createDefaultClientRows() {
-  return createDocumentClientRows()
-}
-
-function createDefaultProductRows() {
-  return (masterData.items ?? []).map((item) => ({
-    id: String(item.id),
-    code: item.code ?? '-',
-    name: item.name ?? '-',
-    nameKr: item.nameKr ?? '-',
-    spec: item.spec ?? '-',
-    unit: item.unit ?? '-',
-    unitPrice: item.unitPrice ?? 0,
-    hsCode: item.hsCode ?? '-',
-    category: item.category ?? '-',
-    status: item.status ?? '-',
-  }))
-}
+import { fetchClients, fetchItems } from '@/api/master'
 
 function includesKeyword(row, fields, keyword) {
   if (!keyword) return true
@@ -30,53 +9,39 @@ function includesKeyword(row, fields, keyword) {
 }
 
 export function useSearchModalLookups() {
-  const clientRowsSource = ref(createDefaultClientRows())
-  const productRowsSource = ref(createDefaultProductRows())
+  const clientRowsSource = ref([])
+  const productRowsSource = ref([])
 
   async function loadSearchModalLookups() {
     try {
-      const [clientsData, countriesData, currenciesData, itemsData] = await Promise.all([
+      const [clientsData, itemsData] = await Promise.all([
         fetchClients(),
-        fetchCountries(),
-        fetchCurrencies(),
         fetchItems(),
       ])
 
-      const countryMap = new Map(
-        countriesData.map((country) => [String(country.id), country.nameKr ?? country.name ?? '-']),
-      )
-
-      const currencyMap = new Map(
-        currenciesData.map((currency) => [String(currency.id), currency.code ?? '-']),
-      )
-
       clientRowsSource.value = clientsData.map((client) => ({
-        id: String(client.id),
-        code: client.code ?? '-',
-        name: client.name ?? '-',
-        country: countryMap.get(String(client.countryId)) ?? '-',
-        city: client.city ?? '-',
-        currency: currencyMap.get(String(client.currencyId)) ?? '-',
-        manager: client.manager ?? '-',
-        tel: client.tel ?? '-',
-        status: client.status ?? '-',
+        id: String(client.clientId),
+        code: client.clientCode ?? '-',
+        name: client.clientName ?? '-',
+        country: client.countryName ?? '-',
+        city: client.clientCity ?? '-',
+        status: client.clientStatus ?? '-',
       }))
 
       productRowsSource.value = itemsData.map((item) => ({
-        id: String(item.id),
-        code: item.code ?? '-',
-        name: item.name ?? '-',
-        nameKr: item.nameKr ?? '-',
-        spec: item.spec ?? '-',
-        unit: item.unit ?? '-',
-        unitPrice: item.unitPrice ?? 0,
-        hsCode: item.hsCode ?? '-',
-        category: item.category ?? '-',
-        status: item.status ?? '-',
+        id: String(item.itemId),
+        code: item.itemCode ?? '-',
+        name: item.itemName ?? '-',
+        nameKr: item.itemNameKr ?? '-',
+        spec: item.itemSpec ?? '-',
+        unit: item.itemUnit ?? '-',
+        unitPrice: item.itemUnitPrice ?? 0,
+        category: item.itemCategory ?? '-',
+        status: item.itemStatus ?? '-',
       }))
     } catch {
-      clientRowsSource.value = createDefaultClientRows()
-      productRowsSource.value = createDefaultProductRows()
+      clientRowsSource.value = []
+      productRowsSource.value = []
     }
   }
 
@@ -87,7 +52,7 @@ export function useSearchModalLookups() {
       const keyword = keywordRef.value.trim().toLowerCase()
       return clientRowsSource.value.filter((row) => includesKeyword(
         row,
-        ['code', 'name', 'country', 'city', 'currency', 'manager', 'tel', 'status'],
+        ['code', 'name', 'country', 'city', 'status'],
         keyword,
       ))
     })
@@ -98,7 +63,7 @@ export function useSearchModalLookups() {
       const keyword = keywordRef.value.trim().toLowerCase()
       return productRowsSource.value.filter((row) => includesKeyword(
         row,
-        ['code', 'name', 'nameKr', 'spec', 'unit', 'hsCode', 'category', 'status'],
+        ['code', 'name', 'nameKr', 'spec', 'unit', 'category', 'status'],
         keyword,
       ))
     })

--- a/src/utils/ciplMaster.js
+++ b/src/utils/ciplMaster.js
@@ -1,30 +1,51 @@
-import masterData from '../../db.json'
 import { formatIncotermsLabel, getIncotermMeta } from '@/utils/incoterms'
+import { fetchCountries, fetchCurrencies, fetchPaymentTerms, fetchPorts } from '@/api/master'
 
-const countriesById = new Map(
-  (masterData.countries ?? []).map((country) => [String(country.id), country]),
-)
+const countriesById = new Map()
+const currenciesByCode = new Map()
+const paymentTermsById = new Map()
+const portsByCode = new Map()
+let cacheLoaded = false
+let cachePromise = null
 
-const currenciesByCode = new Map(
-  (masterData.currencies ?? []).map((currency) => [String(currency.code).toUpperCase(), currency]),
-)
+export async function loadCiplMasterCache() {
+  if (cacheLoaded) return
+  if (cachePromise) return cachePromise
 
-const paymentTermsById = new Map(
-  (masterData.paymentTerms ?? []).map((term) => [String(term.id), term]),
-)
+  cachePromise = (async () => {
+    try {
+      const [countries, currencies, paymentTerms, ports] = await Promise.all([
+        fetchCountries(),
+        fetchCurrencies(),
+        fetchPaymentTerms(),
+        fetchPorts(),
+      ])
+      countries.forEach((c) => countriesById.set(String(c.countryId), c))
+      currencies.forEach((c) => currenciesByCode.set(String(c.currencyCode).toUpperCase(), c))
+      paymentTerms.forEach((t) => paymentTermsById.set(String(t.paymentTermId), t))
+      ports.forEach((p) => portsByCode.set(String(p.portCode).toUpperCase(), p))
+      cacheLoaded = true
+    } catch {
+      // Cache load failed — functions will degrade gracefully.
+    } finally {
+      cachePromise = null
+    }
+  })()
 
-const portsByCode = new Map(
-  (masterData.ports ?? []).map((port) => [String(port.code).toUpperCase(), port]),
-)
+  return cachePromise
+}
+
+// Eagerly start cache loading when this module is first imported.
+loadCiplMasterCache()
 
 function resolveCountryLabel(countryId) {
   const country = countriesById.get(String(countryId))
-  return country?.nameKr ?? country?.name ?? ''
+  return country?.countryNameKr ?? country?.countryName ?? ''
 }
 
 export function resolveMasterCurrency(code, fallback = 'USD') {
   const currency = currenciesByCode.get(String(code ?? '').trim().toUpperCase())
-  return currency?.code ?? fallback
+  return currency?.currencyCode ?? fallback
 }
 
 export function resolvePaymentTermLabel(paymentTermsId, fallback = 'T/T REMITTANCE') {
@@ -34,11 +55,11 @@ export function resolvePaymentTermLabel(paymentTermsId, fallback = 'T/T REMITTAN
     return fallback
   }
 
-  if (term.code === 'T/T') {
+  if (term.paymentTermCode === 'T/T') {
     return 'T/T REMITTANCE'
   }
 
-  return term.code ?? fallback
+  return term.paymentTermCode ?? fallback
 }
 
 export function resolvePortLabel(portCode, fallback = '-') {
@@ -49,7 +70,7 @@ export function resolvePortLabel(portCode, fallback = '-') {
   }
 
   const countryLabel = resolveCountryLabel(port.countryId)
-  return [String(port.name ?? '').toUpperCase(), countryLabel ? String(countryLabel).toUpperCase() : '']
+  return [String(port.portName ?? '').toUpperCase(), countryLabel ? String(countryLabel).toUpperCase() : '']
     .filter(Boolean)
     .join(', ')
 }

--- a/src/utils/documentActivityEmail.js
+++ b/src/utils/documentActivityEmail.js
@@ -1,22 +1,45 @@
-import masterData from '../../db.json'
-
-import { fetchBuyersByClient } from '@/api/master'
+import { fetchBuyersByClient, fetchClients, fetchCurrencies, fetchItems, fetchPorts } from '@/api/master'
 import { api } from '@/lib/api'
 import { resolveMasterCurrency, resolvePaymentTermLabel, resolvePortLabel } from '@/utils/ciplMaster'
 import { resolveIncotermState } from '@/utils/incoterms'
 
-const clientsByName = new Map((masterData.clients ?? []).map((client) => [client.name, client]))
-const currenciesById = new Map((masterData.currencies ?? []).map((currency) => [String(currency.id), currency]))
-const portsById = new Map((masterData.ports ?? []).map((port) => [String(port.id), port]))
-const itemsByName = new Map((masterData.items ?? []).map((item) => [item.name, item]))
+const clientsByName = new Map()
+const currenciesById = new Map()
+const portsById = new Map()
+const itemsByName = new Map()
 const buyersByClientId = new Map()
+let cacheLoaded = false
+let cachePromise = null
 
-;(masterData.buyers ?? []).forEach((buyer) => {
-  const key = String(buyer.clientId)
-  const current = buyersByClientId.get(key) ?? []
-  current.push(buyer)
-  buyersByClientId.set(key, current)
-})
+export async function loadActivityEmailCache() {
+  if (cacheLoaded) return
+  if (cachePromise) return cachePromise
+
+  cachePromise = (async () => {
+    try {
+      const [clients, currencies, ports, items] = await Promise.all([
+        fetchClients(),
+        fetchCurrencies(),
+        fetchPorts(),
+        fetchItems(),
+      ])
+      clients.forEach((c) => clientsByName.set(c.clientName, c))
+      currencies.forEach((c) => currenciesById.set(String(c.currencyId), c))
+      ports.forEach((p) => portsById.set(String(p.id), p))
+      items.forEach((i) => itemsByName.set(i.itemName, i))
+      cacheLoaded = true
+    } catch {
+      // Cache load failed — functions will degrade gracefully.
+    } finally {
+      cachePromise = null
+    }
+  })()
+
+  return cachePromise
+}
+
+// Eagerly start cache loading when this module is first imported.
+loadActivityEmailCache()
 
 function parseNumericValue(value) {
   const numeric = Number.parseFloat(String(value ?? '').replace(/[^0-9.]/g, ''))
@@ -53,12 +76,12 @@ function getClientByName(clientName) {
 
 function getNamedPlace(client) {
   if (!client?.portId) return ''
-  return portsById.get(String(client.portId))?.name?.toUpperCase() ?? ''
+  return portsById.get(String(client.portId))?.portName?.toUpperCase() ?? ''
 }
 
 function getPrimaryBuyer(client) {
-  if (!client?.id) return null
-  return (buyersByClientId.get(String(client.id)) ?? [])[0] ?? null
+  if (!client?.clientId) return null
+  return (buyersByClientId.get(String(client.clientId)) ?? [])[0] ?? null
 }
 
 function getCurrencyCode(poRow, client) {
@@ -67,7 +90,7 @@ function getCurrencyCode(poRow, client) {
   }
 
   if (client?.currencyId) {
-    return currenciesById.get(String(client.currencyId))?.code ?? 'USD'
+    return currenciesById.get(String(client.currencyId))?.currencyCode ?? 'USD'
   }
 
   return 'USD'
@@ -87,7 +110,7 @@ function buildCiItems(poRow) {
     const masterItem = itemsByName.get(item.name)
     return {
       name: item.name ?? '-',
-      hsCode: masterItem?.hsCode ?? '-',
+      hsCode: masterItem?.itemHsCode ?? '-',
       quantity: String(item.qty ?? item.quantity ?? '0'),
       unitPrice: formatNumber(parseNumericValue(item.unitPrice), 2),
       amount: formatNumber(parseNumericValue(item.amount), 2),
@@ -100,7 +123,7 @@ function buildPlItems(poRow) {
   return (poRow.items ?? []).map((item) => {
     const masterItem = itemsByName.get(item.name)
     const quantity = parseNumericValue(item.qty ?? item.quantity)
-    const netWeight = Number(((masterItem?.weight ?? 0) * quantity).toFixed(2))
+    const netWeight = Number(((masterItem?.itemWeight ?? 0) * quantity).toFixed(2))
     const grossWeight = Number((netWeight * 1.05).toFixed(2))
     const measurement = Number((grossWeight * 0.08).toFixed(2))
 
@@ -116,12 +139,12 @@ function buildPlItems(poRow) {
 
 function getPortLabel(client) {
   if (!client?.portId) return '-'
-  const portCode = portsById.get(String(client.portId))?.code ?? ''
+  const portCode = portsById.get(String(client.portId))?.portCode ?? ''
   return resolvePortLabel(portCode, '-')
 }
 
 function getPaymentTermsLabel(client) {
-  return resolvePaymentTermLabel(client?.paymentTermsId ?? null, '-')
+  return resolvePaymentTermLabel(client?.paymentTermId ?? null, '-')
 }
 
 export function ensureCommercialDocumentsForPo(poRow, ciRows, plRows) {
@@ -143,8 +166,8 @@ export function ensureCommercialDocumentsForPo(poRow, ciRows, plRows) {
     status: '발행대기',
     issueDate: formatDateSlash(poRow.issueDate || new Date()),
     clientName: poRow.clientName,
-    clientAddress: poRow.clientAddress || client?.address || '-',
-    buyer: poRow.buyerName || buyer?.name || '-',
+    clientAddress: poRow.clientAddress || client?.clientAddress || '-',
+    buyer: poRow.buyerName || buyer?.buyerName || '-',
     country: poRow.country || '-',
     currencyCode: currency,
     currency,
@@ -154,7 +177,7 @@ export function ensureCommercialDocumentsForPo(poRow, ciRows, plRows) {
     incotermCode: incotermState.code,
     incoterms: [incotermState.code, incotermState.namedPlace].filter(Boolean).join(' ') || '-',
     namedPlace: incotermState.namedPlace,
-    paymentTermsId: client?.paymentTermsId ?? null,
+    paymentTermsId: client?.paymentTermId ?? null,
     paymentTerms: getPaymentTermsLabel(client),
     deliveryDate: poRow.deliveryDate || '-',
     portOfDischarge: getPortLabel(client),
@@ -171,8 +194,8 @@ export function ensureCommercialDocumentsForPo(poRow, ciRows, plRows) {
     status: '발행대기',
     issueDate: formatDateSlash(poRow.issueDate || new Date()),
     clientName: poRow.clientName,
-    clientAddress: poRow.clientAddress || client?.address || '-',
-    buyer: poRow.buyerName || buyer?.name || '-',
+    clientAddress: poRow.clientAddress || client?.clientAddress || '-',
+    buyer: poRow.buyerName || buyer?.buyerName || '-',
     country: poRow.country || '-',
     itemName: poRow.itemName || plItems[0]?.name || '-',
     grossWeight: formatNumber(totalGrossWeight, 2),
@@ -181,7 +204,7 @@ export function ensureCommercialDocumentsForPo(poRow, ciRows, plRows) {
     bookingNo: 'T.B.A.',
     carrier: '-',
     incoterms: [incotermState.code, incotermState.namedPlace].filter(Boolean).join(' ') || '-',
-    paymentTermsId: client?.paymentTermsId ?? null,
+    paymentTermsId: client?.paymentTermId ?? null,
     paymentTerms: getPaymentTermsLabel(client),
     deliveryDate: poRow.deliveryDate || '-',
     portOfDischarge: getPortLabel(client),
@@ -263,28 +286,28 @@ export function applyShipmentOrderToCommercialDocuments(rows, poId, shipmentOrde
 async function loadRecipients(clientName) {
   const client = getClientByName(clientName)
 
-  if (!client?.id) {
-    return client?.email ? [{ name: client.manager || clientName, email: client.email }] : []
+  if (!client?.clientId) {
+    return client?.clientEmail ? [{ name: client.clientManager || clientName, email: client.clientEmail }] : []
   }
 
   try {
-    const buyers = await fetchBuyersByClient(client.id)
+    const buyers = await fetchBuyersByClient(client.clientId)
     const rows = (buyers ?? [])
-      .filter((buyer) => buyer.email)
-      .map((buyer) => ({ name: buyer.name, email: buyer.email }))
+      .filter((buyer) => buyer.buyerEmail)
+      .map((buyer) => ({ name: buyer.buyerName, email: buyer.buyerEmail }))
 
     if (rows.length) return rows
   } catch {
-    // Fallback to local db snapshot below.
+    // Fallback to cached data below.
   }
 
-  const fallbackBuyers = (buyersByClientId.get(String(client.id)) ?? [])
-    .filter((buyer) => buyer.email)
-    .map((buyer) => ({ name: buyer.name, email: buyer.email }))
+  const fallbackBuyers = (buyersByClientId.get(String(client.clientId)) ?? [])
+    .filter((buyer) => buyer.buyerEmail)
+    .map((buyer) => ({ name: buyer.buyerName, email: buyer.buyerEmail }))
 
   if (fallbackBuyers.length) return fallbackBuyers
 
-  return client.email ? [{ name: client.manager || client.name, email: client.email }] : []
+  return client.clientEmail ? [{ name: client.clientManager || client.clientName, email: client.clientEmail }] : []
 }
 
 export async function recordDocumentEmailActivities({

--- a/src/utils/documentClientRows.js
+++ b/src/utils/documentClientRows.js
@@ -1,9 +1,7 @@
-import masterData from '../../db.json'
-
 function createBuyersByClientId(buyersData = []) {
   return buyersData.reduce((map, buyer) => {
     const clientId = String(buyer.clientId)
-    const label = buyer.position ? `${buyer.name} (${buyer.position})` : buyer.name
+    const label = buyer.buyerPosition ? `${buyer.buyerName} (${buyer.buyerPosition})` : buyer.buyerName
     const buyers = map.get(clientId) ?? []
     buyers.push(label)
     map.set(clientId, buyers)
@@ -12,31 +10,31 @@ function createBuyersByClientId(buyersData = []) {
 }
 
 export function createDocumentClientRows({
-  clientsData = masterData.clients ?? [],
-  countriesData = masterData.countries ?? [],
-  currenciesData = masterData.currencies ?? [],
-  buyersData = masterData.buyers ?? [],
+  clientsData = [],
+  countriesData = [],
+  currenciesData = [],
+  buyersData = [],
 } = {}) {
   const countryMap = new Map(
-    countriesData.map((country) => [String(country.id), country.nameKr ?? country.name ?? '-']),
+    countriesData.map((country) => [String(country.countryId), country.countryNameKr ?? country.countryName ?? '-']),
   )
   const currencyMap = new Map(
-    currenciesData.map((currency) => [String(currency.id), currency.code ?? '-']),
+    currenciesData.map((currency) => [String(currency.currencyId), currency.currencyCode ?? '-']),
   )
   const buyersByClientId = createBuyersByClientId(buyersData)
 
   return clientsData.map((client) => ({
-    id: String(client.id),
-    code: client.code ?? '-',
-    name: client.name ?? '-',
-    country: countryMap.get(String(client.countryId)) ?? '-',
-    city: client.city ?? '-',
+    id: String(client.clientId),
+    code: client.clientCode ?? '-',
+    name: client.clientName ?? '-',
+    country: countryMap.get(String(client.countryId)) ?? client.countryName ?? '-',
+    city: client.clientCity ?? '-',
     currency: currencyMap.get(String(client.currencyId)) ?? '-',
-    manager: client.manager ?? '-',
-    tel: client.tel ?? '-',
-    email: client.email ?? '-',
-    address: client.address ?? '-',
-    status: client.status ?? '-',
-    buyers: buyersByClientId.get(String(client.id)) ?? [],
+    manager: client.clientManager ?? '-',
+    tel: client.clientTel ?? '-',
+    email: client.clientEmail ?? '-',
+    address: client.clientAddress ?? '-',
+    status: client.clientStatus ?? '-',
+    buyers: buyersByClientId.get(String(client.clientId)) ?? [],
   }))
 }

--- a/src/views/activity/ActivityCreatePage.vue
+++ b/src/views/activity/ActivityCreatePage.vue
@@ -1,7 +1,8 @@
 <script setup>
 import { computed, onMounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
-import { createActivity, fetchActivityClients, fetchPOsByClient } from '@/api/activity'
+import { createActivity, fetchPOsByClient } from '@/api/activity'
+import { fetchClients } from '@/api/master'
 import { useAuthStore } from '@/stores/auth'
 import { useToast } from '@/composables/useToast'
 import BaseButton from '@/components/common/BaseButton.vue'
@@ -43,8 +44,8 @@ const clientOptions = ref([])
 
 onMounted(async () => {
   try {
-    const data = await fetchActivityClients()
-    clientOptions.value = data.map((c) => ({ label: `${c.name} (${c.nameKr})`, value: c.id }))
+    const data = await fetchClients()
+    clientOptions.value = data.map((c) => ({ label: `${c.clientName} (${c.clientNameKr})`, value: c.clientId }))
   } catch (e) {
     console.error('거래처 목록 로드 실패', e)
     error('거래처 목록을 불러오지 못했습니다. 페이지를 새로고침해주세요.')
@@ -208,7 +209,7 @@ async function openPoSearch() {
 function selectPO(po) {
   formPoDisplay.value = po.id
   formPoId.value = po.id
-  formAuthor.value = authStore.currentUser?.name ?? ''
+  formAuthor.value = authStore.currentUser?.userName ?? ''
   isPoSearchOpen.value = false
 }
 

--- a/src/views/activity/ActivityListPage.vue
+++ b/src/views/activity/ActivityListPage.vue
@@ -1,7 +1,8 @@
 <script setup>
 import { computed, onMounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
-import { fetchActivities, fetchActivityClients, deleteActivity, updateActivity } from '@/api/activity'
+import { fetchActivities, deleteActivity, updateActivity } from '@/api/activity'
+import { fetchClients } from '@/api/master'
 import { useToast } from '@/composables/useToast'
 import ActivityDetailModal from '@/components/domain/activity/ActivityDetailModal.vue'
 import ActivityEditModal from '@/components/domain/activity/ActivityEditModal.vue'
@@ -44,7 +45,7 @@ const authorOptions = computed(() => {
 })
 
 const clientOptions = computed(() => {
-  return clients.value.map((c) => ({ label: `${c.name} (${c.nameKr})`, value: c.id }))
+  return clients.value.map((c) => ({ label: `${c.clientName} (${c.clientNameKr})`, value: c.clientId }))
 })
 
 // 실제 적용된 필터 (검색 버튼 클릭 시에만 반영)
@@ -79,7 +80,7 @@ onMounted(async () => {
   try {
     const [activityData, clientData] = await Promise.all([
       fetchActivities(),
-      fetchActivityClients(),
+      fetchClients(),
     ])
     activities.value = activityData
     clients.value = clientData
@@ -91,7 +92,7 @@ onMounted(async () => {
 
 // ── 필터 computed (applied 기준) ───────────────────────────
 const clientMap = computed(() =>
-  Object.fromEntries(clients.value.map((c) => [c.id, c])),
+  Object.fromEntries(clients.value.map((c) => [c.clientId, c])),
 )
 
 const filteredActivities = computed(() => {
@@ -99,7 +100,7 @@ const filteredActivities = computed(() => {
     const client = clientMap.value[a.clientId]
     const matchType   = !applied.value.type   || a.type === applied.value.type
     const matchTitle  = !applied.value.title  || a.title.includes(applied.value.title)
-      || client?.name.includes(applied.value.title) || client?.nameKr.includes(applied.value.title)
+      || client?.clientName.includes(applied.value.title) || client?.clientNameKr.includes(applied.value.title)
     const matchAuthor = !applied.value.author || a.author === applied.value.author
     const matchPo     = !applied.value.po     || (a.poId ?? '').includes(applied.value.po)
     const dateFrom = applied.value.dateFrom.replaceAll('-', '/')
@@ -130,7 +131,7 @@ function openDetail(activity) {
   const client = clientMap.value[activity.clientId]
   selectedActivity.value = {
     ...activity,
-    client: client ? `${client.name} (${client.nameKr})` : '-',
+    client: client ? `${client.clientName} (${client.clientNameKr})` : '-',
   }
   isDetailOpen.value = true
 }

--- a/src/views/contacts/ContactListPage.vue
+++ b/src/views/contacts/ContactListPage.vue
@@ -2,7 +2,7 @@
 import { computed, onMounted, ref, watch } from 'vue'
 import { useToast } from '@/composables/useToast'
 import { fetchBuyers, createBuyer, updateBuyer, deleteBuyer } from '@/api/contacts'
-import { fetchActivityClients } from '@/api/activity'
+import { fetchClients } from '@/api/master'
 import { useAuthStore } from '@/stores/auth'
 import BaseButton from '@/components/common/BaseButton.vue'
 import FormField from '@/components/common/FormField.vue'
@@ -19,7 +19,7 @@ const { warning, error } = useToast()
 
 const authStore = useAuthStore()
 const currentUser = computed(() => authStore.currentUser)
-const isAdmin = computed(() => currentUser.value?.role === 'admin')
+const isAdmin = computed(() => currentUser.value?.userRole === 'admin')
 
 // ── 데이터 ─────────────────────────────────────────────────
 const clients = ref([])
@@ -28,13 +28,13 @@ const contacts = ref([])
 // 관리자는 전체, 일반 사용자는 본인 등록 연락처만
 const myContacts = computed(() => {
   if (isAdmin.value) return contacts.value
-  return contacts.value.filter((c) => c.createdBy === currentUser.value?.id)
+  return contacts.value.filter((c) => c.createdBy === currentUser.value?.userId)
 })
 
 onMounted(async () => {
   try {
     const [clientData, buyerData] = await Promise.all([
-      fetchActivityClients(),
+      fetchClients(),
       fetchBuyers(),
     ])
     clients.value = clientData
@@ -50,7 +50,7 @@ const searchInput = ref('')
 const searchKeyword = ref('')
 
 const clientSearchOptions = computed(() =>
-  clients.value.map((c) => ({ label: `${c.name} (${c.nameKr})`, value: c.id })),
+  clients.value.map((c) => ({ label: `${c.clientName} (${c.clientNameKr})`, value: c.clientId })),
 )
 
 function applySearch() {
@@ -64,9 +64,9 @@ function getContactsByClient(clientId) {
 const filteredClients = computed(() => {
   let result = clients.value
   if (searchKeyword.value) {
-    result = result.filter((c) => String(c.id) === String(searchKeyword.value))
+    result = result.filter((c) => String(c.clientId) === String(searchKeyword.value))
   }
-  return result.filter((c) => getContactsByClient(c.id).length > 0)
+  return result.filter((c) => getContactsByClient(c.clientId).length > 0)
 })
 
 // ── 상세 모달 ──────────────────────────────────────────────
@@ -84,8 +84,8 @@ function closeDetail() {
 }
 
 function getClientName(clientId) {
-  const client = clients.value.find((c) => c.id === clientId)
-  return client ? `${client.name} (${client.nameKr})` : '-'
+  const client = clients.value.find((c) => c.clientId === clientId)
+  return client ? `${client.clientName} (${client.clientNameKr})` : '-'
 }
 
 // ── 등록/수정 모달 ─────────────────────────────────────────
@@ -109,7 +109,7 @@ const positionOptions = [
 ]
 
 const clientOptions = computed(() =>
-  clients.value.map((c) => ({ label: `${c.name} (${c.nameKr})`, value: c.id })),
+  clients.value.map((c) => ({ label: `${c.clientName} (${c.clientNameKr})`, value: c.clientId })),
 )
 
 function openCreate() {
@@ -158,7 +158,7 @@ async function handleFormSubmit() {
     buyerEmail:   formEmail.value,
     buyerTel:     formTel.value,
     signImageUrl: null,
-    createdBy:    currentUser.value?.id,
+    createdBy:    currentUser.value?.userId,
   }
   try {
     if (isEditMode.value) {
@@ -241,19 +241,19 @@ async function handleDelete() {
     <!-- 거래처별 카드 그룹 -->
     <div
       v-for="client in filteredClients"
-      :key="client.id"
+      :key="client.clientId"
       class="space-y-3"
     >
       <!-- 거래처 그룹 헤더 -->
       <div>
-        <h3 class="text-sm font-bold text-slate-800">{{ client.name }}</h3>
-        <p class="text-xs text-slate-400">{{ client.nameKr }} · {{ client.country }}</p>
+        <h3 class="text-sm font-bold text-slate-800">{{ client.clientName }}</h3>
+        <p class="text-xs text-slate-400">{{ client.clientNameKr }} · {{ client.countryName }}</p>
       </div>
 
       <!-- 컨택 카드 그리드 -->
       <div class="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3">
         <div
-          v-for="contact in getContactsByClient(client.id)"
+          v-for="contact in getContactsByClient(client.clientId)"
           :key="contact.id"
           class="flex cursor-pointer items-center justify-between rounded-xl border border-slate-200 bg-white p-4 shadow-sm transition hover:border-brand-200 hover:shadow-md"
           @click="openDetail(contact)"


### PR DESCRIPTION
## 📋 작업 내용

Document·Activity 화면에서 거래처/품목/사용자 등 타 서비스 데이터를 조회할 때, 원본 서비스(Master/Auth) API를 직접 호출하도록 통일하고 필드명을 백엔드 응답과 맞춥니다.

**주요 변경 (11개 파일):**

Composables (3):
- `useSearchModalLookups` — db.json 폴백 제거, 필드명 백엔드 대응
- `useMasterLookup` — 참조 데이터 필드명 통일 (countryId, currencyCode 등)
- `useDocumentItemCatalog` — 품목 필드명 통일

Utils (3):
- `documentClientRows` — db.json 제거 + Master API 필드명
- `documentActivityEmail` — db.json 제거 + async 캐시 전환
- `ciplMaster` — db.json 제거 + async 캐시 전환

Document (2):
- `PIFormModal` — 사용자/거래처/품목/인코텀즈 필드명 + status 영문 코드
- `POFormModal` — 사용자 필드명 + status 영문 코드

Activity/Contact (3):
- `ActivityListPage`, `ActivityCreatePage`, `ContactListPage` — `fetchActivityClients` → Master `fetchClients` 직접 호출로 통일

## 🔗 관련 이슈

- closes #230

## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

- db.json 의존성을 대폭 제거했습니다. documentActivityEmail/ciplMaster는 모듈 로드 시 API를 lazy-load하는 async 캐시 패턴으로 전환
- Activity 화면의 거래처 조회가 Activity API(`fetchActivityClients`) 대신 Master API(`fetchClients`)를 직접 호출합니다
- 검색 모달의 display 필드키(code, name 등)는 searchModalColumns.js 컬럼 정의와 맞추기 위해 유지, 내부 데이터 매핑만 변경