### PR TITLE
fix: PI 수정 모달 — 통화 KRW 누락, 단가 덮어쓰기, 인코텀즈 NaN

### DIFF
--- a/src/components/domain/document/PIFormModal.vue
+++ b/src/components/domain/document/PIFormModal.vue
@@ -41,7 +41,7 @@ const props = defineProps({
 const emit = defineEmits(['close', 'save', 'open-client-search'])
 const { error } = useToast()
 
-const defaultCurrencyOptions = ['USD', 'EUR', 'JPY', 'GBP', 'AUD', 'CAD', 'SGD', 'AED', 'CNY', 'MYR', 'THB', 'VND', 'IDR', 'INR', 'SAR', 'BRL', 'SEK', 'CHF']
+const defaultCurrencyOptions = ['KRW', 'USD', 'EUR', 'JPY', 'GBP', 'AUD', 'CAD', 'SGD', 'AED', 'CNY', 'MYR', 'THB', 'VND', 'IDR', 'INR', 'SAR', 'BRL', 'SEK', 'CHF']
 const defaultBuyerOptions = [
   'Mr. Ahmad Razak (Purchasing Manager)',
   'Ms. Siti Nurhaliza (Director)',
@@ -304,7 +304,7 @@ async function loadReferenceData() {
         nameKr: item.incotermNameKr,
         description: item.incotermDescription,
         transportMode: item.incotermTransportMode,
-        sellerSegments: Number(item.incotermSellerSegments ?? 6),
+        sellerSegments: Number(item.incotermSellerSegments) || 6,
         defaultNamedPlace: item.incotermDefaultNamedPlace ?? '',
         namedPlacePlaceholder: item.namedPlacePlaceholder ?? '',
       }))
@@ -638,29 +638,8 @@ async function initializeForm() {
       approver: getDefaultApprover(),
       items: props.document.items?.map(normalizeEditItem) ?? [],
     }
-    form.value.items.forEach((itemRow) => {
-      const matchedProduct = findProductByName(itemRow.name)
-
-      if (!matchedProduct) {
-        updateItemAmount(itemRow)
-        return
-      }
-
-      if (!String(itemRow.unit ?? '').trim()) {
-        itemRow.unit = matchedProduct.unit || ''
-      }
-
-      if (parseNumericInput(itemRow.unitPrice) <= 0) {
-        applyCatalogItemToRow(itemRow, itemRow.name)
-        return
-      }
-
-      if (matchedProduct.source === 'catalog') {
-        itemRow.baseUnitPrice = Number(matchedProduct.unitPrice ?? 0)
-      }
-
-      updateItemAmount(itemRow)
-    })
+    // loadReferenceData 전: catalog 없이 기존 데이터 기반으로 금액만 계산
+    form.value.items.forEach((itemRow) => updateItemAmount(itemRow))
     await loadReferenceData()
     form.value.items.forEach((itemRow) => {
       const matchedProduct = findProductByName(itemRow.name)


### PR DESCRIPTION
## 📋 작업 내용

### 통화 필드 빈 값
- `defaultCurrencyOptions`에 KRW 추가 (기존에 누락되어 있었음)
- `loadReferenceData()` 완료 전에도 KRW 선택 가능

### 단가/금액 0 표시
- edit 모드 `initializeForm()`: `loadReferenceData()` 전 첫 번째 forEach에서 catalog 매칭 로직 제거
- catalog 로드 전에 `applyCatalogItemToRow()`가 단가를 0으로 덮어쓰던 문제 해결
- `loadReferenceData()` 후 두 번째 forEach에서 정상 catalog 매칭

### 인코텀즈 "인도자 NaN구간"
- `sellerSegments` 파싱: `Number(val ?? 6)` → `Number(val) || 6`
- 빈 문자열 `""` → `NaN` → fallback `6`으로 처리

## 🔗 관련 이슈

- closes #282

## ✅ 체크리스트

- [x] 정상 동작 확인 (빌드 성공)
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료