### PR TITLE
fix: QA 6차 — 거래처 삭제 + 상세검색 드롭다운 + 담당자 필드 명확화

### DIFF
--- a/src/components/domain/master/ClientFormModal.vue
+++ b/src/components/domain/master/ClientFormModal.vue
@@ -261,8 +261,9 @@ function handleSave() {
       <div>
         <h4 class="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400">연락처</h4>
         <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
-          <FormField label="담당자">
-            <BaseTextField v-model="form.manager" placeholder="담당자명을 입력하세요" />
+          <FormField label="거래처 담당자 (바이어)">
+            <BaseTextField v-model="form.manager" placeholder="거래처 측 바이어 이름 (예: Mr. Ahmad Razak)" />
+            <p class="mt-1 text-xs text-slate-400">거래처 내 주 연락 담당자(바이어). 추가 바이어는 바이어 관리에서 등록합니다.</p>
           </FormField>
           <FormField label="TEL" required>
             <BaseTextField

--- a/src/views/master/ClientListPage.vue
+++ b/src/views/master/ClientListPage.vue
@@ -81,14 +81,18 @@ const columns = [
 const enrichedClients = computed(() =>
   clients.value.map((c) => ({
     ...c,
+    countryName: c.countryName ?? getCountryName(c.countryId),
     portName: c.portName ?? getPortName(c.portId),
     paymentTermsCode: getPaymentTermsLabel(c.paymentTermsId),
     currencyCode: getCurrencyLabel(c.currencyId),
   })),
 )
 
+// 전체 countries 마스터에서 국가 옵션 (거래처에 없는 국가도 선택 가능)
 const countryOptions = computed(() => {
-  const countrySet = [...new Set(enrichedClients.value.map((c) => c.countryName).filter(Boolean))]
+  const fromMaster = countries.value.map((c) => c.countryName).filter(Boolean)
+  const fromClients = enrichedClients.value.map((c) => c.countryName).filter(Boolean)
+  const countrySet = [...new Set([...fromMaster, ...fromClients])]
   return [{ label: '전체', value: '' }, ...countrySet.map((name) => ({ label: name, value: name }))]
 })
 
@@ -193,10 +197,16 @@ async function handleDelete() {
   if (!clientToDelete.value || deleting.value) return
   deleting.value = true
   try {
-    await changeClientStatus(clientToDelete.value.clientId, 'inactive')
+    const id = clientToDelete.value.clientId ?? clientToDelete.value.id
+    if (!id) {
+      error('거래처 ID가 없습니다.')
+      return
+    }
+    await changeClientStatus(id, 'inactive')
     success(`${clientToDelete.value.clientName} 거래처가 비활성화되었습니다.`)
     await loadData()
-  } catch {
+  } catch (e) {
+    console.error('거래처 삭제 실패', e)
     error('삭제 중 오류가 발생했습니다.')
   } finally {
     showConfirmModal.value = false

--- a/src/views/master/ClientListPage.vue
+++ b/src/views/master/ClientListPage.vue
@@ -73,7 +73,7 @@ const columns = [
   { key: 'port', label: '도착항', width: '120px' },
   { key: 'paymentTerms', label: '결제조건', width: '100px', align: 'center' },
   { key: 'currency', label: '통화', width: '80px', align: 'center' },
-  { key: 'clientManager', label: '담당자', width: '120px' },
+  { key: 'clientManager', label: '거래처 담당자', width: '140px' },
   { key: 'clientStatus', label: '상태', width: '80px', align: 'center' },
   { key: 'actions', label: '', width: '120px', align: 'center', sortable: false },
 ]

--- a/src/views/master/ItemListPage.vue
+++ b/src/views/master/ItemListPage.vue
@@ -49,8 +49,10 @@ const statusOptions = [
   { label: '비활성', value: 'inactive' },
 ]
 
+const DEFAULT_UNITS = ['EA', 'KG', 'MT', 'SET']
 const unitOptions = computed(() => {
-  const units = [...new Set(items.value.map((i) => i.itemUnit).filter(Boolean))]
+  const fromItems = items.value.map((i) => i.itemUnit).filter(Boolean)
+  const units = [...new Set([...DEFAULT_UNITS, ...fromItems])]
   return [{ label: '전체', value: '' }, ...units.map((u) => ({ label: u, value: u }))]
 })
 
@@ -75,8 +77,10 @@ const selectedItem = ref(null)
 const showConfirmModal = ref(false)
 const itemToDelete = ref(null)
 
+const DEFAULT_CATEGORIES = ['Steel', 'Pipe', 'Oil', 'Machinery']
 const categoryOptions = computed(() => {
-  const cats = [...new Set(items.value.map((i) => i.itemCategory).filter(Boolean))]
+  const fromItems = items.value.map((i) => i.itemCategory).filter(Boolean)
+  const cats = [...new Set([...DEFAULT_CATEGORIES, ...fromItems])]
   return [{ label: '전체', value: '' }, ...cats.map((c) => ({ label: c, value: c }))]
 })
 


### PR DESCRIPTION
## 📋 작업 내용

### 거래처 삭제 미작동 (Critical)
- \`clientId ?? id\` fallback + null 방어
- \`console.error\`로 에러 원인 추적

### 거래처 상세검색 국가 드롭다운 (Major)
- \`countryName\` fallback (countries 마스터에서 역매핑)
- \`countryOptions\`: 마스터 + 거래처 합집합

### 품목 상세검색 카테고리/단위 (Major)
- \`DEFAULT_CATEGORIES\` (Steel/Pipe/Oil/Machinery) + \`DEFAULT_UNITS\` (EA/KG/MT/SET) 하드코딩
- items 데이터 없어도 옵션 표시

### 거래처 담당자 필드 명확화
- 라벨: \`담당자\` → \`거래처 담당자 (바이어)\`
- placeholder + 안내 문구 추가 — 우리 영업 담당자가 아닌 거래처 측 바이어임을 명시
- 리스트 컬럼 헤더: \`담당자\` → \`거래처 담당자\`

## 🔗 관련 이슈

- closes #294

## ✅ 체크리스트

- [x] 빌드 성공
- [x] 불필요한 코드/주석 제거
- [x] 충돌 해결 완료