### PR TITLE
fix: QA 일괄 수정 — 상태 한글화, 유효성 검증, 전화번호 포맷, 필드 표시

### DIFF
--- a/src/components/common/StatusBadge.vue
+++ b/src/components/common/StatusBadge.vue
@@ -100,10 +100,45 @@ const statusMap = {
   실패: 'border-rose-200 bg-rose-50 text-rose-700',
 }
 
+const labelMap = {
+  active: '활성', inactive: '비활성',
+  leave: '휴직', resigned: '퇴직',
+  draft: '초안', DRAFT: '초안',
+  sent: '발송', SENT: '발송',
+  confirmed: '확정', CONFIRMED: '확정',
+  cancelled: '취소', CANCELLED: '취소',
+  received: '접수', RECEIVED: '접수',
+  in_production: '생산중', IN_PRODUCTION: '생산중',
+  shipped: '출하완료', SHIPPED: '출하완료',
+  preparing: '준비중', PREPARING: '준비중',
+  ready: '준비완료', READY: '준비완료',
+  pending: '대기', PENDING: '대기',
+  approval_pending: '결재대기', APPROVAL_PENDING: '결재대기',
+  registration_requested: '등록요청', REGISTRATION_REQUESTED: '등록요청',
+  update_requested: '수정요청', UPDATE_REQUESTED: '수정요청',
+  deletion_requested: '삭제요청', DELETION_REQUESTED: '삭제요청',
+  in_progress: '진행중', IN_PROGRESS: '진행중',
+  completed: '완료', COMPLETED: '완료',
+  approved: '승인', APPROVED: '승인',
+  rejected: '반려', REJECTED: '반려',
+  paid: '완납', PAID: '완납',
+  unpaid: '미수금', UNPAID: '미수금',
+  normal: '정상', NORMAL: '정상',
+  delay_risk: '지연위험', DELAY_RISK: '지연위험',
+  delayed: '지연', DELAYED: '지연',
+  sent_complete: '발송완료', failed: '실패', FAILED: '실패',
+  temp_saved: '임시저장',
+}
+
 const badgeClasses = computed(() => {
   const rawValue = String(props.value).trim()
   const key = props.variant || rawValue
   return statusMap[key] || 'border-slate-200 bg-slate-100 text-slate-700'
+})
+
+const displayLabel = computed(() => {
+  const raw = String(props.value).trim()
+  return labelMap[raw] ?? raw
 })
 </script>
 
