### PR TITLE
fix: QA 잔여 수정 — 변경이력 포맷, 요청 시각, PL 단위 중복

### DIFF
--- a/src/stores/piDocuments.js
+++ b/src/stores/piDocuments.js
@@ -7,6 +7,16 @@ function tryParseJson(value, fallback = null) {
   try { return JSON.parse(value) } catch { return fallback }
 }
 
+function formatTimestamp(value) {
+  if (!value) return null
+  const str = String(value)
+  if (str.includes('T')) {
+    const [date, time] = str.split('T')
+    return `${date.replace(/-/g, '/')} ${time.substring(0, 5)}`
+  }
+  return str
+}
+
 function formatDate(value) {
   return String(value ?? '').replace(/-/g, '/')
 }
@@ -49,7 +59,7 @@ function mapPiResponse(row) {
     requestStatus: row.requestStatus ?? null,
     approvalAction: row.approvalAction ?? null,
     approvalRequestedBy: row.approvalRequestedBy ?? null,
-    approvalRequestedAt: row.approvalRequestedAt ?? null,
+    approvalRequestedAt: formatTimestamp(row.approvalRequestedAt),
     approvalReview: row.approvalReview ? (typeof row.approvalReview === 'string' ? tryParseJson(row.approvalReview) : row.approvalReview) : null,
     itemsSnapshot: row.itemsSnapshot ? (typeof row.itemsSnapshot === 'string' ? tryParseJson(row.itemsSnapshot) : row.itemsSnapshot) : null,
     linkedDocuments: row.linkedDocuments ? (typeof row.linkedDocuments === 'string' ? tryParseJson(row.linkedDocuments, []) : row.linkedDocuments) : [],

--- a/src/stores/poDocuments.js
+++ b/src/stores/poDocuments.js
@@ -12,6 +12,16 @@ function formatCurrencyAmount(amount, currencyCode) {
   return `${symbol}${Number(amount || 0).toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`
 }
 
+function formatTimestamp(value) {
+  if (!value) return null
+  const str = String(value)
+  if (str.includes('T')) {
+    const [date, time] = str.split('T')
+    return `${date.replace(/-/g, '/')} ${time.substring(0, 5)}`
+  }
+  return str
+}
+
 function parseJsonSafe(value, fallback = null) {
   if (typeof value !== 'string') return value ?? fallback
   try { return JSON.parse(value) } catch { return fallback }
@@ -62,7 +72,7 @@ function mapPoResponse(row) {
     requestStatus: row.requestStatus ?? null,
     approvalAction: row.approvalAction ?? null,
     approvalRequestedBy: row.approvalRequestedBy ?? null,
-    approvalRequestedAt: row.approvalRequestedAt ?? null,
+    approvalRequestedAt: formatTimestamp(row.approvalRequestedAt),
     approvalReview: row.approvalReview ? parseJsonSafe(row.approvalReview) : null,
     itemsSnapshot: row.itemsSnapshot ? parseJsonSafe(row.itemsSnapshot) : null,
     linkedDocuments: parseLinkedDocuments(row.linkedDocuments),

--- a/src/utils/revisionFormat.js
+++ b/src/utils/revisionFormat.js
@@ -1,0 +1,48 @@
+/**
+ * 변경 이력(revision history) 항목을 가독성 있는 문자열로 변환
+ */
+
+const ACTION_LABEL = {
+  CREATE: '생성',
+  UPDATE: '수정',
+  DELETE: '삭제',
+  APPROVE: '승인',
+  REJECT: '반려',
+  REQUEST: '요청',
+  REVIEW_APPROVED: '승인 처리',
+  REVIEW_REJECTED: '반려 처리',
+}
+
+function formatTimestamp(value) {
+  if (!value) return ''
+  const str = String(value)
+  if (str.includes('T')) {
+    const [date, time] = str.split('T')
+    return `${date.replace(/-/g, '/')} ${time.substring(0, 5)}`
+  }
+  return str
+}
+
+/**
+ * revision 객체를 한 줄 요약 문자열로 변환
+ * @param {string|object} rev
+ * @returns {string}
+ */
+export function formatRevisionEntry(rev) {
+  if (typeof rev === 'string') return rev
+
+  if (!rev || typeof rev !== 'object') return String(rev ?? '')
+
+  const action = ACTION_LABEL[rev.action] ?? rev.action ?? ''
+  const docType = rev.docType ?? ''
+  const docCode = rev.docCode ?? ''
+  const message = rev.message ?? ''
+  const timestamp = formatTimestamp(rev.timestamp ?? rev.createdAt ?? '')
+
+  if (message) {
+    return timestamp ? `${timestamp} — ${message}` : message
+  }
+
+  const parts = [timestamp, docType, docCode, action].filter(Boolean)
+  return parts.join(' ') || JSON.stringify(rev)
+}

--- a/src/views/documents/PIDetailPage.vue
+++ b/src/views/documents/PIDetailPage.vue
@@ -8,6 +8,7 @@ import ConfirmModal from '@/components/common/ConfirmModal.vue'
 import DetailPageHeader from '@/components/common/DetailPageHeader.vue'
 import SearchModal from '@/components/common/SearchModal.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
+import { formatRevisionEntry } from '@/utils/revisionFormat'
 import DocumentPreviewModal from '@/components/domain/document/DocumentPreviewModal.vue'
 import PIDocumentTemplate from '@/components/domain/document/PIDocumentTemplate.vue'
 import PIFormModal from '@/components/domain/document/PIFormModal.vue'
@@ -938,7 +939,7 @@ function cancelDeleteApprovalRequest() {
           <div class="space-y-1 text-xs text-slate-400">
             <template v-if="Array.isArray(detail.revisionHistory) && detail.revisionHistory.length">
               <div v-for="(rev, i) in detail.revisionHistory" :key="i" class="rounded border border-slate-100 bg-slate-50 px-2 py-1">
-                {{ typeof rev === 'string' ? rev : (rev.summary ?? rev.description ?? JSON.stringify(rev)) }}
+                {{ formatRevisionEntry(rev) }}
               </div>
             </template>
             <span v-else>변경 이력 없음</span>

--- a/src/views/documents/PLDetailPage.vue
+++ b/src/views/documents/PLDetailPage.vue
@@ -55,7 +55,7 @@ const summaryRows = computed(() => {
 
   return [
     { label: '거래처', value: detail.value.clientName },
-    { label: '총수량', value: detail.value.totalQuantity ? `${detail.value.totalQuantity} EA` : '-' },
+    { label: '총수량', value: detail.value.totalQuantity || '-' },
     { label: '총중량', value: detail.value.totalGrossWeight ? `${detail.value.totalGrossWeight} kg` : '-' },
     { label: '발행일', value: detail.value.issueDate || '-' },
   ]
@@ -69,7 +69,7 @@ const previewFields = computed(() => {
     { label: '거래처', value: detail.value.clientName },
     { label: '국가', value: detail.value.country },
     { label: '인코텀즈', value: detail.value.incoterms || '-' },
-    { label: '총수량', value: detail.value.totalQuantity ? `${detail.value.totalQuantity} EA` : '-' },
+    { label: '총수량', value: detail.value.totalQuantity || '-' },
     { label: '총중량', value: detail.value.totalGrossWeight ? `${detail.value.totalGrossWeight} kg` : '-' },
   ]
 })
@@ -202,7 +202,7 @@ function goToLinkedDocument(document) {
             <div><span class="text-slate-500">결제조건</span><div class="mt-0.5">{{ detail.paymentTerms || '-' }}</div></div>
             <div><span class="text-slate-500">Port of Discharge</span><div class="mt-0.5">{{ detail.portOfDischarge || '-' }}</div></div>
             <div><span class="text-slate-500">Sailing on or about</span><div class="mt-0.5">{{ detail.deliveryDate || '-' }}</div></div>
-            <div><span class="text-slate-500">총수량</span><div class="mt-0.5 font-semibold text-slate-900">{{ detail.totalQuantity ? `${detail.totalQuantity} EA` : '-' }}</div></div>
+            <div><span class="text-slate-500">총수량</span><div class="mt-0.5 font-semibold text-slate-900">{{ detail.totalQuantity || '-' }}</div></div>
             <div><span class="text-slate-500">총중량</span><div class="mt-0.5 font-semibold text-slate-900">{{ detail.totalGrossWeight ? `${detail.totalGrossWeight} kg` : '-' }}</div></div>
           </div>
         </div>

--- a/src/views/documents/PODetailPage.vue
+++ b/src/views/documents/PODetailPage.vue
@@ -8,6 +8,7 @@ import ConfirmModal from '@/components/common/ConfirmModal.vue'
 import DetailPageHeader from '@/components/common/DetailPageHeader.vue'
 import SearchModal from '@/components/common/SearchModal.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
+import { formatRevisionEntry } from '@/utils/revisionFormat'
 import DocumentPreviewModal from '@/components/domain/document/DocumentPreviewModal.vue'
 import PODocumentTemplate from '@/components/domain/document/PODocumentTemplate.vue'
 import POFormModal from '@/components/domain/document/POFormModal.vue'
@@ -1120,7 +1121,7 @@ function cancelDeleteApprovalRequest() {
           <div class="space-y-1 text-xs text-slate-400">
             <template v-if="Array.isArray(detail.revisionHistory) && detail.revisionHistory.length">
               <div v-for="(rev, i) in detail.revisionHistory" :key="i" class="rounded border border-slate-100 bg-slate-50 px-2 py-1">
-                {{ typeof rev === 'string' ? rev : (rev.summary ?? rev.description ?? JSON.stringify(rev)) }}
+                {{ formatRevisionEntry(rev) }}
               </div>
             </template>
             <span v-else>변경 이력 없음</span>


### PR DESCRIPTION
## 📋 작업 내용

QA 3차 리포트 잔여 이슈 일괄 수정.

### 변경이력 가독성 포맷
- `revisionFormat.js` 신규: revision JSON 객체를 `"2026/04/07 09:09 — PO 초안을 생성했습니다"` 형태로 변환
- PI/PO 상세: `formatRevisionEntry()` 적용 (raw JSON 표시 해소)

### 요청 시각 포맷
- PI/PO store: `approvalRequestedAt`에 `formatTimestamp()` 적용
- `2026-04-07T09:09:15.912553` → `2026/04/07 09:09`

### PL 총수량 단위 중복
- PLDetailPage: store에서 이미 "0 EA" 제공 → 템플릿의 추가 " EA" 제거

### CI/PL 거래처명 (DB 역채움)
- 기존 CI 2건, PL 2건에 PO에서 거래처 정보 역채움 완료 (ALTER TABLE + UPDATE)
- 거래처 도착항: PR #273에서 이미 수정 완료 (배포 대기)

## 🔗 관련 이슈

- closes #276

## ✅ 체크리스트

- [x] 정상 동작 확인 (빌드 성공)
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료