### PR TITLE
refactor: API 응답 unwrap HATEOAS PagedModel 통일

### DIFF
--- a/src/api/activity.js
+++ b/src/api/activity.js
@@ -1,4 +1,5 @@
 import { api } from '@/lib/api'
+import { unwrapCollection } from '@/utils/apiResponse'
 
 // ── 거래처 ─────────────────────────────────────────────────
 export async function fetchActivityClients() {
@@ -9,7 +10,7 @@ export async function fetchActivityClients() {
 // ── 활동기록 ───────────────────────────────────────────────
 export async function fetchActivities() {
   const { data } = await api.get('/activities')
-  return data
+  return unwrapCollection(data)
 }
 
 export async function createActivity(activity) {
@@ -29,10 +30,10 @@ export async function deleteActivity(id) {
 // ── PO 검색 ────────────────────────────────────────────────
 export async function fetchPOsByClient(clientId) {
   const { data } = await api.get('/purchase-orders', { params: { clientId: Number(clientId) } })
-  return data.content ?? data
+  return unwrapCollection(data)
 }
 
 export async function fetchAllActivityPOs() {
   const { data } = await api.get('/purchase-orders')
-  return data.content ?? data
+  return unwrapCollection(data)
 }

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -1,4 +1,5 @@
 import { api } from '@/lib/api'
+import { unwrapCollection } from '@/utils/apiResponse'
 
 export async function login(email, password) {
   const { data } = await api.post('/auth/login', { email, password })
@@ -17,7 +18,7 @@ export async function logoutApi(userId) {
 
 export async function fetchUsers() {
   const { data } = await api.get('/users')
-  return data
+  return unwrapCollection(data)
 }
 
 export async function createUser(user) {
@@ -32,12 +33,12 @@ export async function updateUser(id, user) {
 
 export async function fetchPositions() {
   const { data } = await api.get('/positions')
-  return data
+  return unwrapCollection(data)
 }
 
 export async function fetchDepartments() {
   const { data } = await api.get('/departments')
-  return data
+  return unwrapCollection(data)
 }
 
 export async function fetchCompany() {
@@ -76,6 +77,6 @@ export async function changeUserStatus(id, status) {
 }
 
 export async function fetchAllUsers() {
-  const { data } = await api.get('/users')
-  return data.content ?? data
+  const { data } = await api.get('/users', { params: { size: 1000 } })
+  return unwrapCollection(data)
 }

--- a/src/api/dashboard.js
+++ b/src/api/dashboard.js
@@ -1,9 +1,10 @@
 import { api } from '@/lib/api'
+import { unwrapCollection } from '@/utils/apiResponse'
 
 export async function fetchDashboardKpis() {
   try {
     const { data } = await api.get('/purchase-orders', { params: { page: 0, size: 1 } })
-    const totalOrders = data.totalElements ?? 0
+    const totalOrders = data?.page?.totalElements ?? data?.totalElements ?? 0
     return [
       { title: '총 발주건수', value: totalOrders, unit: '건' },
     ]
@@ -19,7 +20,7 @@ export async function fetchDashboardChartPoints() {
 export async function fetchDashboardTableRows() {
   try {
     const { data } = await api.get('/purchase-orders', { params: { page: 0, size: 5 } })
-    return data.content ?? []
+    return unwrapCollection(data)
   } catch {
     return []
   }

--- a/src/api/documents.js
+++ b/src/api/documents.js
@@ -1,8 +1,9 @@
 import { api } from '@/lib/api'
+import { unwrapCollection } from '@/utils/apiResponse'
 
 // Proforma Invoices
 export const fetchProformaInvoices = () =>
-  api.get('/proforma-invoices').then((r) => r.data.content ?? r.data)
+  api.get('/proforma-invoices').then((r) => unwrapCollection(r.data))
 export const fetchProformaInvoice = (piId) =>
   api.get(`/proforma-invoices/${piId}`).then((r) => r.data)
 export const createProformaInvoice = (payload) =>
@@ -12,7 +13,7 @@ export const requestPiRegistration = (payload) =>
 
 // Purchase Orders
 export const fetchPurchaseOrders = () =>
-  api.get('/purchase-orders').then((r) => r.data.content ?? r.data)
+  api.get('/purchase-orders').then((r) => unwrapCollection(r.data))
 export const fetchPurchaseOrder = (poId) =>
   api.get(`/purchase-orders/${poId}`).then((r) => r.data)
 export const createPurchaseOrder = (payload) =>
@@ -20,31 +21,31 @@ export const createPurchaseOrder = (payload) =>
 
 // Commercial Invoices
 export const fetchCommercialInvoices = () =>
-  api.get('/commercial-invoices').then((r) => r.data.content ?? r.data)
+  api.get('/commercial-invoices').then((r) => unwrapCollection(r.data))
 export const fetchCommercialInvoice = (ciId) =>
   api.get(`/commercial-invoices/${ciId}`).then((r) => r.data)
 
 // Packing Lists
 export const fetchPackingLists = () =>
-  api.get('/packing-lists').then((r) => r.data.content ?? r.data)
+  api.get('/packing-lists').then((r) => unwrapCollection(r.data))
 export const fetchPackingList = (plId) =>
   api.get(`/packing-lists/${plId}`).then((r) => r.data)
 
 // Production Orders
 export const fetchProductionOrders = () =>
-  api.get('/production-orders').then((r) => r.data.content ?? r.data)
+  api.get('/production-orders').then((r) => unwrapCollection(r.data))
 export const fetchProductionOrder = (id) =>
   api.get(`/production-orders/${id}`).then((r) => r.data)
 
 // Shipment Orders
 export const fetchShipmentOrders = () =>
-  api.get('/shipment-orders').then((r) => r.data.content ?? r.data)
+  api.get('/shipment-orders').then((r) => unwrapCollection(r.data))
 export const fetchShipmentOrder = (id) =>
   api.get(`/shipment-orders/${id}`).then((r) => r.data)
 
 // Shipments (출하현황)
 export const fetchShipments = () =>
-  api.get('/shipments').then((r) => r.data.content ?? r.data)
+  api.get('/shipments').then((r) => unwrapCollection(r.data))
 export const fetchShipment = (id) =>
   api.get(`/shipments/${id}`).then((r) => r.data)
 export const updateShipment = (id, payload) =>
@@ -52,7 +53,7 @@ export const updateShipment = (id, payload) =>
 
 // Collections (수금현황)
 export const fetchCollections = () =>
-  api.get('/collections').then((r) => r.data.content ?? r.data)
+  api.get('/collections').then((r) => unwrapCollection(r.data))
 export const fetchCollection = (id) =>
   api.get(`/collections/${id}`).then((r) => r.data)
 export const updateCollection = (id, payload) =>
@@ -60,4 +61,4 @@ export const updateCollection = (id, payload) =>
 
 // Approval Requests
 export const fetchApprovalRequests = () =>
-  api.get('/approval-requests').then((r) => r.data.content ?? r.data)
+  api.get('/approval-requests').then((r) => unwrapCollection(r.data))

--- a/src/api/emails.js
+++ b/src/api/emails.js
@@ -1,8 +1,9 @@
 import { api } from '@/lib/api'
+import { unwrapCollection } from '@/utils/apiResponse'
 
 export async function fetchActivityEmails() {
   const { data } = await api.get('/email-logs')
-  return data.content ?? data
+  return unwrapCollection(data)
 }
 
 /**

--- a/src/api/master.js
+++ b/src/api/master.js
@@ -1,19 +1,5 @@
 import { api } from '@/lib/api'
-
-/**
- * master 백엔드는 목록 응답을 HATEOAS CollectionModel 형식
- * (`{ _embedded: { <엔티티>List: [...] }, _links: {...} }`) 으로 반환한다.
- * 빈 리스트인 경우 `_embedded` 키 자체가 없고 `_links` 만 내려오므로 빈 배열 fallback 처리.
- *
- * 단, ItemQueryController 는 PagedResponse 를 유지하므로
- * `response.data.content` 경로를 fallback 으로 함께 지원한다.
- */
-const unwrapCollection = (data, key) => {
-  if (Array.isArray(data)) return data
-  if (data?._embedded?.[key]) return data._embedded[key]
-  if (Array.isArray(data?.content)) return data.content
-  return []
-}
+import { unwrapCollection } from '@/utils/apiResponse'
 
 // Clients
 export const fetchClients = () =>

--- a/src/api/package.js
+++ b/src/api/package.js
@@ -1,8 +1,8 @@
 import { api } from '@/lib/api'
+import { unwrapCollection } from '@/utils/apiResponse'
 
 export function fetchPackages() {
-  // PagedResponse { content: [...] } 반환 → content unwrap
-  return api.get('/activity-packages').then((r) => r.data?.content ?? r.data ?? [])
+  return api.get('/activity-packages').then((r) => unwrapCollection(r.data))
 }
 
 export function fetchPackageById(id) {
@@ -22,7 +22,5 @@ export function deletePackage(id) {
 }
 
 export function fetchAllUsers() {
-  // /api/users 는 PagedResponse { content: [...], totalElements, ... } 반환.
-  // 전체 목록이 필요하므로 size=1000 으로 단일 페이지 조회.
-  return api.get('/users', { params: { size: 1000 } }).then((r) => r.data?.content ?? r.data ?? [])
+  return api.get('/users', { params: { size: 1000 } }).then((r) => unwrapCollection(r.data))
 }

--- a/src/components/domain/auth/UserListTab.vue
+++ b/src/components/domain/auth/UserListTab.vue
@@ -50,8 +50,7 @@ async function loadData() {
       fetchPositions(),
       fetchDepartments(),
     ])
-    // fetchUsers()는 PagedResponse를 반환 → content 배열 추출
-    users.value = usersData.content ?? usersData
+    users.value = usersData
     positions.value = positionsData
     departments.value = departmentsData
     // 첫 번째 부서 펼치기

--- a/src/utils/apiResponse.js
+++ b/src/utils/apiResponse.js
@@ -1,0 +1,23 @@
+/**
+ * HATEOAS 응답(CollectionModel / PagedModel) 및 레거시 PagedResponse 에서
+ * 배열 데이터를 안전하게 추출하는 유틸리티.
+ *
+ * 지원 형식:
+ *  1. 이미 배열                     → 그대로 반환
+ *  2. { _embedded: { xxxList: [] } } → 첫 번째 배열 반환 (key 힌트가 있으면 우선 사용)
+ *  3. { content: [] }               → content 배열 반환 (레거시 PagedResponse)
+ *  4. 그 외                         → 빈 배열
+ */
+export function unwrapCollection(data, key) {
+  if (Array.isArray(data)) return data
+
+  if (data?._embedded) {
+    if (key && data._embedded[key]) return data._embedded[key]
+    const first = Object.values(data._embedded)[0]
+    if (Array.isArray(first)) return first
+  }
+
+  if (Array.isArray(data?.content)) return data.content
+
+  return []
+}


### PR DESCRIPTION
## 📋 작업 내용

백엔드 4개 서비스의 목록 응답이 HATEOAS `PagedModel<EntityModel<T>>` 형식으로 통일됨에 따라,
프론트엔드 API 레이어의 응답 unwrap 로직을 `unwrapCollection` 공용 유틸로 정리.

**변경 요약:**
- `src/utils/apiResponse.js` — `unwrapCollection()` 신규 생성 (`_embedded` 우선 → `content` fallback → plain array)
- `src/api/*.js` 7개 파일 — 각기 다른 unwrap 패턴을 `unwrapCollection()`으로 통일
- `UserListTab.vue` — API 레이어에서 이미 unwrap하므로 로컬 `.content ??` 제거

**해결되는 에러:**
- 대시보드: `TypeError: w.value is not iterable`
- 기록관리: `TypeError: w.value.filter is not a function`
- 활동기록 패키지: `TypeError: Cannot read properties of null`
- 사용자관리: `TypeError: x.value.map is not a function`

## 🔗 관련 이슈

- closes #265

## ✅ 체크리스트

- [x] 정상 동작 확인 (빌드 성공)
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

`unwrapCollection()`이 `_embedded`의 첫 번째 배열을 자동 추출하므로, HATEOAS 키 이름이 DTO에 따라 바뀌어도 프론트에서 깨지지 않습니다.
백엔드 3개 서비스는 이미 main에 반영 완료 (activity, auth, master).