@@ -112,6 +147,6 @@ const badgeClasses = computed(() => {
     class="inline-flex min-h-6 items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold tracking-[0.02em]"
     :class="badgeClasses"
   >
-    <slot>{{ value }}</slot>
+    <slot>{{ displayLabel }}</slot>
   </span>
 </template>

--- a/src/components/domain/auth/DepartmentAccordion.vue
+++ b/src/components/domain/auth/DepartmentAccordion.vue
@@ -24,7 +24,7 @@ const columns = [
   { key: 'userEmail', label: '이메일' },
   { key: 'department', label: '부서', width: '120px' },
   { key: 'status', label: '상태', width: '100px', align: 'center' },
-  { key: 'actions', label: '관리', width: '140px', align: 'center' },
+  { key: 'actions', label: '', width: '140px', align: 'center', sortable: false },
 ]
 
 function getAvatarColor(index) {

--- a/src/components/domain/auth/UserFormModal.vue
+++ b/src/components/domain/auth/UserFormModal.vue
@@ -104,7 +104,7 @@ function validate() {
   }
 
   if (!form.value.role) {
-    e.role = '역할을 선택해주세요.'
+    e.role = '부서를 선택해주세요.'
   }
 
   if (!form.value.departmentId && props.mode === 'create') {
@@ -135,7 +135,7 @@ async function handleResetPassword() {
   if (!props.user?.userId && !props.user?.id) return
   try {
     await resetPassword(props.user.userId ?? props.user.id)
-    success('비밀번호가 test1234로 초기화되었습니다.')
+    success('비밀번호가 password123로 초기화되었습니다.')
   } catch (e) {
     error('비밀번호 초기화 중 오류가 발생했습니다.')
   } finally {
@@ -177,8 +177,8 @@ const currentDepartmentName = computed(() => {
           />
         </FormField>
 
-        <FormField label="역할" required :error="errors.role">
-          <BaseSelect v-model="form.role" :options="roleOptions" placeholder="역할을 선택하세요" />
+        <FormField label="부서" required :error="errors.role">
+          <BaseSelect v-model="form.role" :options="roleOptions" placeholder="부서를 선택하세요" />
         </FormField>
 
         <template v-if="mode === 'create'">
@@ -191,7 +191,11 @@ const currentDepartmentName = computed(() => {
           </FormField>
 
           <FormField label="초기 비밀번호">
-            <BaseTextField model-value="test1234" type="password" readonly />
+            <div class="flex items-center gap-2 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-600">
+              <i class="fas fa-lock text-xs text-slate-400" />
+              <span>password123</span>
+              <span class="text-xs text-slate-400">(가입 후 변경 권장)</span>
+            </div>
           </FormField>
         </template>
       </div>
@@ -240,7 +244,7 @@ const currentDepartmentName = computed(() => {
       <div v-if="mode === 'edit'" class="flex items-center justify-between rounded-xl border border-slate-200 bg-slate-50/50 p-4">
         <div>
           <p class="text-sm font-medium text-ink">비밀번호 초기화</p>
-          <p class="text-xs text-slate-500">비밀번호를 초기값(test1234)으로 재설정합니다.</p>
+          <p class="text-xs text-slate-500">비밀번호를 초기값(password123)으로 재설정합니다.</p>
         </div>
         <BaseButton variant="secondary" size="sm" type="button" @click="confirmResetPassword">
           초기화
@@ -252,7 +256,7 @@ const currentDepartmentName = computed(() => {
     <ConfirmModal
       :open="showResetConfirm"
       title="비밀번호 초기화"
-      :message="`${user?.userName ?? user?.name} 사용자의 비밀번호를 초기값(test1234)으로 초기화하시겠습니까?`"
+      :message="`${user?.userName ?? user?.name} 사용자의 비밀번호를 초기값(password123)으로 초기화하시겠습니까?`"
       confirm-label="초기화"
       confirm-variant="danger"
       @confirm="handleResetPassword"

--- a/src/components/domain/auth/UserListTab.vue
+++ b/src/components/domain/auth/UserListTab.vue
@@ -182,7 +182,7 @@ async function handleSave(formData) {
       const newUser = {
         name: formData.name,
         email: formData.email,
-        password: 'test1234',
+        password: 'password123',
         role: formData.role,
       }
       await createUser(newUser)

--- a/src/components/domain/document/PIFormModal.vue
+++ b/src/components/domain/document/PIFormModal.vue
@@ -27,7 +27,9 @@ import {
 } from '@/utils/incoterms'
 import {
   createExchangeRateHint,
-} from '@/utils/exchangeRate'
+  convertFromKrw,
+  getKrwRate,
+} from '@/stores/exchangeRates'
 
 const props = defineProps({
   open: { type: Boolean, default: false },
@@ -414,7 +416,7 @@ function convertKrwPriceToCurrency(basePrice, currency) {
     return numericBasePrice
   }
 
-  return numericBasePrice
+  return convertFromKrw(numericBasePrice, currency)
 }
 
 function sanitizeNonNegativeInteger(value, fallback = '0') {

--- a/src/components/domain/master/ClientFormModal.vue
+++ b/src/components/domain/master/ClientFormModal.vue
@@ -7,6 +7,8 @@ import BaseTextField from '@/components/common/BaseTextField.vue'
 import FileUploadField from '@/components/common/FileUploadField.vue'
 import FormField from '@/components/common/FormField.vue'
 import SearchableCombobox from '@/components/common/SearchableCombobox.vue'
+import { isValidEmail, isValidTel, MAX_LEN } from '@/utils/validators'
+import { getPhoneInfoByCountry, formatPhoneInput } from '@/utils/phoneFormat'
 
 const props = defineProps({
   open: { type: Boolean, default: false },
@@ -49,6 +51,21 @@ const statusOptions = [
   { label: '활성', value: 'active' },
   { label: '비활성', value: 'inactive' },
 ]
+
+const selectedCountryName = computed(() => {
+  if (!form.value.countryId) return ''
+  const c = props.countries.find((c) => c.countryId === form.value.countryId)
+  return c?.countryName ?? ''
+})
+
+const phoneInfo = computed(() => getPhoneInfoByCountry(selectedCountryName.value))
+
+function handleTelInput(event) {
+  const raw = event.target.value
+  if (phoneInfo.value.code) {
+    form.value.tel = formatPhoneInput(raw, phoneInfo.value.code, phoneInfo.value.format)
+  }
+}
 
 function generateNextCode() {
   const codes = props.allClients.map((c) => c.clientCode ?? c.code)
@@ -115,6 +132,12 @@ watch(
     const cid = String(newId)
     const portBelongs = props.ports.some((p) => String(p.countryId) === cid && String(p.id) === String(form.value.portId))
     if (!portBelongs) form.value.portId = null
+
+    // 국가 변경 시 전화번호 prefix 자동 세팅
+    const info = phoneInfo.value
+    if (info.code && !form.value.tel) {
+      form.value.tel = `${info.code} `
+    }
   },
 )
 
@@ -133,6 +156,12 @@ function validate() {
 
   if (!form.value.name?.trim()) {
     e.name = '영문 거래처명을 입력하세요.'
+  } else if (form.value.name.length > MAX_LEN.NAME) {
+    e.name = `거래처명은 ${MAX_LEN.NAME}자 이내로 입력하세요.`
+  }
+
+  if (form.value.nameKr && form.value.nameKr.length > MAX_LEN.NAME_KR) {
+    e.nameKr = `한글 거래처명은 ${MAX_LEN.NAME_KR}자 이내로 입력하세요.`
   }
 
   if (!form.value.countryId) {
@@ -141,13 +170,22 @@ function validate() {
 
   if (!form.value.tel?.trim()) {
     e.tel = '전화번호를 입력하세요.'
+  } else if (!isValidTel(form.value.tel)) {
+    e.tel = '올바른 전화번호 형식을 입력하세요. (예: +82 02-1234-5678)'
   }
 
   if (form.value.email?.trim()) {
-    const emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/
-    if (!emailRegex.test(form.value.email.trim())) {
+    if (!isValidEmail(form.value.email)) {
       e.email = '올바른 이메일 형식을 입력하세요.'
     }
+  }
+
+  if (form.value.address && form.value.address.length > MAX_LEN.ADDRESS) {
+    e.address = `주소는 ${MAX_LEN.ADDRESS}자 이내로 입력하세요.`
+  }
+
+  if (form.value.manager && form.value.manager.length > MAX_LEN.MANAGER) {
+    e.manager = `담당자명은 ${MAX_LEN.MANAGER}자 이내로 입력하세요.`
   }
 
   errors.value = e
@@ -228,7 +266,12 @@ function handleSave() {
             <BaseTextField v-model="form.manager" placeholder="담당자명을 입력하세요" />
           </FormField>
           <FormField label="TEL" required>
-            <BaseTextField v-model="form.tel" placeholder="전화번호를 입력하세요" />
+            <BaseTextField
+              v-model="form.tel"
+              :placeholder="phoneInfo.placeholder"
+              :maxlength="MAX_LEN.TEL"
+              @input="handleTelInput"
+            />
             <p v-if="errors.tel" class="mt-1 text-xs text-red-500">{{ errors.tel }}</p>
           </FormField>
           <FormField label="Email">

--- a/src/components/domain/master/ItemFormModal.vue
+++ b/src/components/domain/master/ItemFormModal.vue
@@ -5,6 +5,7 @@ import BaseModal from '@/components/common/BaseModal.vue'
 import BaseSelect from '@/components/common/BaseSelect.vue'
 import BaseTextField from '@/components/common/BaseTextField.vue'
 import FormField from '@/components/common/FormField.vue'
+import { MAX_LEN, NUM_RANGE } from '@/utils/validators'
 
 const props = defineProps({
   open: { type: Boolean, default: false },
@@ -126,6 +127,8 @@ function validate() {
 
   if (!form.value.name?.trim()) {
     e.name = '품목명을 입력하세요.'
+  } else if (form.value.name.length > MAX_LEN.NAME) {
+    e.name = `품목명은 ${MAX_LEN.NAME}자 이내로 입력하세요.`
   }
 
   if (!form.value.unit) {
@@ -138,6 +141,8 @@ function validate() {
     const price = Number(form.value.unitPrice)
     if (Number.isNaN(price) || price <= 0) {
       e.unitPrice = '단가는 유효한 양수를 입력하세요.'
+    } else if (price > NUM_RANGE.UNIT_PRICE_MAX) {
+      e.unitPrice = `단가는 ${NUM_RANGE.UNIT_PRICE_MAX.toLocaleString()} 이하로 입력하세요.`
     }
   }
 
@@ -145,6 +150,8 @@ function validate() {
     const w = Number(form.value.weight)
     if (Number.isNaN(w) || w < 0) {
       e.weight = '중량은 0 이상의 유효한 숫자를 입력하세요.'
+    } else if (w > NUM_RANGE.WEIGHT_MAX) {
+      e.weight = `중량은 ${NUM_RANGE.WEIGHT_MAX.toLocaleString()}kg 이하로 입력하세요.`
     }
   }
 
@@ -163,6 +170,8 @@ function validate() {
       const num = Number(val)
       if (Number.isNaN(num) || num <= 0) {
         e[key] = `${label}는 양수를 입력하세요.`
+      } else if (num > NUM_RANGE.DIMENSION_MAX) {
+        e[key] = `${label}는 ${NUM_RANGE.DIMENSION_MAX.toLocaleString()}mm 이하로 입력하세요.`
       }
     }
   }

--- a/src/stores/exchangeRates.js
+++ b/src/stores/exchangeRates.js
@@ -1,0 +1,100 @@
+import { ref } from 'vue'
+
+/**
+ * 환율 Pinia-like store (PI 관리 페이지 진입 시 로드, 이탈 시 클리어)
+ *
+ * 데이터 소스: https://github.com/fawazahmed0/exchange-api
+ * KRW 기준 환율을 가져와서 1 KRW = ? 외화 비율을 저장한다.
+ */
+
+const API_BASE = 'https://cdn.jsdelivr.net/npm/@fawazahmed0/currency-api@latest/v1/currencies'
+
+const rates = ref({})
+const rateDate = ref('')
+const loading = ref(false)
+const loaded = ref(false)
+
+/**
+ * 환율 데이터 로드 (KRW 기준)
+ * rates = { usd: 0.000742, eur: 0.000686, jpy: 0.1124, ... }
+ * 의미: 1 KRW = 0.000742 USD
+ */
+export async function loadExchangeRates() {
+  if (loaded.value || loading.value) return
+  loading.value = true
+
+  try {
+    const response = await fetch(`${API_BASE}/krw.json`)
+    if (!response.ok) throw new Error(`HTTP ${response.status}`)
+    const data = await response.json()
+    rates.value = data.krw ?? {}
+    rateDate.value = data.date ?? ''
+    loaded.value = true
+  } catch (e) {
+    console.warn('환율 데이터 로드 실패 (fallback 없음):', e.message)
+  } finally {
+    loading.value = false
+  }
+}
+
+/**
+ * 환율 데이터 클리어 (PI 페이지 이탈 시)
+ */
+export function clearExchangeRates() {
+  rates.value = {}
+  rateDate.value = ''
+  loaded.value = false
+}
+
+/**
+ * KRW → 외화 변환
+ * @param {number} krwAmount KRW 금액
+ * @param {string} targetCurrency 목표 통화 코드 (예: 'USD')
+ * @returns {number} 변환된 금액 (소수점 2자리)
+ */
+export function convertFromKrw(krwAmount, targetCurrency) {
+  const amount = Number(krwAmount)
+  if (!Number.isFinite(amount)) return 0
+  if (!targetCurrency || targetCurrency === 'KRW') return amount
+
+  const rate = rates.value[targetCurrency.toLowerCase()]
+  if (!rate) return amount
+
+  return Number((amount * rate).toFixed(2))
+}
+
+/**
+ * 특정 통화의 환율 조회 (1 USD = ? KRW 형태로 반환)
+ * @param {string} currencyCode 통화 코드
+ * @returns {number|null} 환율 (예: 1 USD = 1348.5 KRW) 또는 null
+ */
+export function getKrwRate(currencyCode) {
+  if (!currencyCode || currencyCode === 'KRW') return 1
+
+  const rate = rates.value[currencyCode.toLowerCase()]
+  if (!rate || rate === 0) return null
+
+  return Number((1 / rate).toFixed(2))
+}
+
+/**
+ * 환율 힌트 텍스트 생성
+ * @param {string} currency 통화 코드
+ * @returns {string} 힌트 텍스트
+ */
+export function createExchangeRateHint(currency) {
+  if (!currency || currency === 'KRW') {
+    return '원화(KRW) 거래입니다.'
+  }
+
+  const krwRate = getKrwRate(currency)
+  if (krwRate === null) {
+    return `${currency} 환율 정보를 불러오는 중...`
+  }
+
+  return `1 ${currency} = ${krwRate.toLocaleString('ko-KR')} KRW (${rateDate.value})`
+}
+
+export function useExchangeRates() {
+  return { rates, rateDate, loading, loaded, loadExchangeRates, clearExchangeRates, convertFromKrw, getKrwRate, createExchangeRateHint }
+}

--- a/src/utils/phoneFormat.js
+++ b/src/utils/phoneFormat.js
@@ -1,0 +1,98 @@
+/**
+ * 국가별 전화번호 포맷 유틸리티
+ *
+ * 국가 선택 시 국제 전화번호 prefix 자동 삽입 + 하이픈 자동 포맷.
+ * countryId → 국가 코드 매핑은 countries 마스터 데이터의 countryName 기반.
+ */
+
+const COUNTRY_PHONE = {
+  'United States':  { code: '+1',   format: '###-###-####',       placeholder: '+1 XXX-XXX-XXXX' },
+  'Canada':         { code: '+1',   format: '###-###-####',       placeholder: '+1 XXX-XXX-XXXX' },
+  'Japan':          { code: '+81',  format: '##-####-####',       placeholder: '+81 XX-XXXX-XXXX' },
+  'China':          { code: '+86',  format: '###-####-####',      placeholder: '+86 XXX-XXXX-XXXX' },
+  'South Korea':    { code: '+82',  format: '##-####-####',       placeholder: '+82 XX-XXXX-XXXX' },
+  'Korea':          { code: '+82',  format: '##-####-####',       placeholder: '+82 XX-XXXX-XXXX' },
+  'Germany':        { code: '+49',  format: '####-#######',       placeholder: '+49 XXXX-XXXXXXX' },
+  'United Kingdom': { code: '+44',  format: '####-######',        placeholder: '+44 XXXX-XXXXXX' },
+  'France':         { code: '+33',  format: '#-##-##-##-##',      placeholder: '+33 X-XX-XX-XX-XX' },
+  'Australia':      { code: '+61',  format: '###-###-###',        placeholder: '+61 XXX-XXX-XXX' },
+  'India':          { code: '+91',  format: '#####-#####',        placeholder: '+91 XXXXX-XXXXX' },
+  'Singapore':      { code: '+65',  format: '####-####',          placeholder: '+65 XXXX-XXXX' },
+  'Thailand':       { code: '+66',  format: '##-###-####',        placeholder: '+66 XX-XXX-XXXX' },
+  'Vietnam':        { code: '+84',  format: '###-###-####',       placeholder: '+84 XXX-XXX-XXXX' },
+  'Indonesia':      { code: '+62',  format: '###-####-####',      placeholder: '+62 XXX-XXXX-XXXX' },
+  'Malaysia':       { code: '+60',  format: '##-####-####',       placeholder: '+60 XX-XXXX-XXXX' },
+  'UAE':            { code: '+971', format: '##-###-####',        placeholder: '+971 XX-XXX-XXXX' },
+  'Saudi Arabia':   { code: '+966', format: '##-###-####',        placeholder: '+966 XX-XXX-XXXX' },
+  'Brazil':         { code: '+55',  format: '##-#####-####',      placeholder: '+55 XX-XXXXX-XXXX' },
+  'Mexico':         { code: '+52',  format: '###-###-####',       placeholder: '+52 XXX-XXX-XXXX' },
+  'Turkey':         { code: '+90',  format: '###-###-####',       placeholder: '+90 XXX-XXX-XXXX' },
+  'Netherlands':    { code: '+31',  format: '##-########',        placeholder: '+31 XX-XXXXXXXX' },
+  'Italy':          { code: '+39',  format: '###-###-####',       placeholder: '+39 XXX-XXX-XXXX' },
+  'Spain':          { code: '+34',  format: '###-###-###',        placeholder: '+34 XXX-XXX-XXX' },
+  'Sweden':         { code: '+46',  format: '##-###-####',        placeholder: '+46 XX-XXX-XXXX' },
+  'Switzerland':    { code: '+41',  format: '##-###-##-##',       placeholder: '+41 XX-XXX-XX-XX' },
+  'Poland':         { code: '+48',  format: '###-###-###',        placeholder: '+48 XXX-XXX-XXX' },
+  'Russia':         { code: '+7',   format: '###-###-##-##',      placeholder: '+7 XXX-XXX-XX-XX' },
+  'Philippines':    { code: '+63',  format: '###-###-####',       placeholder: '+63 XXX-XXX-XXXX' },
+  'Taiwan':         { code: '+886', format: '##-####-####',       placeholder: '+886 XX-XXXX-XXXX' },
+}
+
+const DEFAULT_PHONE = { code: '', format: '###-####-####', placeholder: '전화번호를 입력하세요' }
+
+/**
+ * 국가명으로 전화번호 정보 조회
+ */
+export function getPhoneInfoByCountry(countryName) {
+  if (!countryName) return DEFAULT_PHONE
+  return COUNTRY_PHONE[countryName] ?? DEFAULT_PHONE
+}
+
+/**
+ * 입력값에 포맷 마스크 적용 (하이픈 자동 삽입)
+ * @param {string} raw 숫자만 추출된 입력값
+ * @param {string} format 포맷 패턴 (예: '###-###-####')
+ * @returns {string} 포맷된 전화번호
+ */
+export function applyPhoneMask(raw, format) {
+  const digits = String(raw).replace(/[^\d]/g, '')
+  let result = ''
+  let di = 0
+
+  for (let i = 0; i < format.length && di < digits.length; i++) {
+    if (format[i] === '#') {
+      result += digits[di++]
+    } else {
+      result += format[i]
+      // 마지막 숫자가 채워진 직후의 하이픈은 포함하지 않음
+      if (di >= digits.length) break
+    }
+  }
+
+  return result
+}
+
+/**
+ * 전화번호 입력 이벤트 핸들러 — v-model과 함께 사용
+ * @param {string} inputValue 사용자 입력값
+ * @param {string} countryCode 국제 전화번호 prefix (예: '+82')
+ * @param {string} format 포맷 패턴
+ * @returns {string} prefix + 포맷된 번호
+ */
+export function formatPhoneInput(inputValue, countryCode, format) {
+  const prefix = countryCode ? `${countryCode} ` : ''
+  // prefix 이후의 순수 입력 부분만 추출
+  const afterPrefix = inputValue.startsWith(prefix)
+    ? inputValue.slice(prefix.length)
+    : inputValue.replace(/^\+?\d{1,3}\s?/, '')
+
+  const formatted = applyPhoneMask(afterPrefix, format)
+  return formatted ? `${prefix}${formatted}` : prefix
+}
+
+/**
+ * 전화번호에서 prefix 제거 후 순수 숫자만 추출
+ */
+export function extractPhoneDigits(value) {
+  return String(value ?? '').replace(/[^\d]/g, '')
+}

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -2,9 +2,73 @@
  * 공통 유효성 검증 유틸리티
  */
 
-/** 이메일 유효성 검증 정규식 (Auth 도메인 전체 통일) */
+// ── 이메일 ────────────────────────────────────────────────
 export const EMAIL_REGEX = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/
 
 export function isValidEmail(email) {
-  return EMAIL_REGEX.test(email.trim())
+  return EMAIL_REGEX.test(String(email ?? '').trim())
+}
+
+// ── 전화번호 (숫자·하이픈·플러스·공백·괄호 허용, 7~20자) ──
+export const TEL_REGEX = /^\+?[\d\s()-]{7,20}$/
+
+export function isValidTel(tel) {
+  return TEL_REGEX.test(String(tel ?? '').trim())
+}
+
+// ── HS Code (숫자·점만 허용) ──────────────────────────────
+export const HS_CODE_REGEX = /^[\d.]+$/
+
+export function isValidHsCode(code) {
+  return HS_CODE_REGEX.test(String(code ?? '').trim())
+}
+
+// ── 숫자 범위 검증 ───────────────────────────────────────
+export function isInRange(value, min, max) {
+  const num = Number(value)
+  if (Number.isNaN(num)) return false
+  return num >= min && num <= max
+}
+
+// ── 양수 / 비음수 검증 ──────────────────────────────────
+export function isPositiveNumber(value) {
+  const num = Number(value)
+  return !Number.isNaN(num) && num > 0
+}
+
+export function isNonNegativeNumber(value) {
+  const num = Number(value)
+  return !Number.isNaN(num) && num >= 0
+}
+
+// ── 글자 수 제한 ────────────────────────────────────────
+export function isWithinLength(value, maxLen) {
+  return String(value ?? '').length <= maxLen
+}
+
+// ── 필수 문자열 ─────────────────────────────────────────
+export function isRequired(value) {
+  return String(value ?? '').trim().length > 0
+}
+
+// ── 상수 ────────────────────────────────────────────────
+export const MAX_LEN = {
+  NAME: 100,
+  NAME_KR: 50,
+  ADDRESS: 200,
+  TEL: 20,
+  FAX: 20,
+  EMAIL: 100,
+  CODE: 20,
+  CITY: 50,
+  MANAGER: 50,
+  HS_CODE: 20,
+  REMARK: 500,
+}
+
+export const NUM_RANGE = {
+  DIMENSION_MAX: 99999,
+  WEIGHT_MAX: 999999,
+  UNIT_PRICE_MAX: 9999999999,
+  QUANTITY_MAX: 99999999,
 }

--- a/src/views/activity/ActivityListPage.vue
+++ b/src/views/activity/ActivityListPage.vue
@@ -203,7 +203,7 @@ const columns = [
   { key: 'poId', label: 'PO', width: '130px', align: 'center' },
   { key: 'date', label: '날짜', width: '110px', align: 'center' },
   { key: 'author', label: '작성자', width: '100px' },
-  { key: 'actions', label: '작업', width: '70px', align: 'center' },
+  { key: 'actions', label: '', width: '70px', align: 'center', sortable: false },
 ]
 </script>
 

--- a/src/views/contacts/ContactListPage.vue
+++ b/src/views/contacts/ContactListPage.vue
@@ -141,7 +141,14 @@ function validate() {
   const e = {}
   if (!formClientId.value)     e.clientId  = '거래처 값이 누락되었습니다.'
   if (!formName.value.trim())  e.buyerName  = '이름 값이 누락되었습니다.'
-  if (!formEmail.value.trim()) e.buyerEmail = '이메일 값이 누락되었습니다.'
+  if (!formEmail.value.trim()) {
+    e.buyerEmail = '이메일 값이 누락되었습니다.'
+  } else if (!/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(formEmail.value.trim())) {
+    e.buyerEmail = '올바른 이메일 형식을 입력하세요.'
+  }
+  if (formTel.value.trim() && !/^\+?[\d\s()-]{7,20}$/.test(formTel.value.trim())) {
+    e.buyerTel = '올바른 전화번호 형식을 입력하세요.'
+  }
   formErrors.value = e
   return Object.keys(e).length === 0
 }

--- a/src/views/documents/PIPage.vue
+++ b/src/views/documents/PIPage.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 
 import ApprovalRequestModal from '@/components/common/ApprovalRequestModal.vue'
@@ -22,6 +22,7 @@ import { useDocumentFilter } from '@/composables/useDocumentFilter'
 import { usePagination } from '@/composables/usePagination'
 import { useSearchModalLookups } from '@/composables/useSearchModalLookups'
 import { useAuthStore } from '@/stores/auth'
+import { loadExchangeRates, clearExchangeRates } from '@/stores/exchangeRates'
 import { usePiDocuments } from '@/stores/piDocuments'
 import { usePoDocuments } from '@/stores/poDocuments'
 import { useShipmentOrderDocuments } from '@/stores/shipmentOrderDocuments'
@@ -197,7 +198,12 @@ async function loadClientRows() {
   }
 }
 
-onMounted(loadClientRows)
+onMounted(() => {
+  loadClientRows()
+  loadExchangeRates()
+})
+
+onUnmounted(clearExchangeRates)
 
 function openClientSearch(context = 'filter') {
   clientSearchContext.value = context

--- a/src/views/master/ClientListPage.vue
+++ b/src/views/master/ClientListPage.vue
@@ -75,7 +75,7 @@ const columns = [
   { key: 'currency', label: '통화', width: '80px', align: 'center' },
   { key: 'clientManager', label: '담당자', width: '120px' },
   { key: 'clientStatus', label: '상태', width: '80px', align: 'center' },
-  { key: 'actions', label: '액션', width: '120px', align: 'center' },
+  { key: 'actions', label: '', width: '120px', align: 'center', sortable: false },
 ]
 
 const enrichedClients = computed(() =>

--- a/src/views/master/ClientListPage.vue
+++ b/src/views/master/ClientListPage.vue
@@ -81,6 +81,7 @@ const columns = [
 const enrichedClients = computed(() =>
   clients.value.map((c) => ({
     ...c,
+    portName: getPortName(c.portId),
     paymentTermsCode: getPaymentTermsLabel(c.paymentTermsId),
     currencyCode: getCurrencyLabel(c.currencyId),
   })),

--- a/src/views/master/ItemListPage.vue
+++ b/src/views/master/ItemListPage.vue
@@ -93,7 +93,7 @@ const columns = computed(() => {
     { key: 'itemStatus', label: '상태', width: '80px', align: 'center' },
   ]
   if (isItemAdmin.value) {
-    base.push({ key: 'actions', label: '액션', width: '120px', align: 'center' })
+    base.push({ key: 'actions', label: '', width: '120px', align: 'center', sortable: false })
   }
   return base
 })


### PR DESCRIPTION
## 📋 작업 내용

### 1. 상태 뱃지 한글화
- StatusBadge: 영어 상태값(CONFIRMED, PENDING, APPROVED 등)을 한글로 자동 변환하는 labelMap + displayLabel 추가

### 2. 필드 표시 수정
- 거래처 목록: 도착항(port) 비어있던 문제 — enrichedClients에 portName 추가
- 품목 포장단위: **백엔드(master) main 반영 완료** — ItemListResponse + SQL에 itemPackUnit 추가

### 3. 유효성 검증 강화
- `validators.js` 강화: 전화번호·이메일 정규식, 숫자 범위·글자 수 제한 상수
- `phoneFormat.js` 신규: 30개국 국제전화번호 prefix + 하이픈 자동 마스크
- 거래처(ClientFormModal): TEL 국가별 자동 포맷, 이메일 통일, 이름/주소/담당자 maxLength
- 품목(ItemFormModal): 규격 99,999mm / 단가 99억 / 중량 999,999kg 범위 제한
- 연락처(ContactListPage): 이메일 형식 + 전화번호 형식 검증

### 4. 액션 컬럼 + 사용자 등록 UX
- 액션 컬럼: 전체 테이블에서 헤더 텍스트 제거 + 정렬 비활성화
- 사용자 등록: '역할' → '부서' 라벨 변경
- 초기 비밀번호: password123으로 통일 (표시 + 실제 전송값 모두)

### 5. PI 환율 실시간 적용
- `exchangeRates.js` store 신규: fawazahmed0/exchange-api에서 KRW 기준 환율 로드
- PI 페이지 진입 시 로드 → 이탈 시 클리어 (메모리 관리)
- 통화 변경 시 힌트에 실제 환율 표시 (예: `1 USD = 1,348 KRW`)
- 품목 선택 시 마스터 KRW 단가를 선택 통화로 자동 환산

## 🔗 관련 이슈

- closes #272
- closes #270
- closes #269

## ✅ 체크리스트

- [x] 정상 동작 확인 (빌드 성공)
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

- 환율 API는 외부 CDN(`cdn.jsdelivr.net`)을 사용하므로 네트워크 차단 환경에서는 환율 힌트가 "불러오는 중..."으로 표시됩니다 (기능 자체는 정상 동작, 환산만 미적용)
- `/api/users` 401 이슈는 Gateway JWKS 캐시 문제로 `rollout restart deploy/gateway`로 해결 가능
- 하드 리프레시(Ctrl+Shift+R) 후 테스트 권장