### PR TITLE
fix: 사용자관리 접근 불가 (role 대소문자) + 활동패키지 TypeError

### DIFF
--- a/src/api/package.js
+++ b/src/api/package.js
@@ -21,5 +21,7 @@ export function deletePackage(id) {
 }
 
 export function fetchAllUsers() {
-  return api.get('/users').then((r) => r.data)
+  // /api/users 는 PagedResponse { content: [...], totalElements, ... } 반환.
+  // 전체 목록이 필요하므로 size=1000 으로 단일 페이지 조회.
+  return api.get('/users', { params: { size: 1000 } }).then((r) => r.data?.content ?? r.data ?? [])
 }

--- a/src/main.js
+++ b/src/main.js
@@ -29,7 +29,8 @@ router.beforeEach(async (to) => {
   }
 
   // 로그인 상태면 통과
-  const getRole = () => authStore.currentUser?.userRole ?? authStore.currentUser?.role
+  // JWT role claim 은 대문자("ADMIN"), meta.requiredRole 은 소문자("admin") → normalize 필수
+  const getRole = () => (authStore.currentUser?.userRole ?? authStore.currentUser?.role ?? '').toLowerCase()
   if (authStore.isLoggedIn) {
     if (to.meta.requiredRole && getRole() !== to.meta.requiredRole) {
       return getRoleHomePath(getRole())


### PR DESCRIPTION
## 📋 작업 내용

### 버그 1: 사용자관리 접근 불가
- JWT `role` claim = `"ADMIN"` (대문자)
- 라우터 meta `requiredRole` = `"admin"` (소문자)
- `getRole()` 에 `.toLowerCase()` 누락 → 항상 불일치 → 대시보드로 리다이렉트
- **수정**: `main.js` `getRole()` 에 `.toLowerCase()` 추가

### 버그 2: 활동 패키지 페이지 TypeError
- `/api/users` 응답이 `PagedResponse { content: [...] }` (배열 아님)
- `fetchAllUsers()` 가 `r.data` 를 배열로 가정 → `.filter()` TypeError
- **수정**: `r.data?.content ?? r.data ?? []` 로 안전 unwrap

## 🔗 관련 이슈
- closes #259

## ✅ 체크리스트
- [x] `npm run build` EXIT=0
- [x] 충돌 없음