### PR TITLE
fix: fetchPackages() PagedResponse unwrap — 대시보드 TypeError 해소

### DIFF
--- a/src/api/package.js
+++ b/src/api/package.js
@@ -1,7 +1,8 @@
 import { api } from '@/lib/api'
 
 export function fetchPackages() {
-  return api.get('/activity-packages').then((r) => r.data)
+  // PagedResponse { content: [...] } 반환 → content unwrap
+  return api.get('/activity-packages').then((r) => r.data?.content ?? r.data ?? [])
 }
 
 export function fetchPackageById(id) {


### PR DESCRIPTION
## 📋 작업 내용
`/api/activity-packages` → `PagedResponse { content: [...] }` 반환인데 `fetchPackages()`가 `r.data`를 배열로 가정 → `w.value is not iterable` TypeError.

`r.data?.content ?? r.data ?? []` 로 안전 unwrap.

## 🔗 관련 이슈
- closes #263

## ✅ 체크리스트
- [x] `npm run build` EXIT=0
- [x] 충돌 없음