### PR TITLE
fix: PI/PO JSON 필드 파싱 + 변경이력 표시 + 문서 데이터 누락 수정

### DIFF
--- a/src/stores/piDocuments.js
+++ b/src/stores/piDocuments.js
@@ -2,6 +2,11 @@ import { useAuthStore } from './auth'
 import { ref } from 'vue'
 import { fetchProformaInvoices } from '@/api/documents'
 
+function tryParseJson(value, fallback = null) {
+  if (typeof value !== 'string') return value ?? fallback
+  try { return JSON.parse(value) } catch { return fallback }
+}
+
 function formatDate(value) {
   return String(value ?? '').replace(/-/g, '/')
 }
@@ -45,10 +50,10 @@ function mapPiResponse(row) {
     approvalAction: row.approvalAction ?? null,
     approvalRequestedBy: row.approvalRequestedBy ?? null,
     approvalRequestedAt: row.approvalRequestedAt ?? null,
-    approvalReview: row.approvalReview ?? null,
-    itemsSnapshot: row.itemsSnapshot ?? null,
-    linkedDocuments: row.linkedDocuments ? (typeof row.linkedDocuments === 'string' ? JSON.parse(row.linkedDocuments) : row.linkedDocuments) : [],
-    revisionHistory: row.revisionHistory ?? null,
+    approvalReview: row.approvalReview ? (typeof row.approvalReview === 'string' ? tryParseJson(row.approvalReview) : row.approvalReview) : null,
+    itemsSnapshot: row.itemsSnapshot ? (typeof row.itemsSnapshot === 'string' ? tryParseJson(row.itemsSnapshot) : row.itemsSnapshot) : null,
+    linkedDocuments: row.linkedDocuments ? (typeof row.linkedDocuments === 'string' ? tryParseJson(row.linkedDocuments, []) : row.linkedDocuments) : [],
+    revisionHistory: row.revisionHistory ? (typeof row.revisionHistory === 'string' ? tryParseJson(row.revisionHistory, []) : row.revisionHistory) : [],
     items,
   }
 }

--- a/src/stores/poDocuments.js
+++ b/src/stores/poDocuments.js
@@ -12,6 +12,11 @@ function formatCurrencyAmount(amount, currencyCode) {
   return `${symbol}${Number(amount || 0).toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`
 }
 
+function parseJsonSafe(value, fallback = null) {
+  if (typeof value !== 'string') return value ?? fallback
+  try { return JSON.parse(value) } catch { return fallback }
+}
+
 function parseLinkedDocuments(value) {
   if (!value) return []
   if (typeof value === 'string') {
@@ -58,10 +63,10 @@ function mapPoResponse(row) {
     approvalAction: row.approvalAction ?? null,
     approvalRequestedBy: row.approvalRequestedBy ?? null,
     approvalRequestedAt: row.approvalRequestedAt ?? null,
-    approvalReview: row.approvalReview ?? null,
-    itemsSnapshot: row.itemsSnapshot ?? null,
+    approvalReview: row.approvalReview ? parseJsonSafe(row.approvalReview) : null,
+    itemsSnapshot: row.itemsSnapshot ? parseJsonSafe(row.itemsSnapshot) : null,
     linkedDocuments: parseLinkedDocuments(row.linkedDocuments),
-    revisionHistory: row.revisionHistory ? (typeof row.revisionHistory === 'string' ? JSON.parse(row.revisionHistory) : row.revisionHistory) : [],
+    revisionHistory: row.revisionHistory ? parseJsonSafe(row.revisionHistory, []) : [],
     items,
   }
 }

--- a/src/views/documents/PIDetailPage.vue
+++ b/src/views/documents/PIDetailPage.vue
@@ -935,8 +935,13 @@ function cancelDeleteApprovalRequest() {
           <div class="mb-3 flex items-center justify-between">
             <h3 class="font-bold text-slate-800">변경 이력</h3>
           </div>
-          <div class="text-xs text-slate-400">
-            {{ detail.revisionHistory.length ? detail.revisionHistory.join(', ') : '변경 이력 없음' }}
+          <div class="space-y-1 text-xs text-slate-400">
+            <template v-if="Array.isArray(detail.revisionHistory) && detail.revisionHistory.length">
+              <div v-for="(rev, i) in detail.revisionHistory" :key="i" class="rounded border border-slate-100 bg-slate-50 px-2 py-1">
+                {{ typeof rev === 'string' ? rev : (rev.summary ?? rev.description ?? JSON.stringify(rev)) }}
+              </div>
+            </template>
+            <span v-else>변경 이력 없음</span>
           </div>
         </div>
       </div>

--- a/src/views/documents/PODetailPage.vue
+++ b/src/views/documents/PODetailPage.vue
@@ -1117,8 +1117,13 @@ function cancelDeleteApprovalRequest() {
           <div class="mb-3 flex items-center justify-between">
             <h3 class="font-bold text-slate-800">변경 이력</h3>
           </div>
-          <div class="text-xs text-slate-400">
-            {{ detail.revisionHistory.length ? detail.revisionHistory.join(', ') : '변경 이력 없음' }}
+          <div class="space-y-1 text-xs text-slate-400">
+            <template v-if="Array.isArray(detail.revisionHistory) && detail.revisionHistory.length">
+              <div v-for="(rev, i) in detail.revisionHistory" :key="i" class="rounded border border-slate-100 bg-slate-50 px-2 py-1">
+                {{ typeof rev === 'string' ? rev : (rev.summary ?? rev.description ?? JSON.stringify(rev)) }}
+              </div>
+            </template>
+            <span v-else>변경 이력 없음</span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 📋 작업 내용

### QA 리포트 대응 — 근본 원인 수정

**백엔드 (documents main 반영 완료):**
- PI mapper: 3컬럼 → 전체 컬럼 + items 컬렉션 로드 (PI 상세 빈 화면 근본 수정)
- CI view + mapper + response: clientName, paymentTerms, portOfDischarge, buyer, itemsSnapshot, linkedDocuments 추가
- PL view + mapper + response: 동일 필드 추가

**프론트엔드:**
- piDocuments store: revisionHistory, itemsSnapshot, approvalReview에 JSON.parse 방어 추가
- poDocuments store: 동일 JSON 파싱 방어 추가
- PIDetailPage: `revisionHistory.join()` → 배열 순회 + object 안전 렌더링 (TypeError 해결)
- PODetailPage: 동일 변경이력 표시 수정

### 해결되는 QA 이슈

| QA# | 증상 | 상태 |
|---|---|---|
| 1 | PI 상세 빈 화면 (revisionHistory.join TypeError) | 해결 |
| 2 | PI 핵심 필드 전부 null | 해결 (매퍼 완성) |
| 3 | PO 변경이력 [object Object] | 해결 |
| 4 | CI/PL 거래처명 "-" | 해결 (clientName 매핑) |
| 5 | CI 상세 인코텀즈/결제조건 등 "-" | 해결 (필드 추가) |
| 6 | PI 상태 "DRAFT" 영문 표시 | 해결 (StatusBadge labelMap, PR #273) |

## 🔗 관련 이슈

- closes #274

## ✅ 체크리스트

- [x] 정상 동작 확인 (빌드 성공)
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

- documents 백엔드는 이미 main 반영 → 배포 대기 중
- 하드 리프레시(Ctrl+Shift+R) 후 테스트 권장
- PL 단위 중복("0 EA EA") 이슈는 PL store에서 별도 수정 필요 (다음 PR)