### PR TITLE
fix: QA 최종 일괄 — CI/PL 품목, 검색, 도착항, 사이드바

### DIFF
--- a/src/components/layout/AppSidebar.vue
+++ b/src/components/layout/AppSidebar.vue
@@ -43,7 +43,7 @@ function isActive(path) {
     return route.path === '/'
   }
 
-  return route.path.startsWith(path)
+  return route.path === path || route.path.startsWith(path + '/')
 }
 
 onMounted(async () => {

--- a/src/composables/useDocumentFilter.js
+++ b/src/composables/useDocumentFilter.js
@@ -1,4 +1,4 @@
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 
 /**
  * 문서 목록 페이지 공통 필터 composable
@@ -61,6 +61,15 @@ export function useDocumentFilter(rows, options = {}) {
   function applyFilters() {
     appliedFilters.value = { ...filters.value }
   }
+
+  // 키워드 입력 시 자동 필터링 (300ms 디바운스)
+  let keywordTimer = null
+  watch(() => filters.value.keyword, () => {
+    clearTimeout(keywordTimer)
+    keywordTimer = setTimeout(() => {
+      appliedFilters.value = { ...appliedFilters.value, keyword: filters.value.keyword }
+    }, 300)
+  })
 
   const filteredRows = computed(() => {
     const nextRows = rows.value.filter((row) => {

--- a/src/composables/useMasterLookup.js
+++ b/src/composables/useMasterLookup.js
@@ -27,7 +27,7 @@ export function useMasterLookup() {
   }
 
   function getPortName(portId) {
-    const found = ports.value.find((p) => String(p.id) === String(portId))
+    const found = ports.value.find((p) => String(p.portId ?? p.id) === String(portId))
     return found ? found.portName : '-'
   }
 

--- a/src/stores/ciDocuments.js
+++ b/src/stores/ciDocuments.js
@@ -19,8 +19,15 @@ function formatCurrencyAmount(amount, currencyCode) {
   return `${symbol}${formatNumber(amount, 0)}`
 }
 
+function parseJsonSafe(value, fallback = []) {
+  if (!value) return fallback
+  if (typeof value !== 'string') return Array.isArray(value) ? value : fallback
+  try { return JSON.parse(value) } catch { return fallback }
+}
+
 function mapCiResponse(row) {
-  const items = (row.items ?? []).map((item) => ({
+  const rawItems = row.items?.length ? row.items : parseJsonSafe(row.itemsSnapshot)
+  const items = rawItems.map((item) => ({
     name: item.itemName ?? item.name ?? '-',
     hsCode: item.hsCode ?? '-',
     quantity: String(item.quantity ?? 1),
@@ -58,6 +65,7 @@ function mapCiResponse(row) {
     shipmentOrderId: row.shipmentOrderId ?? '',
     remarks: row.remarks ?? '-',
     manager: row.managerName ?? '-',
+    linkedDocuments: parseJsonSafe(row.linkedDocuments),
     items,
   }
 }

--- a/src/stores/plDocuments.js
+++ b/src/stores/plDocuments.js
@@ -13,8 +13,15 @@ function formatNumber(value, maximumFractionDigits = 0) {
   })
 }
 
+function parseJsonSafe(value, fallback = []) {
+  if (!value) return fallback
+  if (typeof value !== 'string') return Array.isArray(value) ? value : fallback
+  try { return JSON.parse(value) } catch { return fallback }
+}
+
 function mapPlResponse(row) {
-  const items = (row.items ?? []).map((item) => ({
+  const rawItems = row.items?.length ? row.items : parseJsonSafe(row.itemsSnapshot)
+  const items = rawItems.map((item) => ({
     name: item.itemName ?? item.name ?? '-',
     quantity: String(item.quantity ?? 1),
     netWeight: formatNumber(Number(item.netWeight ?? 0), 2),
@@ -58,6 +65,7 @@ function mapPlResponse(row) {
     totalGrossWeight: formatNumber(totalGrossWeight, 2),
     totalMeasurement: formatNumber(totalMeasurement, 2),
     manager: row.managerName ?? '-',
+    linkedDocuments: parseJsonSafe(row.linkedDocuments),
     items,
   }
 }


### PR DESCRIPTION
## 📋 작업 내용

### CI/PL 품목 데이터 누락 (Critical)
- CI/PL은 아이템 테이블이 없고 JSON 스냅샷(`itemsSnapshot`)에만 저장됨
- `ciDocuments`/`plDocuments` store: `items` 없으면 `itemsSnapshot` JSON 파싱으로 대체
- `linkedDocuments` 파싱 추가 → 참조 문서 표시

### 검색 실시간 필터링 (Major)
- `useDocumentFilter`: keyword watch + 300ms 디바운스 추가
- 입력 즉시 자동 필터링 (PI/PO/CI/PL 등 모든 문서 목록에 일괄 반영)

### 거래처 도착항 "-" (Minor)
- `useMasterLookup`: `getPortName()`에서 `p.portId ?? p.id` 호환 처리

### 사이드바 active 오류 (Major)
- `AppSidebar`: `startsWith(path)` → `=== path || startsWith(path + '/')` 정확 매칭
- `/master/clients`와 `/master/items` 구분

### DB 확인 필요 (별도)
- 금액 불일치: PI `totalAmount` vs items 합산 확인
- PI 수정 모달 단가 0: `pi_items.pi_item_unit_price` 데이터 확인

## 🔗 관련 이슈

- closes #279

## ✅ 체크리스트

- [x] 정상 동작 확인 (빌드 성공)
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료