### PR TITLE
fix: 사용자 관리 부서 중복 + SearchModal rowKey prop

### DIFF
--- a/src/components/common/SearchModal.vue
+++ b/src/components/common/SearchModal.vue
@@ -32,7 +32,15 @@ const props = defineProps({
     type: String,
     default: 'max-w-6xl',
   },
+  rowKey: {
+    type: String,
+    default: 'id',
+  },
 })
+
+function getRowKey(row) {
+  return row[props.rowKey] ?? row.id ?? JSON.stringify(row)
+}
 
 const emit = defineEmits(['close', 'update:searchKeyword', 'select'])
 
@@ -113,7 +121,7 @@ function getCellValue(row, column) {
             <tr
               v-for="row in rows"
               v-else
-              :key="row.id ?? JSON.stringify(row)"
+              :key="getRowKey(row)"
               class="cursor-pointer transition hover:bg-slate-50"
               @click="$emit('select', row)"
             >

--- a/src/components/domain/auth/UserListTab.vue
+++ b/src/components/domain/auth/UserListTab.vue
@@ -52,10 +52,17 @@ async function loadData() {
     ])
     users.value = usersData
     positions.value = positionsData
-    departments.value = departmentsData
+    // 부서 중복 제거 (JPA 연관관계 조인 시 동일 부서 중복 방지)
+    const seenDeptIds = new Set()
+    departments.value = (departmentsData ?? []).filter((d) => {
+      const id = String(d.departmentId ?? d.id ?? '')
+      if (!id || seenDeptIds.has(id)) return false
+      seenDeptIds.add(id)
+      return true
+    })
     // 첫 번째 부서 펼치기
-    if (departmentsData.length > 0) {
-      expandedDepts.value = new Set([departmentsData[0].departmentId])
+    if (departments.value.length > 0) {
+      expandedDepts.value = new Set([departments.value[0].departmentId ?? departments.value[0].id])
     }
   } catch (e) {
     error('데이터를 불러오는 중 오류가 발생했습니다.')

--- a/src/views/activity/ActivityCreatePage.vue
+++ b/src/views/activity/ActivityCreatePage.vue
@@ -467,6 +467,7 @@ async function handleSubmit() {
     <SearchModal
       :open="isPoSearchOpen"
       title="PO 검색"
+      row-key="poId"
       :columns="poColumns"
       :rows="filteredPoList"
       :search-keyword="poKeyword"

--- a/src/views/package/ActivityPackagePage.vue
+++ b/src/views/package/ActivityPackagePage.vue
@@ -667,6 +667,7 @@ async function savePackage() {
     <SearchModal
       :open="isPoModalOpen"
       title="수주건 (PO) 검색"
+      row-key="poId"
       :columns="poColumns"
       :rows="filteredPoList"
       :search-keyword="poSearchKeyword"


### PR DESCRIPTION
## 📋 작업 내용

### 사용자 관리 부서 19회 중복 렌더링
- \`UserListTab.loadData()\`: departments 응답을 \`departmentId\` 기준 dedupe
- JPA 연관관계 조인으로 인해 동일 부서가 여러 번 응답되던 문제 방어
- 하단 통계 "총 76개 팀 152명" → "총 4개 팀 8명" 정상화 예상

### 활동기록 PO 검색 행 선택 불가
- \`SearchModal\`: \`rowKey\` prop 추가 (default: 'id')
- \`ActivityCreatePage\`/\`ActivityPackagePage\`: \`row-key="poId"\` 지정
- PO 데이터에 \`id\` 필드가 없어서 Vue key가 \`JSON.stringify(row)\`로 fallback되던 문제

## 🔗 관련 이슈

- closes #288

## ✅ 체크리스트

- [x] 정상 동작 확인 (빌드 성공)
- [x] 불필요한 코드/주석 제거
- [x] 충돌 해결 완료