### PR TITLE
fix: user.role undefined — 품목등록 버튼 미노출 + 역할 분기 14곳 전부 해소

### DIFF
--- a/src/stores/auth.js
+++ b/src/stores/auth.js
@@ -12,6 +12,16 @@ export const useAuthStore = defineStore('auth', () => {
   const currentUser = computed(() => user.value)
 
   /**
+   * 백엔드 UserInfo 정규화.
+   * 백엔드 필드명: userRole ('ADMIN'), 프론트 14곳에서 .role (소문자)로 접근.
+   * → role = userRole.toLowerCase() 를 항상 세팅하여 양쪽 다 동작하도록.
+   */
+  function normalizeUser(raw) {
+    if (!raw) return null
+    return { ...raw, role: (raw.userRole ?? raw.role ?? '').toLowerCase() }
+  }
+
+  /**
    * 로그인
    * 응답 body: { accessToken, user }
    * RefreshToken은 서버가 Set-Cookie(HttpOnly)로 직접 설정
@@ -20,9 +30,10 @@ export const useAuthStore = defineStore('auth', () => {
     const data = await apiLogin(email, password)
 
     accessToken.value = data.accessToken
-    user.value = data.user
+    // 백엔드: userRole='ADMIN'. 프론트 14곳에서 .role (소문자)로 접근 → 양쪽 다 세팅.
+    user.value = normalizeUser(data.user)
 
-    return data.user
+    return user.value
   }
 
   /**
@@ -50,7 +61,7 @@ export const useAuthStore = defineStore('auth', () => {
       const data = await apiRefresh()
 
       accessToken.value = data.accessToken
-      user.value = data.user
+      user.value = normalizeUser(data.user)
 
       return true
     } catch {


### PR DESCRIPTION
## 📋 작업 내용

백엔드 `TokenResponse.UserInfo.userRole = "ADMIN"` (대문자) ↔ 프론트 14곳에서 `currentUser?.role` (소문자) 접근 → `undefined` → 역할 기반 UI 전부 실패.

### 영향 범위 (14곳)

- `ItemListPage` / `ItemDetailPage` — 품목등록 버튼 안 보임 (관리자)
- `ClientListPage` / `ClientDetailPage` — 관리자/영업 판단 실패
- `DashboardPage` — 역할별 대시보드 분기 실패 (production/shipping/sales)
- `ProductionOrderDetailPage` — 생산 역할 분기 실패
- `roleAccess.js` — `canManageItems`, `canManageClients` 항상 false

### 수정

`src/stores/auth.js` — `normalizeUser()` 함수 추가:

```javascript
function normalizeUser(raw) {
  if (!raw) return null
  return { ...raw, role: (raw.userRole ?? raw.role ?? '').toLowerCase() }
}
```

`login()` / `restoreSession()` 에서 `user.value = normalizeUser(data.user)` 적용.

## 🔗 관련 이슈
- closes #261

## ✅ 체크리스트
- [x] `npm run build` EXIT=0
- [x] 충돌 없음