### PR TITLE
fix: 빠른 로그인 UI + 로그인 401/로그아웃 흐름 정리

### DIFF
--- a/src/components/layout/AppHeader.vue
+++ b/src/components/layout/AppHeader.vue
@@ -99,10 +99,10 @@ function handleLogout() {
   isLogoutConfirmOpen.value = true
 }
 
-function confirmLogout() {
+async function confirmLogout() {
   isLogoutConfirmOpen.value = false
-  authStore.logout()
-  router.push({ name: 'login' })
+  await authStore.logout()
+  await router.push({ name: 'login' })
 }
 
 function handleClickOutside(event) {

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -65,10 +65,11 @@ api.interceptors.response.use(
   async (error) => {
     const originalRequest = error.config
 
-    // /auth/refresh 자체의 401 은 인터셉터에서 제외 — 데드락 방지.
-    // 이 guard 가 없으면: refresh 401 → interceptor refresh → 또 401 → 큐 대기 → 영원히 안 풀림.
-    // restoreSession() 의 try-catch 가 직접 처리한다.
-    if (originalRequest?.url?.includes('/auth/refresh')) {
+    // /auth/refresh, /auth/login 의 401 은 인터셉터에서 제외 — 데드락/오류 가림 방지.
+    // refresh 401 을 또 refresh 로 보내면 큐 대기 무한루프, login 401 을 refresh 로 가리면
+    // 잘못된 비밀번호 toast 가 안 뜨고 logout/redirect 만 일어남.
+    const url = originalRequest?.url ?? ''
+    if (url.includes('/auth/refresh') || url.includes('/auth/login')) {
       return Promise.reject(error)
     }
 

--- a/src/views/auth/LoginPage.vue
+++ b/src/views/auth/LoginPage.vue
@@ -10,7 +10,6 @@ import { isValidEmail } from '@/utils/validators'
 
 const router = useRouter()
 const route = useRoute()
-const isDev = import.meta.env.DEV
 const authStore = useAuthStore()
 const { error } = useToast()
 
@@ -20,20 +19,44 @@ const emailError = ref('')
 const passwordError = ref('')
 const loading = ref(false)
 
-const demoAccounts = [
-  { label: '관리자', email: 'admin@salesboost.com', pw: 'test1234' },
-  { label: '영업1팀 팀장', email: 'kim@salesboost.com', pw: 'test1234' },
-  { label: '영업1팀 팀원', email: 'jo@salesboost.com', pw: 'test1234' },
-  { label: '영업2팀', email: 'jung@salesboost.com', pw: 'test1234' },
-  { label: '생산', email: 'lee@salesboost.com', pw: 'test1234' },
-  { label: '출하', email: 'park@salesboost.com', pw: 'test1234' },
+// 빠른 로그인 (시연/QA 용) — data.sql seed 계정 기준, 비밀번호 password123
+const QUICK_PW = 'password123'
+const quickGroups = [
+  {
+    department: '경영지원부',
+    accounts: [
+      { team: '경영지원1팀', role: 'admin', name: '최관리', email: 'admin@hanwha.com' },
+    ],
+  },
+  {
+    department: '영업부',
+    accounts: [
+      { team: '영업1팀', role: '팀장', name: '이영업', email: 'lee.sales@hanwha.com' },
+      { team: '영업1팀', role: '팀원', name: '김영업', email: 'kim.sales@hanwha.com' },
+    ],
+  },
+  {
+    department: '생산부',
+    accounts: [
+      { team: '생산1팀', role: '팀장', name: '최생산', email: 'choi.prod@hanwha.com' },
+      { team: '생산1팀', role: '팀원', name: '박생산', email: 'park.prod@hanwha.com' },
+    ],
+  },
+  {
+    department: '출하부',
+    accounts: [
+      { team: '출하1팀', role: '팀원', name: '정출하', email: 'jung.ship@hanwha.com' },
+    ],
+  },
 ]
 
-function fillDemoAccount(account) {
+async function quickLogin(account) {
+  if (loading.value) return
   email.value = account.email
-  password.value = account.pw
+  password.value = QUICK_PW
   emailError.value = ''
   passwordError.value = ''
+  await handleLogin()
 }
 
 function validate() {
@@ -141,20 +164,31 @@ async function handleLogin() {
       </div>
     </div>
 
-    <!-- Demo 계정 안내 -->
-    <div v-if="isDev" class="w-full rounded-2xl bg-white p-4 shadow-panel">
-      <p class="mb-2 text-xs font-semibold text-slate-600">Demo 계정 (클릭하면 자동 입력)</p>
-      <div class="grid grid-cols-2 gap-2 sm:grid-cols-3">
-        <button
-          v-for="account in demoAccounts"
-          :key="account.email"
-          type="button"
-          class="rounded-lg border border-slate-200 px-3 py-2 text-left text-xs text-slate-600 transition hover:border-brand hover:bg-blue-50 hover:text-brand"
-          @click="fillDemoAccount(account)"
-        >
-          <span class="font-semibold">{{ account.label }}</span>
-          <span class="mt-0.5 block truncate text-slate-400">{{ account.email }}</span>
-        </button>
+    <!-- 빠른 로그인 (QA / 시연) -->
+    <div class="w-full rounded-2xl bg-white p-4 shadow-panel">
+      <div class="mb-3 flex items-baseline justify-between">
+        <p class="text-xs font-semibold text-slate-600">빠른 로그인</p>
+        <p class="text-[11px] text-slate-400">클릭 시 즉시 로그인됩니다</p>
+      </div>
+      <div class="space-y-3">
+        <div v-for="group in quickGroups" :key="group.department">
+          <p class="mb-1.5 text-[11px] font-semibold uppercase tracking-wider text-slate-400">
+            {{ group.department }}
+          </p>
+          <div class="grid grid-cols-2 gap-2 sm:grid-cols-3">
+            <button
+              v-for="account in group.accounts"
+              :key="account.email"
+              type="button"
+              :disabled="loading"
+              class="rounded-lg border border-slate-200 px-3 py-2 text-left text-xs text-slate-600 transition hover:border-brand hover:bg-blue-50 hover:text-brand disabled:cursor-not-allowed disabled:opacity-60"
+              @click="quickLogin(account)"
+            >
+              <span class="font-semibold">{{ account.team }} · {{ account.role }}</span>
+              <span class="mt-0.5 block truncate text-slate-400">{{ account.name }}</span>
+            </button>
+          </div>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- **빠른 로그인** UI 추가 — 부서/팀별 카드, 클릭 시 즉시 로그인 (시연·QA 용)
- **잘못된 비밀번호 toast 미표시** 수정 — axios 인터셉터가 `/auth/login` 의 401 도 refresh 흐름으로 전환해버려 LoginPage 의 catch 가 401 분기에 못 들어감. `/auth/login` 도 `/auth/refresh` 와 함께 인터셉터에서 제외 처리.
- **로그아웃 후 /login 미리다이렉트** 수정 — `authStore.logout()` 이 async 인데 await 없이 `router.push` 호출되어 가드 경합. await 추가.

## 배경
PR #298, #299 이후 E2E 스모크에서 발견된 잔여 결함.
- 0.3 잘못된 비밀번호 → UI 에러 메시지 없음 (블로커 중)
- 0.8 로그아웃 → / 경로에 머무름, 사이드바만 사라짐 (블로커 중)
- 빠른 로그인 누락 (PR #299 두 번째 푸시가 머지 타이밍에 못 들어감)

빠른 로그인 카드는 data.sql seed 계정 기준 (admin/영업·생산·출하 팀장+팀원). 비밀번호는 `password123` 고정.

## Test plan
- [x] /login → 잘못된 비밀번호 → 빨강 toast '이메일 또는 비밀번호가 올바르지 않습니다'
- [x] /login → 빠른 로그인 카드 클릭 (예: 영업1팀 팀원) → 즉시 대시보드 진입
- [x] 로그인 후 헤더 → 로그아웃 → 확인 모달 → /login 으로 리다이렉트, 빠른 로그인 카드 다시 보임
- [x] /auth/refresh 만료 시 (수동으로 RT 쿠키 제거 후 새로고침) → /login 리다이렉트 동작 유지
- [x] 정상 로그인 후 페이지 진입 → 일반 API 401 시 기존 refresh 재시도 흐름 깨지지 않음

🤖 Generated with [Claude Code](https://claude.com/claude-code)