### PR TITLE
fix: QA 잔여 이슈 일괄 (헤더 팀 · 거래처 담당팀 컬럼 · 권한별 API 가드 · 조직 CRUD)

### DIFF
--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -41,6 +41,20 @@ export async function fetchDepartments() {
   return unwrapCollection(data)
 }
 
+export async function createDepartment(department) {
+  const { data } = await api.post('/departments', department)
+  return data
+}
+
+export async function updateDepartment(id, department) {
+  const { data } = await api.put(`/departments/${id}`, department)
+  return data
+}
+
+export async function deleteDepartment(id) {
+  await api.delete(`/departments/${id}`)
+}
+
 export async function fetchTeams(departmentId = null) {
   const params = departmentId != null ? { departmentId } : {}
   const { data } = await api.get('/teams', { params })

--- a/src/components/domain/auth/OrgStructureTab.vue
+++ b/src/components/domain/auth/OrgStructureTab.vue
@@ -1,0 +1,337 @@
+<script setup>
+import { computed, onMounted, ref } from 'vue'
+import BaseButton from '@/components/common/BaseButton.vue'
+import BaseModal from '@/components/common/BaseModal.vue'
+import BaseSelect from '@/components/common/BaseSelect.vue'
+import BaseTextField from '@/components/common/BaseTextField.vue'
+import ConfirmModal from '@/components/common/ConfirmModal.vue'
+import FormField from '@/components/common/FormField.vue'
+import {
+  createDepartment,
+  createTeam,
+  deleteDepartment,
+  deleteTeam,
+  fetchDepartments,
+  fetchTeams,
+  updateDepartment,
+  updateTeam,
+} from '@/api/auth'
+import { useToast } from '@/composables/useToast'
+
+const { success, error } = useToast()
+
+const departments = ref([])
+const teams = ref([])
+const loading = ref(false)
+const selectedDeptId = ref(null)
+
+// 모달 상태
+const deptModalOpen = ref(false)
+const deptMode = ref('create')
+const deptForm = ref({ id: null, name: '' })
+const deptError = ref('')
+
+const teamModalOpen = ref(false)
+const teamMode = ref('create')
+const teamForm = ref({ id: null, teamName: '', departmentId: null })
+const teamError = ref('')
+
+const confirmOpen = ref(false)
+const confirmTarget = ref(null) // { kind: 'dept'|'team', id, name }
+const deleting = ref(false)
+
+async function load() {
+  loading.value = true
+  try {
+    const [depts, ts] = await Promise.all([fetchDepartments(), fetchTeams()])
+    departments.value = depts ?? []
+    teams.value = ts ?? []
+    if (!selectedDeptId.value && departments.value.length > 0) {
+      selectedDeptId.value = departments.value[0].departmentId ?? departments.value[0].id
+    }
+  } catch (e) {
+    error('조직 정보를 불러오지 못했습니다.')
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(load)
+
+const deptOptions = computed(() =>
+  departments.value.map((d) => ({ label: d.departmentName ?? d.name, value: d.departmentId ?? d.id })),
+)
+
+const teamsOfSelected = computed(() =>
+  teams.value.filter((t) => String(t.departmentId) === String(selectedDeptId.value)),
+)
+
+const selectedDepartment = computed(() =>
+  departments.value.find((d) => String(d.departmentId ?? d.id) === String(selectedDeptId.value)),
+)
+
+// ── 부서 ─────────────────────────────────────────
+function openCreateDept() {
+  deptMode.value = 'create'
+  deptForm.value = { id: null, name: '' }
+  deptError.value = ''
+  deptModalOpen.value = true
+}
+
+function openEditDept(dept) {
+  deptMode.value = 'edit'
+  deptForm.value = {
+    id: dept.departmentId ?? dept.id,
+    name: dept.departmentName ?? dept.name,
+  }
+  deptError.value = ''
+  deptModalOpen.value = true
+}
+
+async function saveDept() {
+  const name = deptForm.value.name?.trim()
+  if (!name) {
+    deptError.value = '부서명을 입력하세요.'
+    return
+  }
+  try {
+    if (deptMode.value === 'create') {
+      await createDepartment({ name })
+      success('부서가 생성되었습니다.')
+    } else {
+      await updateDepartment(deptForm.value.id, { name })
+      success('부서명이 수정되었습니다.')
+    }
+    deptModalOpen.value = false
+    await load()
+  } catch (e) {
+    error(e.response?.data?.message ?? '저장 중 오류가 발생했습니다.')
+  }
+}
+
+function askDeleteDept(dept) {
+  confirmTarget.value = {
+    kind: 'dept',
+    id: dept.departmentId ?? dept.id,
+    name: dept.departmentName ?? dept.name,
+  }
+  confirmOpen.value = true
+}
+
+// ── 팀 ─────────────────────────────────────────
+function openCreateTeam() {
+  if (!selectedDeptId.value) {
+    error('먼저 부서를 선택하세요.')
+    return
+  }
+  teamMode.value = 'create'
+  teamForm.value = { id: null, teamName: '', departmentId: selectedDeptId.value }
+  teamError.value = ''
+  teamModalOpen.value = true
+}
+
+function openEditTeam(team) {
+  teamMode.value = 'edit'
+  teamForm.value = {
+    id: team.teamId,
+    teamName: team.teamName,
+    departmentId: team.departmentId,
+  }
+  teamError.value = ''
+  teamModalOpen.value = true
+}
+
+async function saveTeam() {
+  const name = teamForm.value.teamName?.trim()
+  if (!name) {
+    teamError.value = '팀명을 입력하세요.'
+    return
+  }
+  if (!teamForm.value.departmentId) {
+    teamError.value = '소속 부서를 선택하세요.'
+    return
+  }
+  try {
+    if (teamMode.value === 'create') {
+      await createTeam({
+        teamName: name,
+        departmentId: Number(teamForm.value.departmentId),
+      })
+      success('팀이 생성되었습니다.')
+    } else {
+      await updateTeam(teamForm.value.id, {
+        teamName: name,
+        departmentId: Number(teamForm.value.departmentId),
+      })
+      success('팀 정보가 수정되었습니다.')
+    }
+    teamModalOpen.value = false
+    await load()
+  } catch (e) {
+    error(e.response?.data?.message ?? '저장 중 오류가 발생했습니다.')
+  }
+}
+
+function askDeleteTeam(team) {
+  confirmTarget.value = { kind: 'team', id: team.teamId, name: team.teamName }
+  confirmOpen.value = true
+}
+
+async function confirmDelete() {
+  if (!confirmTarget.value) return
+  deleting.value = true
+  try {
+    if (confirmTarget.value.kind === 'dept') {
+      await deleteDepartment(confirmTarget.value.id)
+      success('부서가 삭제되었습니다.')
+      if (String(selectedDeptId.value) === String(confirmTarget.value.id)) {
+        selectedDeptId.value = null
+      }
+    } else {
+      await deleteTeam(confirmTarget.value.id)
+      success('팀이 삭제되었습니다.')
+    }
+    confirmOpen.value = false
+    await load()
+  } catch (e) {
+    error(e.response?.data?.message ?? '삭제할 수 없습니다. (소속된 하위 항목이 있을 수 있습니다)')
+  } finally {
+    deleting.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="space-y-4">
+    <div v-if="loading" class="py-12 text-center text-sm text-slate-400">
+      불러오는 중...
+    </div>
+
+    <div v-else class="grid grid-cols-1 gap-4 lg:grid-cols-5">
+      <!-- 부서 패널 -->
+      <div class="rounded-2xl border border-slate-200 bg-white lg:col-span-2">
+        <div class="flex items-center justify-between border-b border-slate-100 px-5 py-3">
+          <h3 class="text-sm font-bold text-ink">부서</h3>
+          <BaseButton variant="primary" size="sm" @click="openCreateDept">+ 부서 추가</BaseButton>
+        </div>
+        <ul class="divide-y divide-slate-100">
+          <li
+            v-for="dept in departments"
+            :key="dept.departmentId ?? dept.id"
+            class="flex cursor-pointer items-center gap-2 px-5 py-3 transition hover:bg-slate-50"
+            :class="String(dept.departmentId ?? dept.id) === String(selectedDeptId) ? 'bg-slate-50' : ''"
+            @click="selectedDeptId = dept.departmentId ?? dept.id"
+          >
+            <span class="flex-1 text-sm font-medium text-ink">
+              {{ dept.departmentName ?? dept.name }}
+            </span>
+            <button
+              type="button"
+              class="text-xs text-slate-500 hover:text-brand"
+              @click.stop="openEditDept(dept)"
+            >수정</button>
+            <button
+              type="button"
+              class="text-xs text-slate-500 hover:text-rose-500"
+              @click.stop="askDeleteDept(dept)"
+            >삭제</button>
+          </li>
+          <li v-if="departments.length === 0" class="px-5 py-8 text-center text-xs text-slate-400">
+            부서가 없습니다.
+          </li>
+        </ul>
+      </div>
+
+      <!-- 팀 패널 -->
+      <div class="rounded-2xl border border-slate-200 bg-white lg:col-span-3">
+        <div class="flex items-center justify-between border-b border-slate-100 px-5 py-3">
+          <h3 class="text-sm font-bold text-ink">
+            {{ selectedDepartment ? `${selectedDepartment.departmentName ?? selectedDepartment.name} · 팀` : '팀' }}
+          </h3>
+          <BaseButton
+            variant="primary"
+            size="sm"
+            :disabled="!selectedDeptId"
+            @click="openCreateTeam"
+          >
+            + 팀 추가
+          </BaseButton>
+        </div>
+        <ul class="divide-y divide-slate-100">
+          <li
+            v-for="team in teamsOfSelected"
+            :key="team.teamId"
+            class="flex items-center gap-2 px-5 py-3"
+          >
+            <span class="flex-1 text-sm font-medium text-ink">{{ team.teamName }}</span>
+            <button
+              type="button"
+              class="text-xs text-slate-500 hover:text-brand"
+              @click="openEditTeam(team)"
+            >수정</button>
+            <button
+              type="button"
+              class="text-xs text-slate-500 hover:text-rose-500"
+              @click="askDeleteTeam(team)"
+            >삭제</button>
+          </li>
+          <li v-if="teamsOfSelected.length === 0" class="px-5 py-8 text-center text-xs text-slate-400">
+            이 부서에 등록된 팀이 없습니다.
+          </li>
+        </ul>
+      </div>
+    </div>
+
+    <!-- 부서 모달 -->
+    <BaseModal
+      :open="deptModalOpen"
+      :title="deptMode === 'create' ? '부서 추가' : '부서 수정'"
+      width="max-w-md"
+      @close="deptModalOpen = false"
+    >
+      <form class="space-y-4" @submit.prevent="saveDept">
+        <FormField label="부서명" required :error="deptError">
+          <BaseTextField v-model="deptForm.name" placeholder="예: 영업부" />
+        </FormField>
+      </form>
+      <template #footer>
+        <BaseButton variant="secondary" @click="deptModalOpen = false">취소</BaseButton>
+        <BaseButton variant="primary" @click="saveDept">저장</BaseButton>
+      </template>
+    </BaseModal>
+
+    <!-- 팀 모달 -->
+    <BaseModal
+      :open="teamModalOpen"
+      :title="teamMode === 'create' ? '팀 추가' : '팀 수정'"
+      width="max-w-md"
+      @close="teamModalOpen = false"
+    >
+      <form class="space-y-4" @submit.prevent="saveTeam">
+        <FormField label="소속 부서" required>
+          <BaseSelect v-model="teamForm.departmentId" :options="deptOptions" placeholder="부서를 선택하세요" />
+        </FormField>
+        <FormField label="팀명" required :error="teamError">
+          <BaseTextField v-model="teamForm.teamName" placeholder="예: 영업1팀" />
+        </FormField>
+      </form>
+      <template #footer>
+        <BaseButton variant="secondary" @click="teamModalOpen = false">취소</BaseButton>
+        <BaseButton variant="primary" @click="saveTeam">저장</BaseButton>
+      </template>
+    </BaseModal>
+
+    <!-- 삭제 확인 -->
+    <ConfirmModal
+      :open="confirmOpen"
+      :title="confirmTarget?.kind === 'dept' ? '부서 삭제' : '팀 삭제'"
+      :message="`${confirmTarget?.name} 을(를) 삭제하시겠습니까?`"
+      :detail="confirmTarget?.kind === 'dept' ? '소속된 팀/사용자가 있으면 삭제되지 않습니다.' : '소속된 사용자가 있으면 삭제되지 않습니다.'"
+      confirm-label="삭제"
+      confirm-variant="danger"
+      :loading="deleting"
+      @confirm="confirmDelete"
+      @cancel="confirmOpen = false"
+    />
+  </div>
+</template>

--- a/src/components/layout/AppHeader.vue
+++ b/src/components/layout/AppHeader.vue
@@ -70,6 +70,12 @@ const userRole = computed(() => {
 const userEmployeeNo = computed(() => loggedInUser.value?.employeeNo || '-')
 const userEmail = computed(() => loggedInUser.value?.userEmail ?? loggedInUser.value?.email ?? '-')
 const userDepartment = computed(() => loggedInUser.value?.departmentName || userRole.value)
+const userTeam = computed(() => loggedInUser.value?.teamName || '')
+const userAffiliation = computed(() => {
+  const team = userTeam.value
+  const role = userRole.value
+  return team ? `${team} · ${role}` : role
+})
 
 const isProfileOpen = ref(false)
 const isProfileEditOpen = ref(false)
@@ -189,7 +195,7 @@ onBeforeUnmount(() => {
           <div class="flex h-7 w-7 items-center justify-center rounded-lg bg-brand text-[11px] font-semibold text-white">{{ userInitial }}</div>
           <div>
             <div class="text-[12px] font-semibold text-[#32363A]">{{ userName }}</div>
-            <div class="text-[10px] text-slate-400">{{ userRole }}</div>
+            <div class="text-[10px] text-slate-400">{{ userAffiliation }}</div>
           </div>
           <i class="fas fa-chevron-down text-[9px] text-slate-300" />
         </div>
@@ -204,7 +210,7 @@ onBeforeUnmount(() => {
               <div class="flex h-10 w-10 items-center justify-center rounded-lg bg-brand text-sm font-semibold text-white">{{ userInitial }}</div>
               <div class="min-w-0 flex-1">
                 <div class="truncate text-sm font-semibold text-slate-800">{{ userName }}</div>
-                <div class="truncate text-xs text-slate-400">{{ userRole }}</div>
+                <div class="truncate text-xs text-slate-400">{{ userAffiliation }}</div>
               </div>
             </div>
           </div>

--- a/src/components/layout/AppSidebar.vue
+++ b/src/components/layout/AppSidebar.vue
@@ -103,12 +103,6 @@ onMounted(async () => {
       </section>
     </nav>
 
-    <div class="border-t border-slate-100 px-4 py-3">
-      <div class="flex items-center gap-2 text-xs font-medium text-slate-400">
-        <span class="inline-block h-1.5 w-1.5 rounded-full bg-emerald-400"></span>
-        운영 준비 완료
-      </div>
-    </div>
   </aside>
 
   <!-- 데스크톱: 토글 핸들 (aside 바깥, overflow-hidden에 잘리지 않도록) -->
@@ -190,12 +184,5 @@ onMounted(async () => {
       </section>
     </nav>
 
-    <!-- 하단 상태 -->
-    <div class="border-t border-slate-100 py-3" :class="uiStore.sidebarOpen ? 'px-4' : 'px-0'">
-      <div class="flex items-center gap-2 text-xs font-medium text-slate-400" :class="{ 'justify-center': !uiStore.sidebarOpen }">
-        <span class="inline-block h-1.5 w-1.5 flex-shrink-0 rounded-full bg-emerald-400"></span>
-        <span v-if="uiStore.sidebarOpen">운영 준비 완료</span>
-      </div>
-    </div>
   </aside>
 </template>

--- a/src/stores/productionOrderDocuments.js
+++ b/src/stores/productionOrderDocuments.js
@@ -62,7 +62,11 @@ export async function loadProductionOrderDocuments() {
 }
 
 export function useProductionOrderDocuments() {
-  if (!loading && useAuthStore().isLoggedIn) {
+  const auth = useAuthStore()
+  const role = auth.currentUser?.role
+  // 생산지시서는 admin/sales/production 만 조회 권한. shipping 에서 401/403 유발 방지.
+  const allowed = ['admin', 'sales', 'production'].includes(role)
+  if (!loading && auth.isLoggedIn && allowed) {
     loading = loadProductionOrderDocuments()
   }
   return productionOrderDocuments

--- a/src/stores/shipmentStatusDocuments.js
+++ b/src/stores/shipmentStatusDocuments.js
@@ -37,7 +37,11 @@ export async function loadShipmentStatusDocuments() {
 }
 
 export function useShipmentStatusDocuments() {
-  if (!loading && useAuthStore().isLoggedIn) {
+  const auth = useAuthStore()
+  const role = auth.currentUser?.role
+  // 출하현황은 admin/sales/shipping 만 조회 권한. production 에서 401/403 유발 방지.
+  const allowed = ['admin', 'sales', 'shipping'].includes(role)
+  if (!loading && auth.isLoggedIn && allowed) {
     loading = loadShipmentStatusDocuments()
   }
   return shipmentStatusDocuments

--- a/src/views/auth/UserManagementPage.vue
+++ b/src/views/auth/UserManagementPage.vue
@@ -4,6 +4,7 @@ import BaseButton from '@/components/common/BaseButton.vue'
 import BaseTabs from '@/components/common/BaseTabs.vue'
 import PageHeader from '@/components/common/PageHeader.vue'
 import CompanyInfoTab from '@/components/domain/auth/CompanyInfoTab.vue'
+import OrgStructureTab from '@/components/domain/auth/OrgStructureTab.vue'
 import UserListTab from '@/components/domain/auth/UserListTab.vue'
 
 const activeTab = ref('users')
@@ -11,6 +12,7 @@ const userListRef = ref(null)
 
 const tabs = [
   { key: 'users', label: '사용자 목록' },
+  { key: 'org', label: '조직 관리' },
   { key: 'company', label: '자사 정보' },
 ]
 
@@ -40,6 +42,7 @@ function handleCreateUser() {
 
     <!-- 탭 내용 -->
     <UserListTab v-if="activeTab === 'users'" ref="userListRef" />
+    <OrgStructureTab v-else-if="activeTab === 'org'" />
     <CompanyInfoTab v-else />
   </div>
 </template>

--- a/src/views/master/ClientListPage.vue
+++ b/src/views/master/ClientListPage.vue
@@ -77,6 +77,7 @@ const columns = [
   { key: 'paymentTerms', label: '결제조건', width: '100px', align: 'center' },
   { key: 'currency', label: '통화', width: '80px', align: 'center' },
   { key: 'clientManager', label: '거래처 담당자', width: '140px' },
+  { key: 'teamLabel', label: '담당 팀', width: '130px' },
   { key: 'clientStatus', label: '상태', width: '80px', align: 'center' },
   { key: 'actions', label: '', width: '120px', align: 'center', sortable: false },
 ]
@@ -88,6 +89,9 @@ const enrichedClients = computed(() =>
     portName: c.portName ?? getPortName(c.portId),
     paymentTermsCode: getPaymentTermsLabel(c.paymentTermsId),
     currencyCode: getCurrencyLabel(c.currencyId),
+    teamLabel: c.teamName
+      ? (c.departmentName ? `${c.departmentName} / ${c.teamName}` : c.teamName)
+      : '-',
   })),
 )
 


### PR DESCRIPTION
## Summary
E2E QA 보고의 블로커 하·중 이슈들을 한 번에 정리.

1. **헤더 프로필 affiliation 에 팀명 추가** (F1-1)
   "최관리 / 관리자" → "최관리 / 경영지원1팀 · 관리자"

2. **대시보드 권한별 API 가드** (F1-2 — 블로커 중)
   \`productionOrderDocuments\` / \`shipmentStatusDocuments\` store 가 role 관계없이 자동 fetch 되어 shipping·production 사용자 진입 시 403 콘솔에러 2건 발생하던 것 제거. role 허용 목록 체크 후 fetch.

3. **거래처 목록에 담당 팀 컬럼** (F4-1)
   '부서 / 팀' 조합 표시. teamName 없으면 '-'.

4. **사용자 관리에 '조직 관리' 탭 신설** (F17 — 블로커 중)
   - 부서: 생성/수정/삭제 (소속 팀·사용자 있으면 백엔드가 409 반환해서 차단 토스트 노출)
   - 팀: 부서 선택 → 팀 목록 마스터·디테일, 부서 이동 포함
   - 기존 사용자 등록 모달의 부서/팀 드롭다운은 동일하게 동작

5. **사이드바 '운영 준비 완료' 디버그 텍스트 제거** (잉여)

## 보류 / 별도 처리
- 로그인 실패 toast (F0-1), JWT teamId (F0-2): auth 백엔드 이미지 롤아웃 이후 재검증 필요
- 테스트 잔여 거래처/팀 데이터: DB 직접 DELETE (리눅스 박스 SQL)
- 프로필 편집: 헤더에 이미 '내정보 수정' 모달 있음 (재확인 완료)

## Test plan
- [ ] shipping/production 로그인 → 대시보드 콘솔에러 0건
- [ ] 헤더 드롭다운에 팀명 포함 affiliation 표시
- [ ] /clients 목록 '담당 팀' 컬럼 렌더
- [ ] /users → '조직 관리' 탭 → 부서/팀 CRUD, 삭제 실패 케이스(사용자 소속된 팀 삭제 시도)에서 토스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)