### PR TITLE
feat: 결재 반려 시 반려 사유 입력 및 조회

### DIFF
--- a/src/components/common/ConfirmModal.vue
+++ b/src/components/common/ConfirmModal.vue
@@ -166,6 +166,8 @@ const emit = defineEmits(['confirm', 'cancel'])
           </div>
         </div>
       </div>
+      <slot />
+
       <div
         v-if="helperText"
         class="rounded-lg border border-slate-200 bg-white px-4 py-3 text-xs text-slate-500"

--- a/src/views/DashboardPage.vue
+++ b/src/views/DashboardPage.vue
@@ -30,6 +30,7 @@ const shipmentStatusDocuments = useShipmentStatusDocuments()
 const selectedRequest = ref(null)
 const decisionConfirmOpen = ref(false)
 const pendingDecision = ref('')
+const rejectReason = ref('')
 const clientsData = ref([])
 const activitiesData = ref([])
 const packagesData = ref([])
@@ -207,6 +208,9 @@ function buildFallbackReview(docType, row) {
       { label: '문서 상태', value: row.status || '-' },
       { label: '요청 상태', value: row.requestStatus || '-' },
       { label: '요청 시각', value: row.approvalRequestedAt || '-' },
+      ...(row.approvalRejectReason
+        ? [{ label: '반려 사유', value: row.approvalRejectReason, fullWidth: true }]
+        : []),
     ],
     requestSectionTitle: '팀장 결재 정보',
     documentRows: [
@@ -251,6 +255,7 @@ function createRequestItem(docType, row) {
     status: row.approvalStatus || '-',
     requestStatus: row.requestStatus || '-',
     requestedAt: row.approvalRequestedAt || '-',
+    rejectReason: row.approvalRejectReason || '',
     urgent: false,
     routeName: docType === 'PI' ? 'pi-detail' : 'po-detail',
     review: row.approvalReview || buildFallbackReview(docType, row),
@@ -301,6 +306,7 @@ function closeRequestReview() {
 function closeDecisionConfirm() {
   decisionConfirmOpen.value = false
   pendingDecision.value = ''
+  rejectReason.value = ''
 }
 
 function updateRequestDocument(item, patch) {
@@ -374,6 +380,7 @@ function confirmDecision() {
       approvalStatus: '반려',
       approvalReviewedBy: currentUser.value?.name || '',
       approvalReviewedAt: getReviewedAt(),
+      approvalRejectReason: rejectReason.value.trim() || '',
     })
   }
 
@@ -703,7 +710,17 @@ async function confirmPackageDelete() {
       :z-index="90"
       @confirm="confirmDecision"
       @cancel="closeDecisionConfirm"
-    />
+    >
+      <div v-if="pendingDecision === 'reject'" class="space-y-1.5">
+        <label class="text-sm font-semibold text-slate-700">반려 사유</label>
+        <textarea
+          v-model="rejectReason"
+          rows="3"
+          placeholder="반려 사유를 입력해주세요."
+          class="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-700 placeholder-slate-400 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
+        />
+      </div>
+    </ConfirmModal>
 
     <PackageDetailModal
       :open="Boolean(selectedPackage)"


### PR DESCRIPTION
## 📋 작업 내용

결재 반려 시 상급자(팀장)가 반려 사유를 입력할 수 있도록 하고,
하급자(팀원)가 결재 결과를 확인할 때 반려 사유가 함께 표시되도록 수정.

**변경:**
- `ConfirmModal.vue` — 기본 슬롯 추가 (커스텀 컨텐츠 삽입 지원)
- `DashboardPage.vue` — 반려 확인 시 textarea로 사유 입력, 결재 결과 조회 시 반려 사유 표시

**백엔드 (이미 main 반영):**
- `ApprovalRequest` 엔티티에 `approval_reason` 필드 추가
- `ApprovalRequestUpdateRequest` DTO에 `reason` 파라미터 추가
- REJECTED 시 reason 저장, Response에 reason 포함

## 🔗 관련 이슈

- closes #267

## ✅ 체크리스트

- [x] 정상 동작 확인 (빌드 성공)
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

- DB에 `ALTER TABLE approval_requests ADD COLUMN approval_reason TEXT NULL;` 실행 필요 (DDL은 이미 업데이트됨)
- 승인 시에는 사유 textarea가 표시되지 않고, 반려 시에만 나타남