### PR TITLE
refactor: 부서→팀→사용자/거래처 계층 정규화

### DIFF
--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -41,6 +41,26 @@ export async function fetchDepartments() {
   return unwrapCollection(data)
 }
 
+export async function fetchTeams(departmentId = null) {
+  const params = departmentId != null ? { departmentId } : {}
+  const { data } = await api.get('/teams', { params })
+  return Array.isArray(data) ? data : unwrapCollection(data)
+}
+
+export async function createTeam(team) {
+  const { data } = await api.post('/teams', team)
+  return data
+}
+
+export async function updateTeam(id, team) {
+  const { data } = await api.put(`/teams/${id}`, team)
+  return data
+}
+
+export async function deleteTeam(id) {
+  await api.delete(`/teams/${id}`)
+}
+
 export async function fetchCompany() {
   const { data } = await api.get('/company')
   return data

--- a/src/components/domain/auth/UserFormModal.vue
+++ b/src/components/domain/auth/UserFormModal.vue
@@ -17,6 +17,7 @@ const props = defineProps({
   user: { type: Object, default: null },
   positions: { type: Array, default: () => [] },
   departments: { type: Array, default: () => [] },
+  teams: { type: Array, default: () => [] },
   allUsers: { type: Array, default: () => [] },
   saving: { type: Boolean, default: false },
 })
@@ -46,9 +47,9 @@ function getInitialForm() {
     email: '',
     positionId: '',
     role: '',
-    departmentId: '',
+    departmentId: '',   // 팀 드롭다운 필터용 (폼 제출 시 사용 안 함)
+    teamId: '',
     status: '재직',
-    transferDepartmentId: '',
     transferReason: '',
     sealImage: null,
   }
@@ -59,14 +60,16 @@ watch(
   (isOpen) => {
     errors.value = {}
     if (isOpen && props.mode === 'edit' && props.user) {
-      // positionName/departmentName 기반 ID 역매핑 fallback
       const resolvedPositionId = props.user.positionId
         ?? props.positions.find((p) => (p.positionName ?? p.name) === props.user.positionName)?.positionId
         ?? props.positions.find((p) => (p.positionName ?? p.name) === props.user.positionName)?.id
         ?? ''
-      const resolvedDepartmentId = props.user.departmentId
-        ?? props.departments.find((d) => (d.departmentName ?? d.name) === props.user.departmentName)?.departmentId
-        ?? props.departments.find((d) => (d.departmentName ?? d.name) === props.user.departmentName)?.id
+      const resolvedTeamId = props.user.teamId
+        ?? props.teams.find((t) => t.teamName === props.user.teamName)?.teamId
+        ?? ''
+      const team = props.teams.find((t) => String(t.teamId) === String(resolvedTeamId))
+      const resolvedDepartmentId = team?.departmentId
+        ?? props.user.departmentId
         ?? ''
       form.value = {
         name: props.user.userName ?? props.user.name ?? '',
@@ -74,8 +77,8 @@ watch(
         positionId: String(resolvedPositionId),
         role: props.user.userRole ?? props.user.role ?? '',
         departmentId: String(resolvedDepartmentId),
+        teamId: String(resolvedTeamId),
         status: props.user.userStatus ?? props.user.status ?? 'active',
-        transferDepartmentId: '',
         transferReason: '',
         sealImage: null,
       }
@@ -85,44 +88,43 @@ watch(
   },
 )
 
+// 부서 변경 시 팀 초기화 (매칭 안 되는 팀이면)
+watch(() => form.value.departmentId, (deptId) => {
+  const team = props.teams.find((t) => String(t.teamId) === String(form.value.teamId))
+  if (team && String(team.departmentId) !== String(deptId)) {
+    form.value.teamId = ''
+  }
+})
+
+const teamOptions = computed(() => {
+  const filtered = form.value.departmentId
+    ? props.teams.filter((t) => String(t.departmentId) === String(form.value.departmentId))
+    : props.teams
+  return filtered.map((t) => ({ label: t.teamName, value: String(t.teamId) }))
+})
+
 function validate() {
   const e = {}
 
-  if (!form.value.name.trim()) {
-    e.name = '이름을 입력해주세요.'
-  }
+  if (!form.value.name.trim()) e.name = '이름을 입력해주세요.'
 
   if (!form.value.email.trim()) {
     e.email = '이메일을 입력해주세요.'
   } else if (!isValidEmail(form.value.email)) {
     e.email = '올바른 이메일 형식을 입력해주세요.'
   } else {
-    // 중복 이메일 체크
     const duplicate = props.allUsers.find(
       (u) =>
         (u.userEmail ?? u.email) === form.value.email.trim() &&
         (props.mode === 'create' || (u.userId ?? u.id) !== (props.user?.userId ?? props.user?.id)),
     )
-    if (duplicate) {
-      e.email = '이미 사용 중인 이메일 주소입니다.'
-    }
+    if (duplicate) e.email = '이미 사용 중인 이메일 주소입니다.'
   }
 
-  if (!form.value.positionId) {
-    e.positionId = '직급을 선택해주세요.'
-  }
-
-  if (!form.value.role) {
-    e.role = '부서를 선택해주세요.'
-  }
-
-  if (!form.value.departmentId && props.mode === 'create') {
-    e.departmentId = '팀을 선택해주세요.'
-  }
-
-  if (form.value.transferDepartmentId && !form.value.transferReason.trim()) {
-    e.transferReason = '이동 사유를 입력해주세요.'
-  }
+  if (!form.value.positionId) e.positionId = '직급을 선택해주세요.'
+  if (!form.value.role) e.role = '역할을 선택해주세요.'
+  if (!form.value.departmentId) e.departmentId = '부서를 선택해주세요.'
+  if (!form.value.teamId) e.teamId = '팀을 선택해주세요.'
 
   errors.value = e
   return Object.keys(e).length === 0
@@ -136,9 +138,7 @@ function handleSave() {
   emit('save', { ...form.value })
 }
 
-function confirmResetPassword() {
-  showResetConfirm.value = true
-}
+function confirmResetPassword() { showResetConfirm.value = true }
 
 async function handleResetPassword() {
   if (!props.user?.userId && !props.user?.id) return
@@ -152,11 +152,10 @@ async function handleResetPassword() {
   }
 }
 
-const currentDepartmentName = computed(() => {
-  // 백엔드 리스트 응답은 departmentName을 직접 포함
-  if (props.user?.departmentName) return props.user.departmentName
-  const dept = props.departments.find(d => String(d.departmentId ?? d.id) === String(props.user?.departmentId))
-  return dept?.departmentName ?? dept?.name ?? '-'
+const currentTeamName = computed(() => {
+  if (props.user?.teamName) return props.user.teamName
+  const team = props.teams.find((t) => String(t.teamId) === String(props.user?.teamId))
+  return team?.teamName ?? '-'
 })
 </script>
 
@@ -168,7 +167,6 @@ const currentDepartmentName = computed(() => {
     @close="emit('close')"
   >
     <form class="space-y-6" @submit.prevent="handleSave">
-      <!-- 기본 정보: 2열 그리드 -->
       <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
         <FormField label="이름" required :error="errors.name">
           <BaseTextField v-model="form.name" placeholder="이름을 입력하세요" />
@@ -186,19 +184,28 @@ const currentDepartmentName = computed(() => {
           />
         </FormField>
 
-        <FormField label="부서" required :error="errors.role">
-          <BaseSelect v-model="form.role" :options="roleOptions" placeholder="부서를 선택하세요" />
+        <FormField label="역할" required :error="errors.role">
+          <BaseSelect v-model="form.role" :options="roleOptions" placeholder="역할을 선택하세요" />
+        </FormField>
+
+        <FormField label="부서" required :error="errors.departmentId">
+          <BaseSelect
+            v-model="form.departmentId"
+            :options="departments.map((d) => ({ label: d.departmentName ?? d.name, value: String(d.departmentId ?? d.id) }))"
+            placeholder="부서를 선택하세요"
+          />
+        </FormField>
+
+        <FormField label="팀" required :error="errors.teamId">
+          <BaseSelect
+            v-model="form.teamId"
+            :options="teamOptions"
+            :placeholder="form.departmentId ? '팀을 선택하세요' : '먼저 부서를 선택하세요'"
+            :disabled="!form.departmentId"
+          />
         </FormField>
 
         <template v-if="mode === 'create'">
-          <FormField label="팀" required :error="errors.departmentId">
-            <BaseSelect
-              v-model="form.departmentId"
-              :options="departments.map((d) => ({ label: d.departmentName ?? d.name, value: String(d.departmentId ?? d.id) }))"
-              placeholder="팀을 선택하세요"
-            />
-          </FormField>
-
           <FormField label="초기 비밀번호">
             <div class="flex items-center gap-2 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-600">
               <i class="fas fa-lock text-xs text-slate-400" />
@@ -209,39 +216,21 @@ const currentDepartmentName = computed(() => {
         </template>
       </div>
 
-      <!-- 수정 모드 전용 -->
       <template v-if="mode === 'edit'">
-        <!-- 상태 -->
         <FormField label="상태">
           <BaseSelect v-model="form.status" :options="statusOptions" />
         </FormField>
 
-        <!-- 팀 이동 -->
-        <div class="space-y-3 rounded-xl border border-slate-200 bg-slate-50/50 p-4">
-          <div class="flex items-center gap-2">
-            <svg class="h-4 w-4 text-slate-500" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-              <path fill-rule="evenodd" d="M15.312 11.424a5.5 5.5 0 0 1-9.201 2.466l-.312-.311h2.433a.75.75 0 0 0 0-1.5H4.28a.75.75 0 0 0-.75.75v3.952a.75.75 0 0 0 1.5 0v-2.146l.312.311a7 7 0 0 0 11.712-3.138.75.75 0 0 0-1.449-.384Zm.39-3.44a.75.75 0 0 0 .326-1.275 7 7 0 0 0-11.712 3.138.75.75 0 0 0 1.449.384 5.5 5.5 0 0 1 9.201-2.466l.312.311H13.28a.75.75 0 0 0 0 1.5h3.952a.75.75 0 0 0 .75-.75V5.384a.75.75 0 0 0-1.5 0v2.146l-.312-.311a.747.747 0 0 0-.468-.235Z" clip-rule="evenodd" />
-            </svg>
-            <h3 class="text-sm font-bold text-ink">팀 이동</h3>
-          </div>
+        <div class="space-y-2 rounded-xl border border-slate-200 bg-slate-50/50 p-4">
           <p class="text-xs text-slate-500">
-            현재 팀: <span class="font-medium text-ink">{{ currentDepartmentName }}</span> → 이동할 팀
+            현재 팀: <span class="font-medium text-ink">{{ currentTeamName }}</span>
           </p>
-          <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
-            <FormField label="이동할 팀">
-              <BaseSelect
-                v-model="form.transferDepartmentId"
-                :options="[{ label: '변경안함', value: '' }, ...departments.map((d) => ({ label: d.departmentName ?? d.name, value: String(d.departmentId ?? d.id) }))]"
-              />
-            </FormField>
-            <FormField label="이동 사유" :required="!!form.transferDepartmentId" :error="errors.transferReason">
-              <BaseTextField v-model="form.transferReason" placeholder="이동 사유를 입력하세요" />
-            </FormField>
-          </div>
+          <FormField label="이동 사유 (팀 변경 시)">
+            <BaseTextField v-model="form.transferReason" placeholder="팀 이동 사유를 입력하세요" />
+          </FormField>
         </div>
       </template>
 
-      <!-- 서명 이미지 -->
       <FileUploadField
         v-model="form.sealImage"
         label="서명 이미지"
@@ -249,7 +238,6 @@ const currentDepartmentName = computed(() => {
         helper-text="서명 이미지를 업로드하세요. (PNG, JPG 권장)"
       />
 
-      <!-- 비밀번호 초기화 (수정 모드) -->
       <div v-if="mode === 'edit'" class="flex items-center justify-between rounded-xl border border-slate-200 bg-slate-50/50 p-4">
         <div>
           <p class="text-sm font-medium text-ink">비밀번호 초기화</p>
@@ -261,7 +249,6 @@ const currentDepartmentName = computed(() => {
       </div>
     </form>
 
-    <!-- 비밀번호 초기화 확인 모달 -->
     <ConfirmModal
       :open="showResetConfirm"
       title="비밀번호 초기화"

--- a/src/components/domain/auth/UserListTab.vue
+++ b/src/components/domain/auth/UserListTab.vue
@@ -2,9 +2,11 @@
 import { computed, onMounted, ref } from 'vue'
 import BaseButton from '@/components/common/BaseButton.vue'
 import BaseSelect from '@/components/common/BaseSelect.vue'
+import BaseTable from '@/components/common/BaseTable.vue'
 import ConfirmModal from '@/components/common/ConfirmModal.vue'
 import SearchInput from '@/components/common/SearchInput.vue'
-import DepartmentAccordion from '@/components/domain/auth/DepartmentAccordion.vue'
+import StatusBadge from '@/components/common/StatusBadge.vue'
+import TableActions from '@/components/common/TableActions.vue'
 import UserFormModal from '@/components/domain/auth/UserFormModal.vue'
 import { useToast } from '@/composables/useToast'
 import {
@@ -12,6 +14,7 @@ import {
   createUser,
   fetchDepartments,
   fetchPositions,
+  fetchTeams,
   fetchUsers,
   updateUser,
 } from '@/api/auth'
@@ -19,40 +22,23 @@ import { label, USER_STATUS_LABEL } from '@/utils/enumLabels'
 
 const { success, error } = useToast()
 
-// 데이터
 const users = ref([])
 const positions = ref([])
 const departments = ref([])
+const teams = ref([])
 const loading = ref(false)
-
-// 사번 자동 생성 (YYMMDD + 2자리 순번)
-function generateEmployeeNo(existingUsers) {
-  const now = new Date()
-  const yy = String(now.getFullYear()).slice(2)
-  const mm = String(now.getMonth() + 1).padStart(2, '0')
-  const dd = String(now.getDate()).padStart(2, '0')
-  const prefix = `${yy}${mm}${dd}`
-  const todayNos = existingUsers
-    .map((u) => u.employeeNo)
-    .filter((no) => no && no.startsWith(prefix))
-  const maxSeq = todayNos.reduce((max, no) => {
-    const seq = parseInt(no.slice(6), 10)
-    return isNaN(seq) ? max : Math.max(max, seq)
-  }, 0)
-  return `${prefix}${String(maxSeq + 1).padStart(2, '0')}`
-}
 
 async function loadData() {
   loading.value = true
   try {
-    const [usersData, positionsData, departmentsData] = await Promise.all([
+    const [usersData, positionsData, departmentsData, teamsData] = await Promise.all([
       fetchUsers(),
       fetchPositions(),
       fetchDepartments(),
+      fetchTeams(),
     ])
     users.value = usersData
     positions.value = positionsData
-    // 부서 중복 제거 (JPA 연관관계 조인 시 동일 부서 중복 방지)
     const seenDeptIds = new Set()
     departments.value = (departmentsData ?? []).filter((d) => {
       const id = String(d.departmentId ?? d.id ?? '')
@@ -60,7 +46,7 @@ async function loadData() {
       seenDeptIds.add(id)
       return true
     })
-    // 첫 번째 부서 펼치기
+    teams.value = teamsData ?? []
     if (departments.value.length > 0) {
       expandedDepts.value = new Set([departments.value[0].departmentId ?? departments.value[0].id])
     }
@@ -77,28 +63,24 @@ const positionMap = computed(() =>
   Object.fromEntries(positions.value.map((p) => [String(p.positionId ?? p.id), p.positionName ?? p.name])),
 )
 
-// 검색 / 필터
 const searchKeyword = ref('')
 const departmentFilter = ref('')
 
-// 아코디언 상태
 const expandedDepts = ref(new Set())
+const expandedTeams = ref(new Set())
 
-// 모달 상태
 const showFormModal = ref(false)
 const formMode = ref('create')
 const selectedUser = ref(null)
 const saving = ref(false)
 
-// 삭제 확인 모달 상태
 const showDeleteModal = ref(false)
 const userToDelete = ref(null)
 const deleting = ref(false)
 
-// 부서별 그룹핑 + 필터
-const groupedByDepartment = computed(() => {
+// department → team → users 트리 구성
+const tree = computed(() => {
   let filtered = users.value
-
   if (searchKeyword.value) {
     const kw = searchKeyword.value.toLowerCase()
     filtered = filtered.filter(
@@ -108,75 +90,104 @@ const groupedByDepartment = computed(() => {
         (u.userEmail && u.userEmail.toLowerCase().includes(kw)),
     )
   }
-
   if (departmentFilter.value) {
-    filtered = filtered.filter((u) => String(u.departmentName) === String(departmentFilter.value))
+    filtered = filtered.filter((u) => String(u.departmentId) === String(departmentFilter.value))
   }
 
   return departments.value
     .map((dept) => {
-      const deptName = dept.departmentName ?? dept.name
       const deptId = dept.departmentId ?? dept.id
-      return {
-        department: { id: deptId, name: deptName },
-        users: filtered
-          .filter((u) => String(u.departmentName) === String(deptName))
-          .map((u) => ({ ...u, department: deptName })),
+      const deptName = dept.departmentName ?? dept.name
+      const deptTeams = teams.value.filter((t) => String(t.departmentId) === String(deptId))
+      const teamGroups = deptTeams.map((t) => ({
+        teamId: t.teamId,
+        teamName: t.teamName,
+        users: filtered.filter((u) => String(u.teamId) === String(t.teamId)),
+      }))
+      // 팀 없이 소속된 사용자 ('미배정')
+      const unassigned = filtered.filter(
+        (u) => String(u.departmentId) === String(deptId) && !u.teamId,
+      )
+      if (unassigned.length > 0) {
+        teamGroups.push({ teamId: `__unassigned_${deptId}`, teamName: '(팀 미배정)', users: unassigned })
       }
+      const total = teamGroups.reduce((s, g) => s + g.users.length, 0)
+      return { deptId, deptName, teamGroups, total }
     })
-    .filter((g) => g.users.length > 0)
+    .filter((g) => g.total > 0)
 })
 
-const totalTeams = computed(() => groupedByDepartment.value.length)
-const totalUsers = computed(() =>
-  groupedByDepartment.value.reduce((sum, g) => sum + g.users.length, 0),
+const totalTeams = computed(() =>
+  tree.value.reduce((s, d) => s + d.teamGroups.filter((t) => t.users.length > 0).length, 0),
 )
+const totalUsers = computed(() => tree.value.reduce((s, d) => s + d.total, 0))
 const activeUsers = computed(() =>
-  groupedByDepartment.value.reduce(
-    (sum, g) => sum + g.users.filter((u) => u.userStatus === 'active').length,
-    0,
-  ),
+  tree.value.reduce(
+    (s, d) => s + d.teamGroups.reduce(
+      (s2, t) => s2 + t.users.filter((u) => u.userStatus === 'active').length, 0), 0),
 )
 
 const departmentFilterOptions = computed(() => [
   { label: '전체 부서', value: '' },
-  ...departments.value.map((d) => ({ label: d.departmentName ?? d.name, value: d.departmentName ?? d.name })),
+  ...departments.value.map((d) => ({
+    label: d.departmentName ?? d.name,
+    value: String(d.departmentId ?? d.id),
+  })),
 ])
 
-function toggleDepartment(deptId) {
+function toggleDept(deptId) {
   const next = new Set(expandedDepts.value)
   if (next.has(deptId)) next.delete(deptId)
   else next.add(deptId)
   expandedDepts.value = next
 }
 
+function toggleTeam(teamId) {
+  const next = new Set(expandedTeams.value)
+  if (next.has(teamId)) next.delete(teamId)
+  else next.add(teamId)
+  expandedTeams.value = next
+}
+
 const allVisibleExpanded = computed(() => {
-  const visibleDeptIds = groupedByDepartment.value.map(g => g.department.id)
-  return visibleDeptIds.length > 0 && visibleDeptIds.every(id => expandedDepts.value.has(id))
+  const visibleDeptIds = tree.value.map((g) => g.deptId)
+  return visibleDeptIds.length > 0 && visibleDeptIds.every((id) => expandedDepts.value.has(id))
 })
 
 function toggleAll() {
-  const visibleDeptIds = groupedByDepartment.value.map(g => g.department.id)
-  const allExpanded = visibleDeptIds.length > 0 && visibleDeptIds.every(id => expandedDepts.value.has(id))
+  const visibleDeptIds = tree.value.map((g) => g.deptId)
+  const visibleTeamIds = tree.value.flatMap((g) => g.teamGroups.map((t) => t.teamId))
+  const allExpanded = allVisibleExpanded.value
   if (allExpanded) {
     expandedDepts.value = new Set()
+    expandedTeams.value = new Set()
   } else {
     expandedDepts.value = new Set([...expandedDepts.value, ...visibleDeptIds])
+    expandedTeams.value = new Set([...expandedTeams.value, ...visibleTeamIds])
   }
 }
+
+const userColumns = [
+  { key: 'employeeNo', label: '사번', width: '120px' },
+  { key: 'userName', label: '이름', width: '200px' },
+  { key: 'userEmail', label: '이메일' },
+  { key: 'status', label: '상태', width: '100px', align: 'center' },
+  { key: 'actions', label: '', width: '140px', align: 'center', sortable: false },
+]
+
+const avatarColors = ['bg-blue-500', 'bg-emerald-500', 'bg-violet-500', 'bg-amber-500', 'bg-rose-500', 'bg-teal-500']
+function getAvatarColor(index) { return avatarColors[index % avatarColors.length] }
 
 function openEditModal(user) {
   selectedUser.value = user
   formMode.value = 'edit'
   showFormModal.value = true
 }
-
 function openCreateModal() {
   selectedUser.value = null
   formMode.value = 'create'
   showFormModal.value = true
 }
-
 function openDeleteModal(user) {
   userToDelete.value = user
   showDeleteModal.value = true
@@ -199,7 +210,7 @@ async function handleSave(formData) {
       const updateData = {
         name: formData.name,
         email: formData.email,
-        departmentId: formData.transferDepartmentId ? Number(formData.transferDepartmentId) : (original.departmentId ? Number(original.departmentId) : undefined),
+        teamId: formData.teamId ? Number(formData.teamId) : (original.teamId ? Number(original.teamId) : undefined),
         positionId: formData.positionId ? Number(formData.positionId) : undefined,
       }
       await updateUser(original.userId, updateData)
@@ -248,49 +259,112 @@ defineExpose({ openCreateModal })
       </BaseButton>
     </div>
 
-    <!-- 로딩 -->
     <div v-if="loading" class="py-12 text-center text-sm text-slate-400">
       불러오는 중...
     </div>
 
-    <!-- 부서별 아코디언 -->
+    <!-- 부서 → 팀 → 사용자 트리 -->
     <div v-else class="space-y-3">
-      <DepartmentAccordion
-        v-for="group in groupedByDepartment"
-        :key="group.department.id"
-        :department="group.department.name"
-        :users="group.users"
-        :expanded="expandedDepts.has(group.department.id)"
-        :position-map="positionMap"
-        @toggle="toggleDepartment(group.department.id)"
-        @edit-user="openEditModal"
-        @delete-user="openDeleteModal"
-      />
-      <div v-if="groupedByDepartment.length === 0" class="py-12 text-center text-sm text-slate-400">
+      <div
+        v-for="dept in tree"
+        :key="dept.deptId"
+        class="overflow-hidden rounded-2xl border border-slate-200 bg-white"
+      >
+        <button
+          type="button"
+          class="flex w-full items-center gap-3 px-5 py-4 text-left transition hover:bg-slate-50"
+          @click="toggleDept(dept.deptId)"
+        >
+          <svg
+            class="h-4 w-4 shrink-0 text-slate-400 transition-transform duration-200"
+            :class="{ 'rotate-90': expandedDepts.has(dept.deptId) }"
+            viewBox="0 0 20 20" fill="currentColor"
+          >
+            <path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 0 1 .02-1.06L11.168 10 7.23 6.29a.75.75 0 1 1 1.04-1.08l4.5 4.25a.75.75 0 0 1 0 1.08l-4.5 4.25a.75.75 0 0 1-1.06-.02Z" clip-rule="evenodd"/>
+          </svg>
+          <svg class="h-5 w-5 shrink-0 text-slate-500" viewBox="0 0 20 20" fill="currentColor">
+            <path d="M7 3.5A1.5 1.5 0 0 1 8.5 2h3A1.5 1.5 0 0 1 13 3.5H7ZM3 6a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v1H3V6ZM2 9.5h16l-.663 7.283A2 2 0 0 1 15.345 18.5H4.655a2 2 0 0 1-1.992-1.717L2 9.5Z"/>
+          </svg>
+          <span class="font-bold text-ink">{{ dept.deptName }}</span>
+          <span class="ml-auto text-sm text-slate-500">{{ dept.total }}명</span>
+        </button>
+
+        <div v-show="expandedDepts.has(dept.deptId)" class="border-t border-slate-100">
+          <div
+            v-for="team in dept.teamGroups"
+            :key="team.teamId"
+            class="border-b border-slate-100 last:border-b-0"
+          >
+            <button
+              type="button"
+              class="flex w-full items-center gap-3 bg-slate-50 px-8 py-3 text-left text-sm transition hover:bg-slate-100"
+              @click="toggleTeam(team.teamId)"
+            >
+              <svg
+                class="h-3.5 w-3.5 shrink-0 text-slate-400 transition-transform duration-200"
+                :class="{ 'rotate-90': expandedTeams.has(team.teamId) }"
+                viewBox="0 0 20 20" fill="currentColor"
+              >
+                <path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 0 1 .02-1.06L11.168 10 7.23 6.29a.75.75 0 1 1 1.04-1.08l4.5 4.25a.75.75 0 0 1 0 1.08l-4.5 4.25a.75.75 0 0 1-1.06-.02Z" clip-rule="evenodd"/>
+              </svg>
+              <span class="font-semibold text-slate-700">{{ team.teamName }}</span>
+              <span class="ml-auto text-xs text-slate-500">{{ team.users.length }}명</span>
+            </button>
+            <div v-show="expandedTeams.has(team.teamId)" class="bg-white px-2">
+              <BaseTable :columns="userColumns" :rows="team.users" row-key="userId" empty-text="사용자가 없습니다.">
+                <template #cell-userName="{ row, value }">
+                  <div class="flex items-center gap-2.5">
+                    <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs font-bold text-white" :class="getAvatarColor(row.userId)">
+                      {{ value?.charAt(0) }}
+                    </span>
+                    <div>
+                      <p class="font-medium text-ink">{{ value }}</p>
+                      <p class="text-xs text-slate-400">{{ row.positionName || positionMap[row.positionId] || '' }}</p>
+                    </div>
+                  </div>
+                </template>
+                <template #cell-status="{ row }">
+                  <StatusBadge
+                    :value="label(USER_STATUS_LABEL, row.userStatus)"
+                    :variant="row.userStatus === 'active' ? 'active' : 'inactive'"
+                  />
+                </template>
+                <template #cell-actions="{ row }">
+                  <TableActions
+                    edit-label="수정"
+                    delete-label="퇴직"
+                    @edit="openEditModal(row)"
+                    @delete="openDeleteModal(row)"
+                  />
+                </template>
+              </BaseTable>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div v-if="tree.length === 0" class="py-12 text-center text-sm text-slate-400">
         검색 결과가 없습니다.
       </div>
     </div>
 
-    <!-- 하단 요약 -->
     <div class="flex items-center justify-between rounded-xl bg-slate-50 px-4 py-3 text-sm text-slate-600">
       <span>총 {{ totalTeams }}개 팀 {{ totalUsers }}명</span>
       <span>{{ activeUsers }}명 재직</span>
     </div>
 
-    <!-- 사용자 등록/수정 모달 -->
     <UserFormModal
       :open="showFormModal"
       :mode="formMode"
       :user="selectedUser"
       :positions="positions"
       :departments="departments"
+      :teams="teams"
       :all-users="users"
       :saving="saving"
       @close="showFormModal = false"
       @save="handleSave"
     />
 
-    <!-- 삭제 확인 모달 -->
     <ConfirmModal
       :open="showDeleteModal"
       title="사용자 퇴직 처리"

--- a/src/views/master/ClientDetailPage.vue
+++ b/src/views/master/ClientDetailPage.vue
@@ -122,7 +122,7 @@ async function loadData() {
     client.value = clientData
 
     if (!isAdmin.value && currentUser.value?.role === 'sales' &&
-        clientData.departmentId !== Number(currentUser.value?.departmentId)) {
+        clientData.teamId !== Number(currentUser.value?.teamId)) {
       error('접근 권한이 없는 거래처입니다.')
       router.push({ name: 'client-list' })
       return

--- a/src/views/master/ClientListPage.vue
+++ b/src/views/master/ClientListPage.vue
@@ -110,9 +110,9 @@ function searchRows() {
 const filteredClients = computed(() => {
   let result = enrichedClients.value
 
-  // RBAC: 영업 사용자는 자기 부서 거래처만 표시
+  // RBAC: 영업 사용자는 자기 팀 거래처만 표시 (팀→부서는 역참조)
   if (!isAdmin.value && currentUser.value?.role === 'sales') {
-    result = result.filter((c) => c.departmentId === Number(currentUser.value.departmentId))
+    result = result.filter((c) => c.teamId === Number(currentUser.value.teamId))
   }
 
   const f = appliedFilters.value
@@ -220,8 +220,8 @@ async function handleSave(formData) {
   saving.value = true
   try {
     if (formMode.value === 'create') {
-      const deptId = isAdmin.value ? undefined : Number(currentUser.value?.departmentId)
-      await createClient({ ...formData, clientRegDate: new Date().toISOString().slice(0, 10), ...(deptId && { departmentId: deptId }) })
+      const teamId = isAdmin.value ? formData.teamId : Number(currentUser.value?.teamId)
+      await createClient({ ...formData, clientRegDate: new Date().toISOString().slice(0, 10), ...(teamId && { teamId }) })
       success('거래처가 등록되었습니다.')
     } else {
       await updateClient(selectedClient.value.clientId, formData)


### PR DESCRIPTION
## Summary
- 사용자 관리 화면을 **부서 → 팀 → 사용자** 2단 아코디언 트리로 개편
- 사용자 등록/수정 폼에 **부서 → 팀 계단식 드롭다운** 적용
- 거래처 RBAC 필터를 기존 departmentId → **teamId** 로 전환 (영업 사용자는 자기 팀 거래처만 조회)
- Team CRUD API 모듈 추가 (\`fetchTeams\`, \`createTeam\`, \`updateTeam\`, \`deleteTeam\`)

## 배경
DDL 정규화 작업의 프론트엔드 파트입니다. users/clients 테이블이 기존 department_id 직접 참조에서 team_id 로 변경되었고, 부서는 팀을 경유해서만 해소됩니다.

백엔드(auth/master) 및 DDL/seed DML 변경은 main 에 직접 반영되었으며, 프론트만 PR 로 쏩니다.

## Test plan
- [ ] 사용자 관리 진입 시 부서 → 팀 트리가 정상 렌더링되는지
- [ ] 전체 접기/펼치기 버튼이 팀까지 반영되는지
- [ ] 사용자 등록 모달에서 부서 변경 시 팀 드롭다운이 해당 부서로 필터링되는지
- [ ] 사용자 수정 모달이 기존 team_id 를 정확히 프리셀렉트하는지
- [ ] sales 역할 로그인 시 자기 팀 거래처만 목록/상세에 표시되는지
- [ ] admin 로그인 시 거래처 등록 시 teamId 가 요청 payload 에 포함되는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)