### PR TITLE
fix(#306): 활동 패키지 키워드 필터 우측 패널로 이동

### DIFF
--- a/src/views/package/ActivityPackagePage.vue
+++ b/src/views/package/ActivityPackagePage.vue
@@ -436,18 +436,6 @@ async function savePackage() {
               />
             </div>
 
-            <!-- 활동기록 키워드 필터 -->
-            <div class="space-y-1.5">
-              <p class="text-sm font-semibold text-slate-700">
-                활동기록 키워드 필터
-                <span class="ml-1 text-xs font-normal text-slate-400">(오른쪽 목록을 제목/내용으로 좁혀서 보기)</span>
-              </p>
-              <BaseTextField
-                v-model="keyword"
-                placeholder="활동 제목 또는 내용 일부"
-              />
-            </div>
-
             <!-- 수주건 (PO) -->
             <div class="space-y-1.5">
               <p class="text-sm font-semibold text-slate-700">
@@ -597,6 +585,15 @@ async function savePackage() {
       <!-- ── 우측: 활동기록 목록 ─────────────────────────────── -->
       <div>
         <BaseCard title="활동기록 목록">
+          <!-- 키워드 필터 -->
+          <div class="mb-3 space-y-1.5">
+            <p class="text-xs font-semibold text-slate-600">키워드 필터</p>
+            <BaseTextField
+              v-model="keyword"
+              placeholder="활동 제목 또는 내용 일부"
+            />
+          </div>
+
           <!-- 활동기록 기간 필터 -->
           <div class="mb-3 space-y-1.5">
             <p class="text-xs font-semibold text-slate-600">기간 필터</p>


### PR DESCRIPTION
## 📋 작업 내용

활동 패키지 작성/수정 화면의 "활동기록 키워드 필터" 입력을 좌측(패키지 작성) 패널에서 우측(활동기록 목록) 패널 상단으로 이동.

좌=메타입력 / 우=활동기록 목록·필터·선택 원칙에 맞춰 같은 패널에서 키워드·기간·유형 탭이 함께 동작하도록 정렬.
"(오른쪽 목록을 제목/내용으로 좁혀서 보기)" 안내 문구도 더 이상 필요 없어 제거.

## 🔗 관련 이슈
- closes #306

## 📸 스크린샷 (선택)
N/A (동일 입력의 위치만 이동)

## ✅ 체크리스트
- [x] 정상 동작 확인 (`npx vite build` 성공)
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게
키워드 필터의 v-model(`keyword`) 바인딩 그대로 유지 — 배치만 이동.