### PR TITLE
refactor: AppHeader 알림 아이콘 화면에서 숨김 (#246)

### DIFF
--- a/src/components/layout/AppHeader.vue
+++ b/src/components/layout/AppHeader.vue
@@ -48,8 +48,8 @@ const pageTooltip = computed(() => {
   return route.meta.description || ''
 })
 
-// TODO(#244): 헤더 알림 기능은 실제 알림 도메인/API/SSE가 준비될 때까지 임시 비활성화됨.
-// 아이콘 버튼 자체는 레이아웃 유지 및 추후 재활성화를 위해 템플릿에 남겨둠.
+// TODO(#244, #246): 헤더 알림 기능은 실제 알림 도메인/API/SSE가 준비될 때까지 화면에서 숨김.
+// 재활성화 시 템플릿의 v-if="false" 블록을 해제하면 됨.
 const isPasswordModalOpen = ref(false)
 
 function openPasswordModal() {
@@ -163,8 +163,12 @@ onBeforeUnmount(() => {
         <i class="fas fa-search absolute left-2.5 top-2 text-[10px] text-slate-300" aria-hidden="true"></i>
       </div>
 
-      <!-- TODO(#244): 알림 기능 임시 비활성화. 실제 알림 도메인/API/SSE 구현 후 재활성화 예정. -->
-      <div class="relative">
+      <!--
+        TODO(#244, #246): 알림 기능 임시 숨김.
+        실제 알림 도메인/API/SSE 구현 후 아래 블록의 v-if를 제거해 재활성화한다.
+        마크업은 재활성화 편의를 위해 보존.
+      -->
+      <div v-if="false" class="relative">
         <button
           type="button"
           class="relative flex h-8 w-8 items-center justify-center rounded-lg text-slate-300"


### PR DESCRIPTION
## 📋 작업 내용

직전 PR #245 에서 종 아이콘을 `disabled` 상태로 남겨두었으나, 비활성화된 아이콘이 헤더에 그대로 노출되어 사용자에게 혼란을 주는 문제가 있어 **화면에서 아예 숨기는 방향**으로 변경합니다.

### 변경 요약
- 알림 버튼 래퍼 `<div>`에 `v-if="false"` 추가 → 렌더링되지 않음
- 마크업/클래스/TODO 주석은 그대로 보존 → 추후 실제 알림 기능 부활 시 `v-if="false"` 한 줄만 제거하면 복구 가능
- script 상단 `TODO(#244, #246)` 주석 갱신해 재활성화 지점 안내

### 왜 `v-if="false"`인가
- 마크업 완전 삭제 시 부활 시점에 위치/스타일을 다시 맞춰야 함
- `v-if="false"`는 DOM에 렌더되지 않아 사용자에게는 완전히 보이지 않지만, 코드상으로는 과거 구조 그대로 남아 복구 비용이 최소
- 향후 feature flag(`import.meta.env.VITE_ENABLE_NOTIFICATIONS` 등)로 교체하기도 쉬움

## 🔗 관련 이슈

- closes #246

## 📸 스크린샷 (선택)

헤더 우측에서 종 아이콘이 사라지고 검색창 → 프로필 → 비밀번호 → 로그아웃 순서로 자연스럽게 정렬됩니다.

## ✅ 체크리스트

- [x] 정상 동작 확인 (빌드 성공, 헤더 레이아웃 정상)
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

- 마크업을 완전히 삭제하는 것보다 `v-if="false"` 로 남겨두는 편이 부활 비용이 낮다고 판단했습니다. 아예 삭제가 낫다고 보시면 의견 주세요.
- 알림 아이콘 제거로 헤더 우측 간격이 어색해 보이는지 확인 부탁드립니다.