### PR TITLE
fix: 사이드바 메뉴 + 대시보드 API 에러 격리

### DIFF
--- a/src/api/navigation.js
+++ b/src/api/navigation.js
@@ -1,3 +1,25 @@
 export async function fetchNavigationItems() {
-  return []
+  return [
+    { path: '/', label: '대시보드', icon: 'fa-chart-pie', section: 'basic', sectionLabel: '기본' },
+
+    { path: '/master/clients', label: '거래처 관리', icon: 'fa-building', section: 'sales', sectionLabel: '기초정보' },
+    { path: '/master/items', label: '품목 관리', icon: 'fa-box', section: 'sales', sectionLabel: '기초정보' },
+
+    { path: '/pi', label: 'PI (견적송장)', icon: 'fa-file-invoice', section: 'orders', sectionLabel: '주문' },
+    { path: '/po', label: 'PO (발주서)', icon: 'fa-file-contract', section: 'orders', sectionLabel: '주문' },
+    { path: '/ci', label: 'CI (상업송장)', icon: 'fa-file-invoice-dollar', section: 'orders', sectionLabel: '주문' },
+    { path: '/pl', label: 'PL (포장명세)', icon: 'fa-boxes-stacked', section: 'orders', sectionLabel: '주문' },
+
+    { path: '/production', label: '생산지시서', icon: 'fa-industry', section: 'status', sectionLabel: '생산·출하' },
+    { path: '/shipment-orders', label: '출하지시서', icon: 'fa-truck-loading', section: 'status', sectionLabel: '생산·출하' },
+    { path: '/collections', label: '매출·수금', icon: 'fa-coins', section: 'status', sectionLabel: '생산·출하' },
+    { path: '/shipments', label: '출하현황', icon: 'fa-shipping-fast', section: 'status', sectionLabel: '생산·출하' },
+
+    { path: '/activities', label: '활동기록', icon: 'fa-clipboard-list', section: 'activity', sectionLabel: '활동' },
+    { path: '/contacts', label: '컨택 리스트', icon: 'fa-address-book', section: 'activity', sectionLabel: '활동' },
+    { path: '/emails', label: '메일 이력', icon: 'fa-envelope', section: 'activity', sectionLabel: '활동' },
+    { path: '/package', label: '활동 패키지', icon: 'fa-folder-open', section: 'activity', sectionLabel: '활동' },
+
+    { path: '/users', label: '사용자 관리', icon: 'fa-users-cog', section: 'admin', sectionLabel: '관리' },
+  ]
 }

--- a/src/views/DashboardPage.vue
+++ b/src/views/DashboardPage.vue
@@ -37,18 +37,14 @@ const selectedPackage = ref(null)
 const deleteConfirmOpen = ref(false)
 
 onMounted(async () => {
-  try {
-    const [clients, activities, packages] = await Promise.all([
-      fetchClients(),
-      fetchActivities(),
-      fetchPackages(),
-    ])
-    clientsData.value = clients
-    activitiesData.value = activities
-    packagesData.value = packages
-  } catch {
-    // silent fail - dashboard still works with store data
-  }
+  const [clientsResult, activitiesResult, packagesResult] = await Promise.allSettled([
+    fetchClients(),
+    fetchActivities(),
+    fetchPackages(),
+  ])
+  if (clientsResult.status === 'fulfilled') clientsData.value = clientsResult.value ?? []
+  if (activitiesResult.status === 'fulfilled') activitiesData.value = activitiesResult.value ?? []
+  if (packagesResult.status === 'fulfilled') packagesData.value = packagesResult.value ?? []
 })
 
 const currentUser = computed(() => authStore.currentUser ?? null)


### PR DESCRIPTION
## Summary
- 사이드바 `fetchNavigationItems()` 빈 배열 스텁 → 라우터 기반 메뉴 항목 반환
- 대시보드 `Promise.all` → `Promise.allSettled`로 변경하여 개별 API 실패 시에도 나머지 데이터 정상 표시

## Test plan
- [ ] 로그인 후 사이드바에 메뉴 항목 표시 확인
- [ ] 대시보드에서 활동기록 패키지 섹션 표시 확인
- [ ] 백엔드 일부 서비스 다운 시에도 대시보드 나머지 섹션 정상 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)