### PR TITLE
fix: 거래처 도착항 매핑 — portName 직접 사용

### DIFF
--- a/src/views/master/ClientListPage.vue
+++ b/src/views/master/ClientListPage.vue
@@ -81,7 +81,7 @@ const columns = [
 const enrichedClients = computed(() =>
   clients.value.map((c) => ({
     ...c,
-    portName: getPortName(c.portId),
+    portName: c.portName ?? getPortName(c.portId),
     paymentTermsCode: getPaymentTermsLabel(c.paymentTermsId),
     currencyCode: getCurrencyLabel(c.currencyId),
   })),


### PR DESCRIPTION
## 📋 작업 내용

거래처 목록 도착항 전부 "-" 표시 수정.
클라이언트 API 응답에 `portId`가 없고 `portName`이 직접 포함되어 있어서
`getPortName(portId)` lookup이 항상 실패하던 문제.

`c.portName` 우선 사용, fallback으로 `getPortName(c.portId)`.

## 🔗 관련 이슈

- closes #280

## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료