### PR TITLE
fix(#308): 권한 거부 toast + PI/PO 테이블 prop 일관성

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,7 @@ import router from './router'
 import { useAuthStore } from './stores/auth'
 import { setupApiInterceptors, setRouter } from './lib/api'
 import { canAccessRouteByRole, getRoleHomePath } from './utils/roleAccess'
+import { useToast } from './composables/useToast'
 import './styles/tailwind.css'
 
 const app = createApp(App)
@@ -31,12 +32,16 @@ router.beforeEach(async (to) => {
   // 로그인 상태면 통과
   // JWT role claim 은 대문자("ADMIN"), meta.requiredRole 은 소문자("admin") → normalize 필수
   const getRole = () => (authStore.currentUser?.userRole ?? authStore.currentUser?.role ?? '').toLowerCase()
+  const denyAccess = () => {
+    useToast().warning('해당 페이지에 접근할 권한이 없습니다.', '접근 제한')
+    return getRoleHomePath(getRole())
+  }
   if (authStore.isLoggedIn) {
     if (to.meta.requiredRole && getRole() !== to.meta.requiredRole) {
-      return getRoleHomePath(getRole())
+      return denyAccess()
     }
     if (!canAccessRouteByRole(authStore.currentUser, to.name)) {
-      return getRoleHomePath(getRole())
+      return denyAccess()
     }
     return true
   }
@@ -45,10 +50,10 @@ router.beforeEach(async (to) => {
   const restored = await authStore.restoreSession()
   if (restored) {
     if (to.meta.requiredRole && getRole() !== to.meta.requiredRole) {
-      return getRoleHomePath(getRole())
+      return denyAccess()
     }
     if (!canAccessRouteByRole(authStore.currentUser, to.name)) {
-      return getRoleHomePath(getRole())
+      return denyAccess()
     }
     return true
   }

--- a/src/views/documents/PIPage.vue
+++ b/src/views/documents/PIPage.vue
@@ -1047,6 +1047,7 @@ function handleProductSelect(product) {
     <BaseTable
       :columns="columns"
       :rows="paginatedRows"
+      row-key="id"
       clickable-rows
       empty-text="데이터가 없습니다."
       :footer-text="`총 ${filteredRows.length}건`"

--- a/src/views/documents/POPage.vue
+++ b/src/views/documents/POPage.vue
@@ -1188,6 +1188,7 @@ function handleProductSelect(product) {
     <BaseTable
       :columns="columns"
       :rows="paginatedRows"
+      row-key="id"
       clickable-rows
       empty-text="데이터가 없습니다."
       :footer-text="`총 ${filteredRows.length}건`"


### PR DESCRIPTION
## 📋 작업 내용

### #9 권한 거부 toast
`main.js` router beforeEach 가드에서 `requiredRole` 또는 `canAccessRouteByRole` 가 거부될 때 warning toast "해당 페이지에 접근할 권한이 없습니다." 표시. redirect 자체 동작은 그대로 유지.

### #10 PI/PO 테이블 prop 일관성
PI/PO 모두 이미 `clickable-rows + @row-click="goToDetail($event.id)"` 로 행 클릭 동작은 정상이나, 거래처 목록과 달리 `row-key` 가 빠져 있어 동일 패턴으로 정렬 (`row-key="id"`).

## 🔗 관련 이슈
- closes #308

## 📸 스크린샷 (선택)
N/A

## ✅ 체크리스트
- [x] 정상 동작 확인 (`npx vite build` 성공)
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게
QA 보고서의 "PI/PO 행 클릭 무반응" 은 코드상으로는 이미 이전 PR (#303 계열) 에서 해소된 것으로 보임. 이번 PR 은 prop 패턴 일관성 보정만 포함.