### PR TITLE
fix: PI 통화 드롭다운 빈 값 — currency.code → currencyCode

### DIFF
--- a/src/components/domain/document/PIFormModal.vue
+++ b/src/components/domain/document/PIFormModal.vue
@@ -280,7 +280,7 @@ async function loadReferenceData() {
       email: client.email ?? '',
     }))
 
-    currencyOptions.value = currenciesData.map((currency) => currency.code).filter(Boolean)
+    currencyOptions.value = currenciesData.map((currency) => currency.currencyCode ?? currency.code).filter(Boolean)
     productCatalog.value = itemsData
       .filter((item) => item.itemStatus === 'active')
       .map((item) => ({


### PR DESCRIPTION
## 📋 작업 내용

PI 수정 모달 통화 드롭다운이 빈 값으로 표시되던 문제 수정.
\`currenciesData.map(c => c.code)\` → API 필드명은 \`currencyCode\`라 전부 undefined → select 매칭 실패.

\`c.currencyCode ?? c.code\` 호환 처리.

## 🔗 관련 이슈

- closes #284

## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌 해결 완료