### PR TITLE
fix(dashboard): admin 에게 전체 결재/패키지 노출 + userId 필드 불일치 수정

### DIFF
--- a/src/views/DashboardPage.vue
+++ b/src/views/DashboardPage.vue
@@ -52,13 +52,18 @@ onMounted(async () => {
 })
 
 const currentUser = computed(() => authStore.currentUser ?? null)
+const isAdminUser = computed(() => currentUser.value?.role === 'admin')
 const isProductionUser = computed(() => currentUser.value?.role === 'production')
 const isShippingUser = computed(() => currentUser.value?.role === 'shipping')
 const isSalesManager = computed(() => currentUser.value?.role === 'sales' && Number(currentUser.value?.positionId) === 1)
 const isSalesMember = computed(() => currentUser.value?.role === 'sales' && Number(currentUser.value?.positionId) === 2)
-const canApproveRequests = computed(() => isSalesManager.value)
+// admin 은 모든 팀 결재 현황을 볼 수 있도록 승인자 분기에 포함 (read/review 전반)
+const canApproveRequests = computed(() => isSalesManager.value || isAdminUser.value)
 const showApprovalSection = computed(() => canApproveRequests.value || isSalesMember.value)
-const requestSectionTitle = computed(() => (canApproveRequests.value ? '결재 요청함' : '내 요청 현황'))
+const requestSectionTitle = computed(() => {
+  if (isAdminUser.value) return '전체 결재 현황'
+  return canApproveRequests.value ? '결재 요청함' : '내 요청 현황'
+})
 
 function parseSlashDate(value) {
   if (!value) return 0
@@ -263,7 +268,7 @@ function createRequestItem(docType, row) {
 }
 
 function canReviewRequest(item) {
-  if (isSalesManager.value) {
+  if (isSalesManager.value || isAdminUser.value) {
     return item.docType === 'PI' || item.docType === 'PO'
   }
   return false
@@ -282,14 +287,17 @@ const allRequestItems = computed(() => {
 })
 
 const requestItems = computed(() => {
-  if (canApproveRequests.value) {
+  // admin 은 전체 팀의 모든 상태(대기·승인·반려) 결재 현황을 본다
+  if (isAdminUser.value) {
+    return allRequestItems.value
+  }
+  // 영업 팀장은 자기 팀 대기 건을 본다 (canReviewRequest 가 PI/PO 한정)
+  if (isSalesManager.value) {
     return allRequestItems.value.filter((item) => item.status === '대기' && canReviewRequest(item))
   }
-
   if (isSalesMember.value) {
     return allRequestItems.value.filter((item) => item.requester === currentUser.value?.name)
   }
-
   return []
 })
 
@@ -420,18 +428,30 @@ function goToShipmentItem(item) {
 }
 
 // ── 패키지 섹션 ────────────────────────────────────────────
+const currentUserId = computed(() => {
+  const u = currentUser.value
+  if (!u) return null
+  return String(u.userId ?? u.id ?? '')
+})
+
 const visiblePackages = computed(() => {
   if (!currentUser.value) return []
-  const uid = String(currentUser.value.id)
+  // admin 은 전체 패키지 열람 가능
+  if (isAdminUser.value) {
+    return [...packagesData.value]
+      .sort((a, b) => parseSlashDate(b.createdAt) - parseSlashDate(a.createdAt))
+      .slice(0, 5)
+  }
+  const uid = currentUserId.value
   return [...packagesData.value]
-    .filter((pkg) => String(pkg.creatorId) === uid || (pkg.viewers ?? []).includes(uid))
+    .filter((pkg) => String(pkg.creatorId) === uid || (pkg.viewers ?? []).map(String).includes(uid))
     .sort((a, b) => parseSlashDate(b.createdAt) - parseSlashDate(a.createdAt))
     .slice(0, 5)
 })
 
 const isPackageOwner = computed(() => {
   if (!selectedPackage.value || !currentUser.value) return false
-  return String(selectedPackage.value.creatorId) === String(currentUser.value.id)
+  return String(selectedPackage.value.creatorId) === currentUserId.value
 })
 
 function openPackageDetail(pkg) {


### PR DESCRIPTION
## Summary
- **admin 결재 현황 전체 노출** — 기존엔 영업 팀장만 결재함을 볼 수 있어서 admin 은 대시보드에서 아무 결재 정보도 못 봤음. isAdminUser 조건을 추가해 모든 팀·모든 상태(대기/승인/반려)를 한 화면에서 조회.
- **패키지 필터 버그 수정** — 대시보드 visiblePackages 가 \`currentUser.id\` 를 참조했는데 실제 로그인 응답의 사용자 객체는 \`userId\` 필드만 있음. 결과적으로 모든 role 에서 패키지가 안 보였을 가능성. userId fallback + admin 은 전체 열람 + viewers 비교 시 String 캐스팅.

## 배경
백엔드 쪽은 별도 커밋(auth c483c9a)에서 /auth/login 응답 + JWT claim 에 \`positionId\`/\`positionLevel\` 추가했음. 이전엔 positionId 가 응답에 없어 영업 팀장/팀원 분기도 NaN 으로 깨져 있었던 것도 같이 풀림.

결재 조회 API(/api/approval-requests) 는 이미 백엔드가 전체 반환 중이라 추가 변경 불필요.

## Test plan
- [ ] admin(최관리) 로그인 → 대시보드 하단 **전체 결재 현황** 섹션 노출, 모든 팀 결재 건(대기/승인/반려) 표시
- [ ] 영업1팀 팀장(이영업) 로그인 → **결재 요청함** 에 자기 팀 대기 건
- [ ] 영업1팀 팀원(김영업) 로그인 → **내 요청 현황** 에 자기가 요청한 건
- [ ] 패키지 섹션: seed/테스트에서 생성한 패키지 1건 이상 있으면 admin 에게 전체, 다른 role 에겐 creator/viewers 기준 노출
- [ ] JWT 디코드: accessToken payload 에 positionId, positionLevel 포함 (백엔드 c483c9a rollout 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)