### PR TITLE
fix(#304): QA 표시 fixes 묶음 — 결재자/PI·PO 바이어/수금 총건수/헤더/도착항

### DIFF
--- a/src/components/common/BaseTable.vue
+++ b/src/components/common/BaseTable.vue
@@ -242,7 +242,7 @@ onBeforeUnmount(() => {
             v-for="column in normalizedColumns"
             :key="column.key"
             scope="col"
-            class="relative select-none border-b border-r border-slate-200 px-4 py-3 text-sm font-bold text-slate-700 last:border-r-0"
+            class="relative select-none whitespace-nowrap border-b border-r border-slate-200 px-4 py-3 text-sm font-bold text-slate-700 last:border-r-0"
             :class="[getHeaderAlignmentClass(column.align), column.sortable !== false ? 'cursor-pointer hover:bg-slate-100 transition-colors' : '']"
             :style="getColumnStyle(column)"
             @click="toggleSort(column)"

--- a/src/utils/documentApproval.js
+++ b/src/utils/documentApproval.js
@@ -58,8 +58,8 @@ export function buildApprovalRequestRows({
 }) {
   return [
     { label: '요청 유형', value: requestTypeLabel },
-    { label: '결재자', value: approver || '-' },
-    { label: '요청자', value: requesterName || '-' },
+    { label: '결재자', value: approver || '미지정' },
+    { label: '요청자', value: requesterName || '미지정' },
     { label: '문서 상태', value: documentStatus || '-' },
     { label: '요청 상태', value: requestStatus || '-' },
     { label: '처리 방식', value: applyPolicy || '-', fullWidth: true },
@@ -76,8 +76,8 @@ export function buildApprovalInfoRows(document) {
     { label: '문서 상태', value: document.status || '-' },
     { label: '결재 상태', value: document.approvalStatus || '-' },
     { label: '요청 상태', value: document.requestStatus || '-' },
-    { label: '결재자', value: document.approver || '-' },
-    { label: '요청자', value: document.approvalRequestedBy || '-' },
+    { label: '결재자', value: document.approver || '미지정' },
+    { label: '요청자', value: document.approvalRequestedBy || '미지정' },
     { label: '요청 시각', value: document.approvalRequestedAt || '-' },
   ]
 }

--- a/src/views/DashboardPage.vue
+++ b/src/views/DashboardPage.vue
@@ -208,8 +208,8 @@ function buildFallbackReview(docType, row) {
     message: '요청 시점의 검토 데이터가 없어 현재 문서 스냅샷 기준으로 표시합니다.',
     requestRows: [
       { label: '요청 유형', value: `${row.approvalAction || '-'} 요청` },
-      { label: '결재자', value: row.approver || '-' },
-      { label: '요청자', value: row.approvalRequestedBy || '-' },
+      { label: '결재자', value: row.approver || '미지정' },
+      { label: '요청자', value: row.approvalRequestedBy || '미지정' },
       { label: '문서 상태', value: row.status || '-' },
       { label: '요청 상태', value: row.requestStatus || '-' },
       { label: '요청 시각', value: row.approvalRequestedAt || '-' },
@@ -255,8 +255,8 @@ function createRequestItem(docType, row) {
     docId: row.id,
     actionLabel: row.approvalAction || row.requestStatus?.replace('요청', '') || '결재',
     company: row.clientName || '-',
-    requester: row.approvalRequestedBy || '-',
-    approver: row.approver || '-',
+    requester: row.approvalRequestedBy || '미지정',
+    approver: row.approver || '미지정',
     status: row.approvalStatus || '-',
     requestStatus: row.requestStatus || '-',
     requestedAt: row.approvalRequestedAt || '-',
@@ -355,8 +355,8 @@ const decisionConfirmDetailRows = computed(() => {
     { label: '문서 종류', value: selectedRequest.value.docType },
     { label: '문서 번호', value: selectedRequest.value.docId },
     { label: '요청 유형', value: `${selectedRequest.value.actionLabel} 요청` },
-    { label: '요청자', value: selectedRequest.value.requester || '-' },
-    { label: '결재자', value: selectedRequest.value.approver || '-' },
+    { label: '요청자', value: selectedRequest.value.requester || '미지정' },
+    { label: '결재자', value: selectedRequest.value.approver || '미지정' },
     { label: '요청 시각', value: selectedRequest.value.requestedAt || '-' },
   ]
 })

--- a/src/views/documents/CollectionsPage.vue
+++ b/src/views/documents/CollectionsPage.vue
@@ -590,6 +590,10 @@ function downloadCurrentTablePdf() {
       >
         데이터가 없습니다.
       </div>
+
+      <div class="border-t border-slate-200 bg-slate-50 px-4 py-2 text-right text-xs text-slate-500">
+        총 {{ sortedRows.length }}건
+      </div>
     </section>
 
     <BasePagination

--- a/src/views/documents/PIDetailPage.vue
+++ b/src/views/documents/PIDetailPage.vue
@@ -99,7 +99,6 @@ const previewFields = computed(() => {
 
   return [
     { label: '거래처', value: detail.value.clientName },
-    { label: '바이어', value: detail.value.buyer },
     { label: '통화', value: detail.value.currency },
     { label: '인코텀즈', value: incotermsLabel.value },
     { label: '납기일', value: detail.value.deliveryDate },
@@ -792,10 +791,6 @@ function cancelDeleteApprovalRequest() {
             <div>
               <span class="text-slate-500">거래처</span>
               <div class="mt-0.5 break-words font-medium">{{ detail.clientName }}</div>
-            </div>
-            <div>
-              <span class="text-slate-500">바이어</span>
-              <div class="mt-0.5 break-words font-medium">{{ detail.buyer }}</div>
             </div>
             <div>
               <span class="text-slate-500">영문주소</span>

--- a/src/views/documents/PODetailPage.vue
+++ b/src/views/documents/PODetailPage.vue
@@ -501,7 +501,6 @@ const previewFields = computed(() => {
 
   return [
     { label: '거래처', value: detail.value.clientName },
-    { label: '바이어', value: detail.value.buyer },
     { label: '통화', value: detail.value.currency },
     { label: '인코텀즈', value: detail.value.incoterms },
     { label: '납기일', value: detail.value.deliveryDate },
@@ -970,10 +969,6 @@ function cancelDeleteApprovalRequest() {
             <div>
               <span class="text-slate-500">거래처</span>
               <div class="mt-0.5 break-words font-medium">{{ detail.clientName }}</div>
-            </div>
-            <div>
-              <span class="text-slate-500">바이어</span>
-              <div class="mt-0.5 break-words font-medium">{{ detail.buyer }}</div>
             </div>
             <div>
               <span class="text-slate-500">영문주소</span>

--- a/src/views/master/ClientDetailPage.vue
+++ b/src/views/master/ClientDetailPage.vue
@@ -79,7 +79,7 @@ const infoGroups = computed(() => {
       fields: [
         { label: '국가', value: client.value.countryName || getCountryName(client.value.countryId, { detailed: true }) },
         { label: '도시', value: client.value.clientCity },
-        { label: '도착항', value: client.value.portName || getPortName(client.value.portId) },
+        { label: '도착항', value: client.value.portName || getPortName(client.value.portId) || '미등록' },
         { label: '주소', value: client.value.clientAddress, wide: true },
       ],
     },

--- a/src/views/master/ClientListPage.vue
+++ b/src/views/master/ClientListPage.vue
@@ -343,7 +343,7 @@ function goToDetail(row) {
       </template>
 
       <template #cell-port="{ row }">
-        {{ row.portName }}
+        {{ row.portName || '미등록' }}
       </template>
 
       <template #cell-paymentTerms="{ row }">


### PR DESCRIPTION
## 📋 작업 내용

2026-04-15 QA 전수 감사 표시(display) 관련 5건 일괄 처리.

| # | 변경 | 파일 |
|---|------|------|
| #1 | 결재자/요청자 fallback `'-'` → `'미지정'` | `DashboardPage.vue`, `documentApproval.js` |
| #3 | PI/PO 상세 "바이어" 행 제거 (엔티티에 buyer 컬럼 없음) | `PIDetailPage.vue`, `PODetailPage.vue` |
| #4 | `/collections` "총 N건" 카운트 추가 | `CollectionsPage.vue` |
| #5 | BaseTable 헤더 `whitespace-nowrap` (메일/활동 줄바꿈 방지) | `BaseTable.vue` |
| #2 | 거래처 도착항 누락 시 "미등록" 표시 | `ClientListPage.vue`, `ClientDetailPage.vue` |

백엔드 #1 enrich 는 별도 머지 완료: `team2-backend-documents@fd8e008`.

## 🔗 관련 이슈
- closes #304

## 📸 스크린샷 (선택)
N/A (텍스트 fallback / CSS 변경)

## ✅ 체크리스트
- [x] 정상 동작 확인 (`npx vite build` 성공)
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게
- PI/PO 상세 revision 스냅샷에 남아있는 `buyerName` 표시는 과거 데이터 보존 차원에서 그대로 둠
- 결재자 enrich 는 백엔드 Feign best-effort. 실패/null 시 `null` → 프론트 "미지정" 으로 일관 표시