### PR TITLE
fix: k8s 전환 후 로그인 페이지 미표시 — 인증 전 API 호출 401 방지

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -7,13 +7,19 @@ export const api = axios.create({
 })
 
 /**
- * auth store 주입 (순환 참조 방지)
- * main.js 또는 router guard에서 setupApiInterceptors(authStore) 호출
+ * auth store + router 주입 (순환 참조 방지)
+ * main.js에서 setupApiInterceptors(authStore) + setRouter(router) 호출
  */
 let _authStore = null
+let _router = null
+let _isRedirecting = false // 401 중복 redirect 방지 플래그
 
 export function setupApiInterceptors(authStore) {
   _authStore = authStore
+}
+
+export function setRouter(router) {
+  _router = router
 }
 
 /**
@@ -28,10 +34,28 @@ api.interceptors.request.use((config) => {
 })
 
 /**
+ * 안전한 로그인 페이지 이동 — Vue Router 우선, fallback window.location
+ * 중복 redirect 방지 (여러 401이 동시에 발생해도 1회만)
+ */
+function redirectToLogin() {
+  if (_isRedirecting) return
+  _isRedirecting = true
+
+  const redirect = _router?.currentRoute?.value?.fullPath
+  const query = redirect && redirect !== '/login' ? { redirect } : {}
+
+  if (_router) {
+    _router.push({ name: 'login', query }).finally(() => {
+      _isRedirecting = false
+    })
+  } else {
+    window.location.href = '/login'
+    // fallback 경로에서는 페이지가 reload되므로 플래그 리셋 불필요
+  }
+}
+
+/**
  * 응답 인터셉터: 401 시 RT로 AT 갱신 후 재시도
- *
- * TODO: 백엔드 연동 시 실제 401 응답에 대해 동작
- * 현재 json-server는 401을 주지 않으므로 방어 코드로만 존재
  */
 let isRefreshing = false
 let pendingRequests = []
