### PR TITLE
fix: 거래처 등록 시 담당 팀 자동 지정 + 상세 표시

### DIFF
--- a/src/components/domain/master/ClientFormModal.vue
+++ b/src/components/domain/master/ClientFormModal.vue
@@ -18,6 +18,11 @@ const props = defineProps({
   ports: { type: Array, default: () => [] },
   currencies: { type: Array, default: () => [] },
   paymentTerms: { type: Array, default: () => [] },
+  departments: { type: Array, default: () => [] },
+  teams: { type: Array, default: () => [] },
+  defaultDepartmentId: { type: [Number, String], default: null },
+  defaultTeamId: { type: [Number, String], default: null },
+  lockTeam: { type: Boolean, default: false },
   allClients: { type: Array, default: () => [] },
   saving: { type: Boolean, default: false },
 })
@@ -91,10 +96,30 @@ function getInitialForm() {
     paymentTermsId: null,
     currencyId: null,
     manager: '',
+    departmentId: null,
+    teamId: null,
     status: 'active',
     sealImage: null,
   }
 }
+
+const teamOptions = computed(() => {
+  const filtered = form.value.departmentId
+    ? props.teams.filter((t) => String(t.departmentId) === String(form.value.departmentId))
+    : props.teams
+  return filtered.map((t) => ({ label: t.teamName, value: t.teamId }))
+})
+
+const departmentOptions = computed(() =>
+  props.departments.map((d) => ({ label: d.departmentName ?? d.name, value: d.departmentId ?? d.id })),
+)
+
+watch(() => form.value.departmentId, (deptId) => {
+  const team = props.teams.find((t) => String(t.teamId) === String(form.value.teamId))
+  if (team && String(team.departmentId) !== String(deptId)) {
+    form.value.teamId = null
+  }
+})
 
 watch(
   () => props.open,
@@ -108,6 +133,9 @@ watch(
       const resolvedPortId = props.client.portId
         ?? props.ports.find((p) => p.portName === props.client.portName)?.id
         ?? null
+      const resolvedTeamId = props.client.teamId ?? null
+      const teamMatch = props.teams.find((t) => String(t.teamId) === String(resolvedTeamId))
+      const resolvedDeptId = teamMatch?.departmentId ?? props.client.departmentId ?? null
       form.value = {
         code: props.client.clientCode ?? '',
         name: props.client.clientName ?? '',
@@ -121,12 +149,17 @@ watch(
         paymentTermsId: props.client.paymentTermId ?? props.client.paymentTermsId ?? null,
         currencyId: props.client.currencyId ?? null,
         manager: props.client.clientManager ?? '',
+        departmentId: resolvedDeptId,
+        teamId: resolvedTeamId,
         status: props.client.clientStatus ?? 'active',
         sealImage: null,
       }
     } else if (isOpen && props.mode === 'create') {
       form.value = getInitialForm()
       form.value.code = generateNextCode()
+      // 작성자(현재 로그인 사용자) 팀으로 기본값 채움
+      if (props.defaultTeamId) form.value.teamId = props.defaultTeamId
+      if (props.defaultDepartmentId) form.value.departmentId = props.defaultDepartmentId
     }
   },
 )
@@ -203,6 +236,14 @@ function validate() {
     e.currencyId = '통화를 선택하세요.'
   }
 
+  if (!form.value.departmentId) {
+    e.departmentId = '담당 부서를 선택하세요.'
+  }
+
+  if (!form.value.teamId) {
+    e.teamId = '담당 팀을 선택하세요.'
+  }
+
   errors.value = e
   return Object.keys(e).length === 0
 }
@@ -223,6 +264,7 @@ function handleSave() {
     paymentTermId: form.value.paymentTermsId,
     currencyId: form.value.currencyId,
     clientManager: form.value.manager,
+    teamId: form.value.teamId,
   }
   emit('save', payload)
 }
@@ -314,6 +356,36 @@ function handleSave() {
           </FormField>
           <FormField label="상태">
             <BaseSelect v-model="form.status" :options="statusOptions" placeholder="상태를 선택하세요" />
+          </FormField>
+        </div>
+      </div>
+
+      <!-- 담당 조직 (작성자 팀 기본 — admin 만 변경 가능) -->
+      <div>
+        <h4 class="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400">
+          담당 조직
+          <span v-if="lockTeam" class="ml-2 text-[11px] font-normal normal-case text-slate-400">
+            본인 소속 팀으로 자동 지정 (관리자만 변경 가능)
+          </span>
+        </h4>
+        <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <FormField label="담당 부서" required>
+            <BaseSelect
+              v-model="form.departmentId"
+              :options="departmentOptions"
+              :disabled="lockTeam"
+              placeholder="부서를 선택하세요"
+            />
+            <p v-if="errors.departmentId" class="mt-1 text-xs text-red-500">{{ errors.departmentId }}</p>
+          </FormField>
+          <FormField label="담당 팀" required>
+            <BaseSelect
+              v-model="form.teamId"
+              :options="teamOptions"
+              :disabled="lockTeam || !form.departmentId"
+              :placeholder="form.departmentId ? '팀을 선택하세요' : '부서를 먼저 선택하세요'"
+            />
+            <p v-if="errors.teamId" class="mt-1 text-xs text-red-500">{{ errors.teamId }}</p>
           </FormField>
         </div>
       </div>

--- a/src/views/master/ClientDetailPage.vue
+++ b/src/views/master/ClientDetailPage.vue
@@ -19,6 +19,7 @@ import {
   updateClient,
 } from '@/api/master'
 import { createBuyer, updateBuyer, deleteBuyer } from '@/api/contacts'
+import { fetchDepartments, fetchTeams } from '@/api/auth'
 import { useMasterLookup } from '@/composables/useMasterLookup'
 import { useToast } from '@/composables/useToast'
 import { isValidEmail, isValidTel } from '@/utils/validators'
@@ -35,6 +36,8 @@ const { countries, ports, currencies, paymentTerms, loadReferenceData, getCountr
 
 const client = ref(null)
 const allClients = ref([])
+const departments = ref([])
+const teams = ref([])
 const loading = ref(false)
 const saving = ref(false)
 
@@ -96,6 +99,13 @@ const infoGroups = computed(() => {
         { label: '등록일', value: client.value.clientRegDate },
       ],
     },
+    {
+      title: '담당 조직',
+      fields: [
+        { label: '부서', value: client.value.departmentName ?? '-' },
+        { label: '팀', value: client.value.teamName ?? '-' },
+      ],
+    },
   ]
 })
 
