### PR TITLE
fix: QA 전수조사 잔여 이슈 일괄 (페이지네이션/패키지 UX/대시보드 빈상태)

### DIFF
--- a/src/api/activity.js
+++ b/src/api/activity.js
@@ -34,6 +34,6 @@ export async function fetchPOsByClient(clientId) {
 }
 
 export async function fetchAllActivityPOs() {
-  const { data } = await api.get('/purchase-orders')
+  const { data } = await api.get('/purchase-orders', { params: { size: 1000 } })
   return unwrapCollection(data)
 }

--- a/src/api/master.js
+++ b/src/api/master.js
@@ -2,8 +2,10 @@ import { api } from '@/lib/api'
 import { unwrapCollection } from '@/utils/apiResponse'
 
 // Clients
-export const fetchClients = () =>
-  api.get('/clients').then((r) => unwrapCollection(r.data, 'clientResponseList'))
+// 서버가 PagedModel(default size 10) 를 반환하므로, 목록 화면은 클라이언트 페이지네이션을 쓰는
+// 상황에선 충분히 큰 size 로 한 번에 로드해서 전체를 확보한다.
+export const fetchClients = (params = { size: 1000 }) =>
+  api.get('/clients', { params }).then((r) => unwrapCollection(r.data, 'clientResponseList'))
 export const fetchClient = (id) => api.get(`/clients/${id}`).then((r) => r.data)
 export const createClient = (client) => api.post('/clients', client).then((r) => r.data)
 export const updateClient = (id, client) => api.put(`/clients/${id}`, client).then((r) => r.data)
@@ -13,8 +15,8 @@ export async function changeClientStatus(id, status) {
 }
 
 // Items (ItemQueryController 는 PagedResponse 형식 유지)
-export const fetchItems = () =>
-  api.get('/items').then((r) => unwrapCollection(r.data, 'itemResponseList'))
+export const fetchItems = (params = { size: 1000 }) =>
+  api.get('/items', { params }).then((r) => unwrapCollection(r.data, 'itemResponseList'))
 export const fetchItem = (id) => api.get(`/items/${id}`).then((r) => r.data)
 export const createItem = (item) => api.post('/items', item).then((r) => r.data)
 export const updateItem = (id, item) => api.put(`/items/${id}`, item).then((r) => r.data)

