### PR TITLE
fix: 활동기록/패키지 PO 검색 — id → poId 필드 매핑

### DIFF
--- a/src/views/activity/ActivityCreatePage.vue
+++ b/src/views/activity/ActivityCreatePage.vue
@@ -176,9 +176,9 @@ const poList = ref([])
 const poKeyword = ref('')
 
 const poColumns = [
-  { key: 'id',           label: 'PO번호'  },
+  { key: 'poId',         label: 'PO번호'  },
   { key: 'issueDate',    label: '등록일'  },
-  { key: 'manager',      label: '담당자명' },
+  { key: 'managerName',  label: '담당자명' },
   { key: 'country',      label: '국가'    },
   { key: 'deliveryDate', label: '납기일'  },
 ]
@@ -187,7 +187,7 @@ const filteredPoList = computed(() => {
   if (!poKeyword.value) return poList.value
   const kw = poKeyword.value.toLowerCase()
   return poList.value.filter(
-    (p) => p.id.toLowerCase().includes(kw) || (p.title ?? '').toLowerCase().includes(kw),
+    (p) => String(p.poId ?? '').toLowerCase().includes(kw) || (p.title ?? '').toLowerCase().includes(kw),
   )
 })
 
@@ -207,8 +207,8 @@ async function openPoSearch() {
 }
 
 function selectPO(po) {
-  formPoDisplay.value = po.id
-  formPoId.value = po.id
+  formPoDisplay.value = po.poId
+  formPoId.value = po.poId
   formAuthor.value = authStore.currentUser?.userName ?? ''
   isPoSearchOpen.value = false
 }

--- a/src/views/package/ActivityPackagePage.vue
+++ b/src/views/package/ActivityPackagePage.vue
@@ -90,9 +90,9 @@ async function loadPackageForEdit() {
 }
 
 const poColumns = [
-  { key: 'id',           label: 'PO번호'  },
+  { key: 'poId',         label: 'PO번호'  },
   { key: 'issueDate',    label: '등록일'  },
-  { key: 'manager',      label: '담당자명' },
+  { key: 'managerName',  label: '담당자명' },
   { key: 'country',      label: '국가'    },
   { key: 'deliveryDate', label: '납기일'  },
 ]
@@ -112,13 +112,13 @@ const filteredPoList = computed(() => {
   const q = poSearchKeyword.value.trim().toLowerCase()
   if (!q) return list
   return list.filter(
-    (p) => p.id.toLowerCase().includes(q) || (p.title ?? '').toLowerCase().includes(q),
+    (p) => String(p.poId ?? '').toLowerCase().includes(q) || (p.title ?? '').toLowerCase().includes(q),
   )
 })
 
 function selectPo(po) {
-  selectedPoId.value = po.id
-  poDisplay.value = po.id
+  selectedPoId.value = po.poId
+  poDisplay.value = po.poId
   isPoModalOpen.value = false
   poSearchKeyword.value = ''
 }


### PR DESCRIPTION
## 📋 작업 내용

활동기록 등록 + 활동 패키지 작성 시 PO 검색 모달에서
PO번호가 '-'로 표시되고 행 클릭 시 선택되지 않던 문제 수정.

PO API 응답 필드는 \`poId\`인데 SearchModal column key가 \`id\`로 되어 있어
\`p.id\` 접근이 undefined → '-' 표시 + filter/select 동작 불가.

- \`poColumns\` key 'id' → 'poId', 'manager' → 'managerName'
- \`filteredPoList\` filter: p.id → p.poId
- \`selectPO\`/\`selectPo\`: po.id → po.poId

## 🔗 관련 이슈

- closes #286

## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌 해결 완료