@@ -62,14 +86,14 @@ api.interceptors.response.use(
           _authStore.logout()
           pendingRequests.forEach(({ reject }) => reject(error))
           pendingRequests = []
-          window.location.href = '/login'
+          redirectToLogin()
           return Promise.reject(error)
         }
       } catch (refreshError) {
         _authStore.logout()
         pendingRequests.forEach(({ reject }) => reject(refreshError))
         pendingRequests = []
-        window.location.href = '/login'
+        redirectToLogin()
         return Promise.reject(refreshError)
       } finally {
         isRefreshing = false

--- a/src/main.js
+++ b/src/main.js
@@ -3,7 +3,7 @@ import { createPinia } from 'pinia'
 import App from './App.vue'
 import router from './router'
 import { useAuthStore } from './stores/auth'
-import { setupApiInterceptors } from './lib/api'
+import { setupApiInterceptors, setRouter } from './lib/api'
 import { canAccessRouteByRole, getRoleHomePath } from './utils/roleAccess'
 import './styles/tailwind.css'
 
@@ -15,6 +15,7 @@ app.use(pinia)
 // Pinia 등록 후 auth store 초기화 & API 인터셉터 연결
 const authStore = useAuthStore()
 setupApiInterceptors(authStore)
+setRouter(router)
 
 // 라우터 가드: 비로그인 시 /login으로 리다이렉트
 const PUBLIC_ROUTES = ['login', 'forgot-password']

--- a/src/stores/ciDocuments.js
+++ b/src/stores/ciDocuments.js
@@ -1,3 +1,4 @@
+import { useAuthStore } from './auth'
 import { ref } from 'vue'
 import { fetchCommercialInvoices } from '@/api/documents'
 
@@ -74,7 +75,7 @@ export async function loadCiDocuments() {
 }
 
 export function useCiDocuments() {
-  if (!loading) {
+  if (!loading && useAuthStore().isLoggedIn) {
     loading = loadCiDocuments()
   }
   return ciDocuments

--- a/src/stores/piDocuments.js
+++ b/src/stores/piDocuments.js
@@ -1,3 +1,4 @@
+import { useAuthStore } from './auth'
 import { ref } from 'vue'
 import { fetchProformaInvoices } from '@/api/documents'
 
@@ -65,7 +66,7 @@ export async function loadPiDocuments() {
 }
 
 export function usePiDocuments() {
-  if (!loading) {
+  if (!loading && useAuthStore().isLoggedIn) {
     loading = loadPiDocuments()
   }
   return piDocuments

--- a/src/stores/plDocuments.js
+++ b/src/stores/plDocuments.js
@@ -1,3 +1,4 @@
+import { useAuthStore } from './auth'
 import { ref } from 'vue'
 import { fetchPackingLists } from '@/api/documents'
 
@@ -74,7 +75,7 @@ export async function loadPlDocuments() {
 }
 
 export function usePlDocuments() {
-  if (!loading) {
+  if (!loading && useAuthStore().isLoggedIn) {
     loading = loadPlDocuments()
   }
   return plDocuments

--- a/src/stores/poDocuments.js
+++ b/src/stores/poDocuments.js
@@ -1,3 +1,4 @@
+import { useAuthStore } from './auth'
 import { ref } from 'vue'
 import { fetchPurchaseOrders } from '@/api/documents'
 
@@ -78,7 +79,7 @@ export async function loadPoDocuments() {
 }
 
 export function usePoDocuments() {
-  if (!loading) {
+  if (!loading && useAuthStore().isLoggedIn) {
     loading = loadPoDocuments()
   }
   return poDocuments

--- a/src/stores/productionOrderDocuments.js
+++ b/src/stores/productionOrderDocuments.js
@@ -1,3 +1,4 @@
+import { useAuthStore } from './auth'
 import { ref } from 'vue'
 import { fetchProductionOrders } from '@/api/documents'
 
@@ -61,7 +62,7 @@ export async function loadProductionOrderDocuments() {
 }
 
 export function useProductionOrderDocuments() {
-  if (!loading) {
+  if (!loading && useAuthStore().isLoggedIn) {
     loading = loadProductionOrderDocuments()
   }
   return productionOrderDocuments

--- a/src/stores/salesCollectionDocuments.js
+++ b/src/stores/salesCollectionDocuments.js
@@ -1,3 +1,4 @@
+import { useAuthStore } from './auth'
 import { ref } from 'vue'
 import { fetchCollections } from '@/api/documents'
 
@@ -26,7 +27,7 @@ async function loadSalesCollectionDocuments() {
 }
 
 export function useSalesCollectionDocuments() {
-  if (!loading) {
+  if (!loading && useAuthStore().isLoggedIn) {
     loading = loadSalesCollectionDocuments()
   }
   return salesCollectionDocuments

--- a/src/stores/shipmentOrderDocuments.js
+++ b/src/stores/shipmentOrderDocuments.js
@@ -1,3 +1,4 @@
+import { useAuthStore } from './auth'
 import { ref } from 'vue'
 import { fetchShipmentOrders } from '@/api/documents'
 
@@ -59,7 +60,7 @@ export async function loadShipmentOrderDocuments() {
 }
 
 export function useShipmentOrderDocuments() {
-  if (!loading) {
+  if (!loading && useAuthStore().isLoggedIn) {
     loading = loadShipmentOrderDocuments()
   }
   return shipmentOrderDocuments

--- a/src/stores/shipmentStatusDocuments.js
+++ b/src/stores/shipmentStatusDocuments.js
@@ -1,3 +1,4 @@
+import { useAuthStore } from './auth'
 import { ref } from 'vue'
 import { fetchShipments } from '@/api/documents'
 
@@ -36,7 +37,7 @@ export async function loadShipmentStatusDocuments() {
 }
 
 export function useShipmentStatusDocuments() {
-  if (!loading) {
+  if (!loading && useAuthStore().isLoggedIn) {
     loading = loadShipmentStatusDocuments()
   }
   return shipmentStatusDocuments

--- a/src/views/DashboardPage.vue
+++ b/src/views/DashboardPage.vue
@@ -37,6 +37,9 @@ const selectedPackage = ref(null)
 const deleteConfirmOpen = ref(false)
 
 onMounted(async () => {
+  // 인증되지 않은 상태에서는 API 호출하지 않음 (k8s 전환 후 401 크래시 방지)
+  if (!authStore.isLoggedIn) return
+
   const [clientsResult, activitiesResult, packagesResult] = await Promise.allSettled([
     fetchClients(),
     fetchActivities(),


### PR DESCRIPTION
## 📋 작업 내용

k8s 전환 후 `http://playdata4.iptime.org:8001/` 접속 시 로그인 폼이 표시되지 않고 빈 화면 + 401 다수 출력되는 문제 수정.

### 변경 사항

1. **`src/stores/*.js` (8개)**: `useXxxDocuments()` 에 `authStore.isLoggedIn` 가드 추가 → 인증 전 API 호출 차단
2. **`src/lib/api.js`**: 401 인터셉터에서 `window.location.href` → `Vue Router push` 전환 (SPA 상태 보존) + `_isRedirecting` 플래그로 중복 redirect 방지 + `setRouter()` 주입 패턴
3. **`src/main.js`**: `setRouter(router)` 호출 추가
4. **`src/views/DashboardPage.vue`**: `onMounted`에서 `authStore.isLoggedIn` 체크 후 fetch

### 원인
docker-compose 환경에서는 Gateway 타이밍 차이로 동작했으나, k8s 환경에서는 모든 `/api/*`가 즉시 JWT 검증 → 로그인 전 호출 시 401 → SPA 크래시.

## 🔗 관련 이슈
- closes #253

## ✅ 체크리스트
- [x] 정상 동작 확인 (`npm run build` 성공)
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게
인프라 측 CORS 설정은 서버에서 이미 완료됨 (nginx-ingress annotation). 본 PR은 프론트 코드만.
머지 후 서버에서 `kubectl -n team2 rollout restart deploy/frontend` 로 반영.