### PR TITLE
fix: HTTP 환경에서 RT 쿠키 Secure 플래그 조건부 적용

### DIFF
--- a/src/lib/token.js
+++ b/src/lib/token.js
@@ -29,7 +29,8 @@ export function isTokenExpired(token) {
 /** RT를 쿠키에 저장 */
 export function setRefreshTokenCookie(token) {
   const expires = new Date(Date.now() + RT_EXPIRY_DAYS * 24 * 60 * 60 * 1000).toUTCString()
-  document.cookie = `${RT_COOKIE_NAME}=${token}; expires=${expires}; path=/; SameSite=Strict; Secure`
+  const secure = location.protocol === 'https:' ? '; Secure' : ''
+  document.cookie = `${RT_COOKIE_NAME}=${token}; expires=${expires}; path=/; SameSite=Lax${secure}`
 }
 
 /** RT를 쿠키에서 읽기 */
@@ -40,5 +41,5 @@ export function getRefreshTokenCookie() {
 
 /** RT 쿠키 삭제 */
 export function removeRefreshTokenCookie() {
-  document.cookie = `${RT_COOKIE_NAME}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; SameSite=Strict; Secure`
+  document.cookie = `${RT_COOKIE_NAME}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; SameSite=Lax`
 }


### PR DESCRIPTION
## 📋 작업 내용

1. RT 쿠키 `Secure` 플래그를 HTTPS 환경에서만 적용 → HTTP에서 새로고침 시 로그인 유지
2. auth store에서 user 객체 정규화 (`userId`↔`id`, `userRole`↔`role` 양쪽 필드 보장)

## 🔗 관련 이슈

- closes #238

## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

- **쿠키 수정**: `location.protocol === 'https:'` 조건으로 Secure 플래그 분기, SameSite=Strict→Lax
- **user 정규화**: 백엔드는 `userId`/`userRole` 반환, 프론트 일부 페이지는 `id`/`role` 사용 → `normalizeUser()`로 양쪽 지원
- 대시보드 패키지 미표시 원인: `currentUser.id`가 undefined여서 필터링 전부 실패