### PR TITLE
[Refactor] X-Screen-Only 헤더 제거 (사용처 0건)

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -20,8 +20,6 @@ export function setupApiInterceptors(authStore) {
  * 요청 인터셉터: AT를 Authorization 헤더에 첨부
  */
 api.interceptors.request.use((config) => {
-  config.headers['X-Screen-Only'] = 'true'
-
   if (_authStore?.accessToken) {
     config.headers.Authorization = `Bearer ${_authStore.accessToken}`
   }


### PR DESCRIPTION
## Summary
Phase 7 cleanup. `src/lib/api.js`의 axios request interceptor에서 `X-Screen-Only: true` 헤더 세팅 코드 제거.

## 배경
Stage 0 audit에서 이 헤더가 정체 불명으로 발견됨. 6개 레포(team2-backend-auth/master/documents/activity, team2-gateway, team2-manifest) 전수 grep 결과 **소비처 0건** 확인. dead weight로 판정.

## 변경
- `src/lib/api.js:22` 에서 `config.headers['X-Screen-Only'] = 'true'` 라인 제거
- 2 lines deleted

## Test plan
- [x] `vite build` 로컬 통과 확인
- [ ] 리뷰 후 머지