### PR TITLE
fix: QA 5차 일괄 — 품목 규격 + 패키지 렌더링 + PO 유효성 + 수정 모달 + 코드 자동생성

### DIFF
--- a/src/components/domain/master/ItemFormModal.vue
+++ b/src/components/domain/master/ItemFormModal.vue
@@ -89,15 +89,15 @@ watch(
   (isOpen) => {
     errors.value = {}
     if (isOpen && props.mode === 'edit' && props.item) {
-      const spec = parseSpec(props.item.itemSpec ?? props.item.spec)
+      const specFallback = parseSpec(props.item.itemSpec ?? props.item.spec)
       form.value = {
         code: props.item.itemCode ?? props.item.code ?? '',
         name: props.item.itemName ?? props.item.name ?? '',
         nameKr: props.item.itemNameKr ?? props.item.nameKr ?? '',
         category: props.item.itemCategory ?? props.item.category ?? '',
-        specWidth: spec.width,
-        specDepth: spec.depth,
-        specHeight: spec.height,
+        specWidth: props.item.itemWidth ?? specFallback.width,
+        specDepth: props.item.itemDepth ?? specFallback.depth,
+        specHeight: props.item.itemHeight ?? specFallback.height,
         unit: props.item.itemUnit ?? props.item.unit ?? '',
         packUnit: props.item.itemPackUnit ?? props.item.packUnit ?? '',
         unitPrice: props.item.itemUnitPrice ?? props.item.unitPrice ?? '',
@@ -166,13 +166,15 @@ function validate() {
   ]
   for (const { key, label } of dimFields) {
     const val = form.value[key]
-    if (val !== '' && val !== null && val !== undefined) {
-      const num = Number(val)
-      if (Number.isNaN(num) || num <= 0) {
-        e[key] = `${label}는 양수를 입력하세요.`
-      } else if (num > NUM_RANGE.DIMENSION_MAX) {
-        e[key] = `${label}는 ${NUM_RANGE.DIMENSION_MAX.toLocaleString()}mm 이하로 입력하세요.`
-      }
+    if (val === '' || val === null || val === undefined) {
+      e[key] = `${label}를 입력하세요.`
+      continue
+    }
+    const num = Number(val)
+    if (Number.isNaN(num) || num <= 0 || !Number.isInteger(num)) {
+      e[key] = `${label}는 양의 정수를 입력하세요.`
+    } else if (num > NUM_RANGE.DIMENSION_MAX) {
+      e[key] = `${label}는 ${NUM_RANGE.DIMENSION_MAX.toLocaleString()}mm 이하로 입력하세요.`
     }
   }
 
@@ -194,6 +196,9 @@ function handleSave() {
     itemNameKr: form.value.nameKr,
     itemCategory: form.value.category,
     itemSpec: specStr,
+    itemWidth: Number(form.value.specWidth),
+    itemDepth: Number(form.value.specDepth),
+    itemHeight: Number(form.value.specHeight),
     itemUnit: form.value.unit,
     itemPackUnit: form.value.packUnit,
     itemUnitPrice: Number(form.value.unitPrice),
@@ -239,13 +244,13 @@ function handleSave() {
       <div>
         <h4 class="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400">규격 / 단위</h4>
         <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
-          <FormField label="규격 (W × D × H)" class="md:col-span-2">
+          <FormField label="규격 (W × D × H)" required class="md:col-span-2">
             <div class="flex items-center gap-2">
-              <BaseTextField v-model="form.specWidth" placeholder="W" />
+              <BaseTextField v-model="form.specWidth" type="number" placeholder="W" min="1" :max="NUM_RANGE.DIMENSION_MAX" inputmode="numeric" />
               <span class="text-xs text-slate-400">×</span>
-              <BaseTextField v-model="form.specDepth" placeholder="D" />
+              <BaseTextField v-model="form.specDepth" type="number" placeholder="D" min="1" :max="NUM_RANGE.DIMENSION_MAX" inputmode="numeric" />
               <span class="text-xs text-slate-400">×</span>
-              <BaseTextField v-model="form.specHeight" placeholder="H" />
+              <BaseTextField v-model="form.specHeight" type="number" placeholder="H" min="1" :max="NUM_RANGE.DIMENSION_MAX" inputmode="numeric" />
               <span class="text-xs text-slate-500">mm</span>
             </div>
             <p v-if="errors.specWidth" class="mt-1 text-xs text-red-500">{{ errors.specWidth }}</p>


### PR DESCRIPTION
## 📋 작업 내용

### 1. 품목 규격 W/D/H (Critical)
- 숫자 전용 + 필수값 + 개별 필드 저장
- 백엔드 Item 엔티티 + DTO + Service에 W/D/H 컬럼 반영 (별도 master PR 완료)

### 2. 활동기록 패키지 렌더링 실패 (Critical)
- \`api.get('/departments'/'/positions')\` raw 응답 → \`fetchDepartments/fetchPositions\`로 교체
  (HATEOAS unwrap 적용, \`.map\` TypeError 해소)
- 배열 방어 (\`Array.isArray\` 체크)
- 재직 필터: \`userStatus === 'active'\` 기반

### 3. PO 등록 유효성 검증 (Critical)
- \`POFormModal\`: 거래처/납기일/통화/결재자 필수 체크
- 에러 메시지 UI 바인딩

### 4. 수정 모달 필드 미로딩 (Major)
- \`ClientFormModal\`: countryName/portName 기반 ID 역매핑 fallback
- \`UserFormModal\`: positionName/departmentName 기반 ID 역매핑 fallback

### 5. 수정 모달 제목 (Major)
- Item/Client 모달 제목: \`item.name\` → \`item.itemName\`, \`client.name\` → \`client.clientName\`

### 6. 코드 자동 생성 (동시성 이슈 방지)
- 생성 모달에서 코드 필드 숨김 (create 모드)
- payload에서 create 시 \`clientCode\`/\`itemCode\` 제거
- 백엔드 \`ClientCommandService\`/\`ItemCommandService\`: code 미제공 시 auto-generate (master main 반영)

## 🔗 관련 이슈

- closes #290
- closes #288

## ✅ 체크리스트

- [x] 정상 동작 확인 (빌드 성공)
- [x] 불필요한 코드/주석 제거
- [x] 충돌 해결 완료

## 💬 리뷰어에게

- 배포 후 \`ALTER TABLE items ADD COLUMN item_width/item_depth/item_height INT UNSIGNED NULL\` 실행 필요
- backend-master 재배포 필수 (auto-generate 로직)