### PR TITLE
hotfix: /auth/refresh 401 데드락 해소 — 로그인 페이지 렌더 불가 수정

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -65,6 +65,13 @@ api.interceptors.response.use(
   async (error) => {
     const originalRequest = error.config
 
+    // /auth/refresh 자체의 401 은 인터셉터에서 제외 — 데드락 방지.
+    // 이 guard 가 없으면: refresh 401 → interceptor refresh → 또 401 → 큐 대기 → 영원히 안 풀림.
+    // restoreSession() 의 try-catch 가 직접 처리한다.
+    if (originalRequest?.url?.includes('/auth/refresh')) {
+      return Promise.reject(error)
+    }
+
     if (error.response?.status === 401 && !originalRequest._retry && _authStore) {
       if (isRefreshing) {
         return new Promise((resolve, reject) => {


### PR DESCRIPTION
## 📋 작업 내용

k8s 환경에서 최초 접속 시 로그인 폼이 렌더링되지 않는 치명적 버그 수정.

### 원인 (데드락)

```
router guard → restoreSession() → POST /auth/refresh → 401
  → axios interceptor: isRefreshing=true → refreshAccessToken()
    → restoreSession() → POST /auth/refresh → 401
      → interceptor: isRefreshing=true → pendingRequests 큐 대기
      → 영원히 resolve 안 됨 (데드락)
→ 라우터 가드 미완료 → 로그인 페이지 렌더 안 됨 → 빈 화면
```

### 수정

`src/lib/api.js` — `/auth/refresh` URL의 401 응답을 인터셉터에서 즉시 통과:

```javascript
if (originalRequest?.url?.includes('/auth/refresh')) {
  return Promise.reject(error)
}
```

`restoreSession()`의 `try-catch`가 false 반환 → router guard가 `/login`으로 redirect → 로그인 폼 정상 렌더.

## 🔗 관련 이슈
- closes #255

## ✅ 체크리스트
- [x] 정상 동작 확인 (`npm run build` EXIT=0)
- [x] 불필요한 코드/주석 제거
- [x] 충돌 없음

## 💬 리뷰어에게
7줄 추가. 머지 후 GHA 빌드 → Image Updater → ArgoCD 자동 배포 대기.