@@ -107,13 +117,17 @@ async function loadData() {
   }
   loading.value = true
   try {
-    const [clientData, buyersData, clientsData] =
+    const [clientData, buyersData, clientsData, , deptsData, teamsData] =
       await Promise.all([
         fetchClient(route.params.id),
         fetchBuyersByClient(route.params.id),
         fetchClients(),
         loadReferenceData(),
+        fetchDepartments(),
+        fetchTeams(),
       ])
+    departments.value = deptsData ?? []
+    teams.value = teamsData ?? []
     if (!clientData) {
       error('거래처를 찾을 수 없습니다.')
       router.push({ name: 'client-list' })
@@ -347,6 +361,9 @@ function goBack() {
       :ports="ports"
       :currencies="currencies"
       :payment-terms="paymentTerms"
+      :departments="departments"
+      :teams="teams"
+      :lock-team="!isAdmin"
       :all-clients="allClients"
       :saving="saving"
       @close="showFormModal = false"

--- a/src/views/master/ClientListPage.vue
+++ b/src/views/master/ClientListPage.vue
@@ -21,6 +21,7 @@ import {
   fetchClients,
   updateClient,
 } from '@/api/master'
+import { fetchDepartments, fetchTeams } from '@/api/auth'
 import { useMasterLookup } from '@/composables/useMasterLookup'
 import { useToast } from '@/composables/useToast'
 import { label, CLIENT_STATUS_LABEL } from '@/utils/enumLabels'
@@ -33,6 +34,8 @@ const { success, error } = useToast()
 
 const { countries, ports, currencies, paymentTerms, loadReferenceData, getCountryName, getPortName, getPaymentTermsLabel, getCurrencyLabel } = useMasterLookup()
 
+const departments = ref([])
+const teams = ref([])
 const clients = ref([])
 const loading = ref(false)
 const saving = ref(false)
@@ -162,11 +165,15 @@ const paginatedClients = computed(() => {
 async function loadData() {
   loading.value = true
   try {
-    const [clientsData] = await Promise.all([
+    const [clientsData, , deptsData, teamsData] = await Promise.all([
       fetchClients(),
       loadReferenceData(),
+      fetchDepartments(),
+      fetchTeams(),
     ])
     clients.value = clientsData
+    departments.value = deptsData ?? []
+    teams.value = teamsData ?? []
   } catch {
     error('데이터를 불러오는 중 오류가 발생했습니다.')
   } finally {
@@ -365,6 +372,11 @@ function goToDetail(row) {
       :ports="ports"
       :currencies="currencies"
       :payment-terms="paymentTerms"
+      :departments="departments"
+      :teams="teams"
+      :default-department-id="currentUser?.departmentId ?? null"
+      :default-team-id="currentUser?.teamId ?? null"
+      :lock-team="!isAdmin"
       :all-clients="clients"
       :saving="saving"
       @close="showFormModal = false"


### PR DESCRIPTION
## Summary
- **거래처 등록 모달에 담당 부서/팀 선택 UI 추가** — 작성자(현재 로그인 사용자) 팀으로 자동 default. sales 는 잠금, admin 만 변경 가능.
- **거래처 상세에 '담당 조직' 섹션** — departmentName / teamName 표시 (Feign enrich 결과 노출)
- ClientListPage/ClientDetailPage 에서 fetchDepartments/fetchTeams 호출 + 모달에 전달

## 배경
PR #298 에서 백엔드 team_id 전환은 했는데 거래처 폼 UI 갱신을 누락. E2E 스모크에서 '거래처 등록 모달에 부서/팀 선택 필드 자체가 없음 → teamId POST 안 됨' (블로커 4.6.4) 발견.

## Test plan
- [ ] 영업 사용자 로그인 → /clients/new → 본인 팀이 자동 표시되고 disabled
- [ ] 등록 후 목록에서 본인 팀 거래처로 보이는지
- [ ] admin 로그인 → 등록 모달에서 부서 변경 시 팀 드롭다운 필터링
- [ ] 부서/팀 미선택 시 에러 메시지
- [ ] 거래처 상세 페이지에서 '담당 조직' 섹션에 부서/팀 정상 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)