### PR TITLE
hotfix: 모듈 레벨 eager API 호출 제거 — 로그인 전 401 해소

### DIFF
--- a/src/utils/ciplMaster.js
+++ b/src/utils/ciplMaster.js
@@ -35,20 +35,28 @@ export async function loadCiplMasterCache() {
   return cachePromise
 }
 
-// Eagerly start cache loading when this module is first imported.
-loadCiplMasterCache()
+// 캐시 로딩은 실제 resolve 함수 호출 시점까지 지연 (lazy).
+// 로그인 전 모듈 import 만으로 401 API 호출이 발생하던 문제 수정.
+function ensureCacheStarted() {
+  if (!cacheLoaded && !cachePromise) {
+    loadCiplMasterCache()
+  }
+}
 
 function resolveCountryLabel(countryId) {
+  ensureCacheStarted()
   const country = countriesById.get(String(countryId))
   return country?.countryNameKr ?? country?.countryName ?? ''
 }
 
 export function resolveMasterCurrency(code, fallback = 'USD') {
+  ensureCacheStarted()
   const currency = currenciesByCode.get(String(code ?? '').trim().toUpperCase())
   return currency?.currencyCode ?? fallback
 }
 
 export function resolvePaymentTermLabel(paymentTermsId, fallback = 'T/T REMITTANCE') {
+  ensureCacheStarted()
   const term = paymentTermsById.get(String(paymentTermsId))
 
   if (!term) {
@@ -63,6 +71,7 @@ export function resolvePaymentTermLabel(paymentTermsId, fallback = 'T/T REMITTAN
 }
 
 export function resolvePortLabel(portCode, fallback = '-') {
+  ensureCacheStarted()
   const port = portsByCode.get(String(portCode ?? '').trim().toUpperCase())
 
   if (!port) {
@@ -76,6 +85,7 @@ export function resolvePortLabel(portCode, fallback = '-') {
 }
 
 export function resolveIncotermsLabel(code, namedPlace = '') {
+  ensureCacheStarted()
   const meta = getIncotermMeta(code)
   return formatIncotermsLabel(code || meta.code, namedPlace || meta.defaultNamedPlace)
 }

--- a/src/utils/documentActivityEmail.js
+++ b/src/utils/documentActivityEmail.js
@@ -38,8 +38,8 @@ export async function loadActivityEmailCache() {
   return cachePromise
 }
 
-// Eagerly start cache loading when this module is first imported.
-loadActivityEmailCache()
+// 캐시 로딩은 실제 사용 시점까지 지연 (lazy).
+// 로그인 전 모듈 import 만으로 401 API 호출이 발생하던 문제 수정.
 
 function parseNumericValue(value) {
   const numeric = Number.parseFloat(String(value ?? '').replace(/[^0-9.]/g, ''))


### PR DESCRIPTION
## 📋 작업 내용

`ciplMaster.js`와 `documentActivityEmail.js`가 모듈 import 시점에 즉시 마스터 데이터 API를 호출하여 로그인 전 401 에러 발생하는 문제 수정.

### 원인

```javascript
// ciplMaster.js — 모듈 최상단
loadCiplMasterCache()  // → fetchCountries/Currencies/PaymentTerms/Ports

// documentActivityEmail.js — 모듈 최상단  
loadActivityEmailCache()  // → fetchClients/Currencies/Ports/Items
```

Vite 번들에 POPage가 포함 → 이 유틸 import → 앱 로드 시 모듈 평가 → 로그인 전 API 호출 → 401

### 수정

- `ciplMaster.js`: eager 호출 제거 + `ensureCacheStarted()` lazy 패턴 (각 resolve 함수 진입점에서 캐시 없으면 fire-and-forget 로딩)
- `documentActivityEmail.js`: eager 호출 제거 (사용처에서 명시 호출 or 캐시 없으면 fallback)

## 🔗 관련 이슈
- closes #257

## ✅ 체크리스트
- [x] `npm run build` EXIT=0
- [x] 불필요한 코드/주석 제거
- [x] 충돌 없음

## 💬 리뷰어에게
#255(데드락) + 본 PR(eager 호출)이 합쳐져야 로그인 페이지 401 문제 완전 해소.