### PR TITLE
fix: QA 5차 잔여 — 패키지 렌더링, PO 유효성, 수정 모달, 코드 자동생성

### DIFF
--- a/src/components/domain/auth/UserFormModal.vue
+++ b/src/components/domain/auth/UserFormModal.vue
@@ -59,12 +59,21 @@ watch(
   (isOpen) => {
     errors.value = {}
     if (isOpen && props.mode === 'edit' && props.user) {
+      // positionName/departmentName 기반 ID 역매핑 fallback
+      const resolvedPositionId = props.user.positionId
+        ?? props.positions.find((p) => (p.positionName ?? p.name) === props.user.positionName)?.positionId
+        ?? props.positions.find((p) => (p.positionName ?? p.name) === props.user.positionName)?.id
+        ?? ''
+      const resolvedDepartmentId = props.user.departmentId
+        ?? props.departments.find((d) => (d.departmentName ?? d.name) === props.user.departmentName)?.departmentId
+        ?? props.departments.find((d) => (d.departmentName ?? d.name) === props.user.departmentName)?.id
+        ?? ''
       form.value = {
         name: props.user.userName ?? props.user.name ?? '',
         email: props.user.userEmail ?? props.user.email ?? '',
-        positionId: String(props.user.positionId ?? ''),
+        positionId: String(resolvedPositionId),
         role: props.user.userRole ?? props.user.role ?? '',
-        departmentId: String(props.user.departmentId ?? ''),
+        departmentId: String(resolvedDepartmentId),
         status: props.user.userStatus ?? props.user.status ?? 'active',
         transferDepartmentId: '',
         transferReason: '',

--- a/src/components/domain/document/POFormModal.vue
+++ b/src/components/domain/document/POFormModal.vue
@@ -31,6 +31,7 @@ function createInitialForm() {
 }
 
 const form = ref(createInitialForm())
+const errors = ref({})
 const approverOptions = ref([...defaultApproverOptions])
 const isLinkedToPi = computed(() => Boolean(form.value.linkedPiId))
 const isDeliveryDateLocked = computed(() => isLinkedToPi.value && !form.value.deliveryDateOverride)
@@ -98,7 +99,18 @@ function clearLinkedPi() {
   form.value.deliveryDateOverride = false
 }
 
+function validate() {
+  const e = {}
+  if (!form.value.clientName?.trim()) e.clientName = '거래처를 선택해주세요.'
+  if (!form.value.deliveryDate) e.deliveryDate = '납기일을 입력해주세요.'
+  if (!form.value.currency?.trim()) e.currency = '통화가 지정되지 않았습니다.'
+  if (!form.value.approver?.trim()) e.approver = '결재자를 선택해주세요.'
+  errors.value = e
+  return Object.keys(e).length === 0
+}
+
 function handleSave() {
+  if (!validate()) return
   emit('save', { ...form.value })
 }
 
@@ -213,7 +225,8 @@ watch(
               <i class="fas fa-search text-xs" aria-hidden="true"></i>
             </button>
           </div>
-          <p v-if="isLinkedToPi" class="mt-1 text-xs text-slate-500">
+          <p v-if="errors.clientName" class="mt-1 text-xs text-red-500">{{ errors.clientName }}</p>
+          <p v-else-if="isLinkedToPi" class="mt-1 text-xs text-slate-500">
             연결된 PI의 거래처를 기준값으로 사용합니다.
           </p>
         </div>
@@ -226,6 +239,7 @@ watch(
             readonly
             class="w-full rounded-lg border border-slate-300 bg-slate-100 px-3 py-2 text-slate-500"
           >
+          <p v-if="errors.currency" class="mt-1 text-xs text-red-500">{{ errors.currency }}</p>
         </div>
       </div>
 
@@ -254,7 +268,8 @@ watch(
               isDeliveryDateLocked ? 'cursor-not-allowed bg-slate-100 text-slate-500' : '',
             ]"
           >
-          <p v-if="isLinkedToPi && form.sourceDeliveryDate" class="mt-1 text-xs text-slate-500">
+          <p v-if="errors.deliveryDate" class="mt-1 text-xs text-red-500">{{ errors.deliveryDate }}</p>
+          <p v-else-if="isLinkedToPi && form.sourceDeliveryDate" class="mt-1 text-xs text-slate-500">
             PI 기준 납기일: {{ form.sourceDeliveryDate }}
           </p>
         </div>
@@ -274,6 +289,7 @@ watch(
           :options="approverOptions"
           placeholder="결재자 선택"
         />
+        <p v-if="errors.approver" class="mt-1 text-xs text-red-500">{{ errors.approver }}</p>
       </div>
 
       <p class="text-xs text-gray-400">

--- a/src/components/domain/master/ClientFormModal.vue
+++ b/src/components/domain/master/ClientFormModal.vue
@@ -101,13 +101,20 @@ watch(
   (isOpen) => {
     errors.value = {}
     if (isOpen && props.mode === 'edit' && props.client) {
+      // countryName/portName 기반 ID 역매핑 fallback
+      const resolvedCountryId = props.client.countryId
+        ?? props.countries.find((c) => c.countryName === props.client.countryName)?.countryId
+        ?? null
+      const resolvedPortId = props.client.portId
+        ?? props.ports.find((p) => p.portName === props.client.portName)?.id
+        ?? null
       form.value = {
         code: props.client.clientCode ?? '',
         name: props.client.clientName ?? '',
         nameKr: props.client.clientNameKr ?? '',
-        countryId: props.client.countryId ?? null,
+        countryId: resolvedCountryId,
         city: props.client.clientCity ?? '',
-        portId: props.client.portId ?? null,
+        portId: resolvedPortId,
         address: props.client.clientAddress ?? '',
         tel: props.client.clientTel ?? '',
         email: props.client.clientEmail ?? '',
@@ -144,15 +151,7 @@ watch(
 function validate() {
   const e = {}
 
-  if (!form.value.code?.trim()) {
-    e.code = '코드를 입력하세요.'
-  } else if (
-    props.allClients.some(
-      (c) => c.clientCode.toLowerCase() === form.value.code.trim().toLowerCase() && (c.clientId ?? c.id) !== (props.client?.clientId ?? props.client?.id),
-    )
-  ) {
-    e.code = '이미 사용 중인 코드입니다.'
-  }
+  // 코드는 백엔드 auto-generate (create 모드), 수정 모드는 disabled
 
   if (!form.value.name?.trim()) {
     e.name = '영문 거래처명을 입력하세요.'
@@ -195,7 +194,8 @@ function validate() {
 function handleSave() {
   if (!validate()) return
   const payload = {
-    clientCode: form.value.code,
+    // 생성 시 code는 백엔드 auto-generate, 수정 시만 기존 code 유지
+    ...(props.mode === 'edit' ? { clientCode: form.value.code } : {}),
     clientName: form.value.name,
     clientNameKr: form.value.nameKr,
     countryId: form.value.countryId,
@@ -215,7 +215,7 @@ function handleSave() {
 <template>
   <BaseModal
     :open="open"
-    :title="mode === 'create' ? '거래처 등록' : `거래처 수정 – ${client?.name ?? ''}`"
+    :title="mode === 'create' ? '거래처 등록' : `거래처 수정 – ${client?.clientName ?? client?.name ?? ''}`"
     width="max-w-3xl"
     @close="emit('close')"
   >
@@ -224,9 +224,8 @@ function handleSave() {
       <div>
         <h4 class="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400">기본 정보</h4>
         <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
-          <FormField label="코드" required>
-            <BaseTextField v-model="form.code" placeholder="예) CLI011" :disabled="mode === 'edit'" />
-            <p v-if="errors.code" class="mt-1 text-xs text-red-500">{{ errors.code }}</p>
+          <FormField v-if="mode === 'edit'" label="코드">
+            <BaseTextField v-model="form.code" disabled />
           </FormField>
           <FormField label="영문 거래처명" required>
             <BaseTextField v-model="form.name" placeholder="영문 거래처명을 입력하세요" />

--- a/src/components/domain/master/ItemFormModal.vue
+++ b/src/components/domain/master/ItemFormModal.vue
@@ -107,7 +107,7 @@ watch(
       }
     } else if (isOpen && props.mode === 'create') {
       form.value = getInitialForm()
-      form.value.code = generateNextCode()
+      // 코드는 백엔드 auto-generate
     }
   },
 )
@@ -115,15 +115,7 @@ watch(
 function validate() {
   const e = {}
 
-  if (!form.value.code?.trim()) {
-    e.code = '코드를 입력하세요.'
-  } else if (
-    props.allItems.some(
-      (i) => (i.itemCode ?? i.code).toLowerCase() === form.value.code.trim().toLowerCase() && i.id !== props.item?.id,
-    )
-  ) {
-    e.code = '이미 사용 중인 코드입니다.'
-  }
+  // 코드는 백엔드 auto-generate (create 모드), 수정 모드는 disabled
 
   if (!form.value.name?.trim()) {
     e.name = '품목명을 입력하세요.'
@@ -191,7 +183,8 @@ function handleSave() {
   const specStr = spec ? `${spec} mm` : ''
 
   const payload = {
-    itemCode: form.value.code,
+    // 생성 시 code는 백엔드 auto-generate, 수정 시만 기존 code 유지
+    ...(props.mode === 'edit' ? { itemCode: form.value.code } : {}),
     itemName: form.value.name,
     itemNameKr: form.value.nameKr,
     itemCategory: form.value.category,
@@ -214,7 +207,7 @@ function handleSave() {
 <template>
   <BaseModal
     :open="open"
-    :title="mode === 'create' ? '품목 등록' : `품목 수정 – ${item?.name ?? ''}`"
+    :title="mode === 'create' ? '품목 등록' : `품목 수정 – ${item?.itemName ?? item?.name ?? ''}`"
     width="max-w-2xl"
     @close="emit('close')"
   >
@@ -223,9 +216,8 @@ function handleSave() {
       <div>
         <h4 class="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400">기본 정보</h4>
         <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
-          <FormField label="코드" required>
-            <BaseTextField v-model="form.code" placeholder="예) ITM011" :disabled="mode === 'edit'" />
-            <p v-if="errors.code" class="mt-1 text-xs text-red-500">{{ errors.code }}</p>
+          <FormField v-if="mode === 'edit'" label="코드">
+            <BaseTextField v-model="form.code" disabled />
           </FormField>
           <FormField label="품목명 (영문)" required>
             <BaseTextField v-model="form.name" placeholder="영문 품목명을 입력하세요" />

--- a/src/views/package/ActivityPackagePage.vue
+++ b/src/views/package/ActivityPackagePage.vue
@@ -2,7 +2,7 @@
 import { computed, nextTick, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { fetchActivities, fetchAllActivityPOs } from '@/api/activity'
-import { api } from '@/lib/api'
+import { fetchDepartments, fetchPositions } from '@/api/auth'
 import { createPackage, fetchAllUsers, fetchPackageById, updatePackage } from '@/api/package'
 import { useToast } from '@/composables/useToast'
 import { useAuthStore } from '@/stores/auth'
@@ -55,14 +55,16 @@ onMounted(async () => {
       fetchActivities(),
       fetchAllActivityPOs(),
       fetchAllUsers(),
-      api.get('/departments').then(r => r.data),
-      api.get('/positions').then(r => r.data),
+      fetchDepartments(),
+      fetchPositions(),
     ])
-    activities.value = actData
-    poList.value = poData
-    allUsers.value = userData.filter((u) => u.status === '재직')
-    departments.value = deptData
-    positions.value = posData
+    activities.value = Array.isArray(actData) ? actData : []
+    poList.value = Array.isArray(poData) ? poData : []
+    allUsers.value = (Array.isArray(userData) ? userData : []).filter(
+      (u) => u.userStatus === 'active' || u.status === 'active' || u.status === '재직',
+    )
+    departments.value = Array.isArray(deptData) ? deptData : []
+    positions.value = Array.isArray(posData) ? posData : []
 
     if (isEditMode.value) {
       await loadPackageForEdit()


### PR DESCRIPTION
## 📋 작업 내용

### 1. 활동기록 패키지 렌더링 실패 (Critical)
- \`api.get('/departments'/'/positions')\` raw → \`fetchDepartments/fetchPositions\` (HATEOAS unwrap)
- \`.map is not a function\` TypeError 해소
- 배열 방어 + 재직 필터 \`userStatus === 'active'\`

### 2. PO 등록 유효성 검증 (Critical)
- \`POFormModal\`: 거래처/납기일/통화/결재자 필수 체크
- 에러 메시지 UI

### 3. 수정 모달 필드 미로딩 (Major)
- \`ClientFormModal\`: countryName/portName → ID 역매핑
- \`UserFormModal\`: positionName/departmentName → ID 역매핑

### 4. 수정 모달 제목 (Major)
- Client/Item: \`client.name\`/\`item.name\` → \`clientName\`/\`itemName\`

### 5. 코드 자동생성 (동시성 이슈 방지)
- 생성 모달에서 코드 필드 숨김
- payload create 시 \`clientCode\`/\`itemCode\` 제거
- 백엔드 \`ClientCommandService\`/\`ItemCommandService\`가 서버에서 생성 (master main 반영)

## 🔗 관련 이슈

- closes #292

## ✅ 체크리스트

- [x] 빌드 성공
- [x] 불필요한 코드/주석 제거
- [x] 충돌 해결 완료

## 💬 리뷰어에게

- backend-master 재배포 필수 (auto-generate 로직)