--- a/src/views/DashboardPage.vue
+++ b/src/views/DashboardPage.vue
@@ -605,7 +605,7 @@ async function confirmPackageDelete() {
     </BaseCard>
 
     <!-- 공유 활동기록 패키지 (생산/출하: 요약카드 바로 뒤에 표시됨, 영업: 결재 뒤에 표시) -->
-    <BaseCard v-if="visiblePackages.length > 0 && !isProductionUser && !isShippingUser">
+    <BaseCard v-if="!isProductionUser && !isShippingUser">
       <template #title>
         <h3 class="flex items-center gap-2 font-bold text-slate-800">
           <i class="fas fa-cube text-brand-500" />
@@ -617,7 +617,10 @@ async function confirmPackageDelete() {
           전체보기 <i class="fas fa-chevron-right ml-0.5 text-[9px]" />
         </RouterLink>
       </template>
-      <div class="space-y-2">
+      <div v-if="visiblePackages.length === 0" class="py-6 text-center text-sm text-slate-400">
+        공유된 활동기록 패키지가 없습니다.
+      </div>
+      <div v-else class="space-y-2">
         <div
           v-for="pkg in visiblePackages"
           :key="pkg.id"
@@ -628,8 +631,12 @@ async function confirmPackageDelete() {
             <i class="fas fa-cube" />
           </div>
           <div class="min-w-0 flex-1">
-            <div class="truncate font-medium text-slate-800 transition group-hover:text-brand-600">{{ pkg.title }}</div>
-            <div class="truncate text-xs text-slate-400 sm:whitespace-normal">{{ pkg.creatorName }} · {{ pkg.createdAt }}</div>
+            <div class="truncate font-medium text-slate-800 transition group-hover:text-brand-600">
+              {{ pkg.packageTitle ?? pkg.title ?? '-' }}
+            </div>
+            <div class="truncate text-xs text-slate-400 sm:whitespace-normal">
+              {{ pkg.creatorName ?? '-' }} · {{ pkg.createdAt ?? '-' }}
+            </div>
           </div>
           <i class="fas fa-chevron-right text-xs text-slate-300 self-center" />
         </div>

--- a/src/views/package/ActivityPackagePage.vue
+++ b/src/views/package/ActivityPackagePage.vue
@@ -105,16 +105,19 @@ const poSearchKeyword = ref('')
 const selectedPoId = ref('')
 
 const filteredPoList = computed(() => {
-  if (!dateFrom.value) return []
   let list = poList.value
-  const from = dateFrom.value.replaceAll('-', '/')
-  const to   = dateTo.value.replaceAll('-', '/')
-  if (from) list = list.filter((p) => p.date >= from)
-  if (to)   list = list.filter((p) => p.date <= to)
+  // PO 응답 필드는 issueDate(LocalDate ISO: YYYY-MM-DD). YYYY-MM-DD 형식으로 정규화해 비교.
+  const norm = (s) => (s ? String(s).slice(0, 10).replaceAll('/', '-') : '')
+  const from = norm(dateFrom.value)
+  const to = norm(dateTo.value)
+  if (from) list = list.filter((p) => norm(p.issueDate ?? p.date) >= from)
+  if (to) list = list.filter((p) => norm(p.issueDate ?? p.date) <= to)
   const q = poSearchKeyword.value.trim().toLowerCase()
   if (!q) return list
   return list.filter(
-    (p) => String(p.poId ?? '').toLowerCase().includes(q) || (p.title ?? '').toLowerCase().includes(q),
+    (p) =>
+      String(p.poId ?? '').toLowerCase().includes(q) ||
+      (p.clientName ?? '').toLowerCase().includes(q),
   )
 })
 
@@ -144,32 +147,42 @@ const selectedViewerIds = ref([])
 const viewerSearchQuery = ref('')
 const viewerDeptFilter = ref('')
 
-const departmentNameById = computed(() => new Map(departments.value.map(d => [String(d.id), d.name])))
-const positionNameById = computed(() => new Map(positions.value.map(p => [String(p.id), p.name])))
+// 백엔드 Department 응답은 departmentId / departmentName 필드. Position 도 동일.
+// 이전엔 d.id / d.name 으로 접근해 전부 undefined 로 표시됐었다.
+const departmentNameById = computed(() => new Map(
+  departments.value.map(d => [String(d.departmentId ?? d.id), d.departmentName ?? d.name])
+))
+const positionNameById = computed(() => new Map(
+  positions.value.map(p => [String(p.positionId ?? p.id), p.positionName ?? p.name])
+))
 
 const deptOptions = computed(() => [
   { label: '전체 부서', value: '' },
-  ...departments.value.map((d) => ({ label: d.name, value: String(d.id) })),
+  ...departments.value.map((d) => ({
+    label: d.departmentName ?? d.name,
+    value: String(d.departmentId ?? d.id),
+  })),
 ])
 
 const filteredUsers = computed(() => {
   const q = viewerSearchQuery.value.trim().toLowerCase()
-  let userList = allUsers.value.filter((u) => String(u.id) !== String(currentUser.value?.id))
+  const meId = String(currentUser.value?.userId ?? currentUser.value?.id ?? '')
+  let userList = allUsers.value.filter((u) => String(u.userId ?? u.id) !== meId)
   if (viewerDeptFilter.value) {
     userList = userList.filter((u) => String(u.departmentId) === viewerDeptFilter.value)
   }
   if (!q) return userList
   return userList.filter((u) =>
-    u.name.toLowerCase().includes(q) ||
+    (u.userName ?? u.name ?? '').toLowerCase().includes(q) ||
     (u.employeeNo ?? '').includes(q) ||
-    (u.email ?? '').toLowerCase().includes(q),
+    (u.userEmail ?? u.email ?? '').toLowerCase().includes(q),
   )
 })
 
 const groupedUsers = computed(() => {
   const groups = new Map()
   for (const user of filteredUsers.value) {
-    const deptId = String(user.departmentId)
+    const deptId = String(user.departmentId ?? '')
     const deptName = departmentNameById.value.get(deptId) || '기타'
     if (!groups.has(deptId)) groups.set(deptId, { deptId, deptName, users: [] })
     groups.get(deptId).users.push(user)
@@ -179,11 +192,11 @@ const groupedUsers = computed(() => {
 
 const isAllViewersSelected = computed(() =>
   filteredUsers.value.length > 0 &&
-  filteredUsers.value.every((u) => selectedViewerIds.value.includes(String(u.id))),
+  filteredUsers.value.every((u) => selectedViewerIds.value.includes(String(u.userId ?? u.id))),
 )
 
 function isDeptAllSelected(users) {
-  return users.length > 0 && users.every((u) => selectedViewerIds.value.includes(String(u.id)))
+  return users.length > 0 && users.every((u) => selectedViewerIds.value.includes(String(u.userId ?? u.id)))
 }
 
 function toggleViewer(userId) {
@@ -196,7 +209,7 @@ function toggleViewer(userId) {
 }
 
 function toggleAllViewers(checked) {
-  const ids = filteredUsers.value.map((u) => String(u.id))
+  const ids = filteredUsers.value.map((u) => String(u.userId ?? u.id))
   if (checked) {
     selectedViewerIds.value = [...new Set([...selectedViewerIds.value, ...ids])]
   } else {
@@ -205,7 +218,7 @@ function toggleAllViewers(checked) {
 }
 
 function toggleDeptViewers(users, checked) {
-  const ids = users.map((u) => String(u.id))
+  const ids = users.map((u) => String(u.userId ?? u.id))
   if (checked) {
     selectedViewerIds.value = [...new Set([...selectedViewerIds.value, ...ids])]
   } else {
@@ -423,12 +436,15 @@ async function savePackage() {
               />
             </div>
 
-            <!-- 키워드 검색 -->
+            <!-- 활동기록 키워드 필터 -->
             <div class="space-y-1.5">
-              <p class="text-sm font-semibold text-slate-700">키워드 검색</p>
+              <p class="text-sm font-semibold text-slate-700">
+                활동기록 키워드 필터
+                <span class="ml-1 text-xs font-normal text-slate-400">(오른쪽 목록을 제목/내용으로 좁혀서 보기)</span>
+              </p>
               <BaseTextField
                 v-model="keyword"
-                placeholder="제목, 내용 등 키워드 검색"
+                placeholder="활동 제목 또는 내용 일부"
               />
             </div>
 
@@ -533,21 +549,21 @@ async function savePackage() {
                     <!-- 사용자 행 -->
                     <label
                       v-for="user in group.users"
-                      :key="user.id"
+                      :key="user.userId ?? user.id"
                       class="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 pl-6 transition hover:bg-slate-100"
                     >
                       <input
                         type="checkbox"
                         class="rounded border-slate-300 text-brand-500"
-                        :checked="selectedViewerIds.includes(String(user.id))"
-                        @change="toggleViewer(user.id)"
+                        :checked="selectedViewerIds.includes(String(user.userId ?? user.id))"
+                        @change="toggleViewer(user.userId ?? user.id)"
                       />
                       <div class="min-w-0 flex-1">
                         <p class="text-sm text-slate-700">
                           <span class="mr-1.5 text-xs text-slate-400">{{ user.employeeNo }}</span>
-                          {{ user.name }}
+                          {{ user.userName ?? user.name }}
                         </p>
-                        <p class="truncate text-xs text-slate-400">{{ user.email || '' }}</p>
+                        <p class="truncate text-xs text-slate-400">{{ user.userEmail ?? user.email ?? '' }}</p>
                       </div>
                       <span class="ml-auto shrink-0 text-xs text-slate-400">{{ positionNameById.get(String(user.positionId)) || '' }}</span>
                     </label>


### PR DESCRIPTION
## Summary
2차 전수 QA 결과의 프론트 결함을 일괄 정리. 백엔드 수정분(team2-backend-documents \`fcf7e75\` — 문서 총액 서버재계산 + 출하지시서 대표 품목명 추출)은 별도 main 푸시로 이미 반영.

### 페이지네이션 (블로커 상)
- 서버가 PagedModel(size 10 기본)을 반환하는데 목록 화면들이 page 메타 참조 없이 클라이언트 페이지네이션만 하고 있어 "총 N건" 과 페이지 이동이 모두 현재 페이지 10건에 갇혀 있었음
- fetchClients / fetchItems / fetchAllActivityPOs 의 기본 params 에 \`size: 1000\` 지정해 한 번에 전량 수급

### 활동 패키지 (P2 ~ P4, 블로커 상)
- **P4 부서 드롭다운 'undefined'**: 백엔드 응답 필드는 \`departmentName\` 인데 프론트가 \`d.name\` 접근. 같은 API 쓰는 /users 페이지는 정상 동작하는 것으로 원인 확정. \`departmentId/departmentName\` fallback 으로 수정, 사용자 필드도 \`userId ?? id\` / \`userName ?? name\` fallback.
- **P3 PO 검색 모달 0건**: PO 응답은 \`issueDate\` (ISO YYYY-MM-DD) 인데 프론트가 \`p.date\` + 슬래시 포맷으로 비교해 항상 불일치. \`issueDate\` 로 수정 + 포맷 정규화. \`dateFrom\` 없어도 전체 표시.
- **P2 키워드 검색 의미 불명**: 라벨/placeholder 를 '활동기록 키워드 필터' 로 명확화 + 부연 문구.

### 대시보드 패키지 섹션
- \`v-if="visiblePackages.length > 0"\` 이라 0건이면 섹션 자체가 사라져 사용자가 기능 존재 여부를 인지 못함. 빈 상태 메시지('공유된 활동기록 패키지가 없습니다.') 노출로 변경 + \`pkg.packageTitle\` fallback.

## 관련 백엔드 커밋
- team2-backend-documents \`fcf7e75\`: CI 총액 100배 오류(Stainless Steel Coil × 2 × ₩50 = ₩100 인데 ₩10,000) 및 출하지시서 품목명 빈 문자열 수정

## 남은 이슈 (이번 PR 범위 외)
- 대시보드 shipment/production documents 403 (admin 세션) — backend RBAC 설정 검토 필요
- 로그인 실패 토스트 미표시 — PR #300 로직상 동작해야 하는데 여전히 failing 으로 보고됨. 실제 배포 이미지 재확인 필요

## Test plan
- [ ] /master/clients 20건 전수 표시, 페이지 이동 동작
- [ ] /master/items 21건 전수 표시
- [ ] /package 열람권한 드롭다운: 영업부/생산부/출하부/경영지원부 정상 표시, undefined 없음
- [ ] /package PO 검색 모달: 기간 선택 시 해당 범위 PO 노출, 기간 비워도 전체 표시
- [ ] /package 키워드 검색: 라벨·placeholder 문구 '활동기록 키워드 필터'
- [ ] 대시보드: 패키지 섹션 빈 상태 메시지 노출 (0건인 경우)

🤖 Generated with [Claude Code](https://claude.com/claude-code)