### PR TITLE
fix(#310): QA 2차 회귀 — 로그인 피드백/도착항/권한 toast/PI·PO 클릭

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -33,7 +33,9 @@ router.beforeEach(async (to) => {
   // JWT role claim 은 대문자("ADMIN"), meta.requiredRole 은 소문자("admin") → normalize 필수
   const getRole = () => (authStore.currentUser?.userRole ?? authStore.currentUser?.role ?? '').toLowerCase()
   const denyAccess = () => {
-    useToast().warning('해당 페이지에 접근할 권한이 없습니다.', '접근 제한')
+    // sessionStorage flash: 현재 route 언마운트 후 다음 route 마운트 시점에 toast 노출.
+    // useToast() 를 가드 내에서 즉시 호출하면 redirect 로 DOM 이 바뀌며 transition 이 유실됨.
+    try { sessionStorage.setItem('flash.denyAccess', '1') } catch {}
     return getRoleHomePath(getRole())
   }
   if (authStore.isLoggedIn) {
@@ -60,6 +62,17 @@ router.beforeEach(async (to) => {
 
   // 복구 실패 → 로그인 페이지
   return { name: 'login', query: { redirect: to.fullPath } }
+})
+
+router.afterEach(() => {
+  if (typeof sessionStorage === 'undefined') return
+  if (sessionStorage.getItem('flash.denyAccess') === '1') {
+    sessionStorage.removeItem('flash.denyAccess')
+    // 다음 tick 에서 toast 띄워 ToastContainer 마운트 완료 보장
+    setTimeout(() => {
+      useToast().warning('해당 페이지에 접근할 권한이 없습니다.', '접근 제한')
+    }, 0)
+  }
 })
 
 app.use(router)

--- a/src/views/auth/LoginPage.vue
+++ b/src/views/auth/LoginPage.vue
@@ -88,8 +88,11 @@ async function handleLogin() {
     const safePath = redirect && typeof redirect === 'string' && redirect.startsWith('/') && !redirect.startsWith('//') ? redirect : '/'
     router.push(safePath)
   } catch (e) {
-    if (e.response?.status === 400 || e.response?.status === 401) {
+    const status = e.response?.status
+    if (status === 400 || status === 401) {
       error('이메일 또는 비밀번호가 올바르지 않습니다.')
+    } else if (status === 403) {
+      error(e.response?.data?.message || '로그인할 수 없는 상태입니다. 관리자에게 문의하세요.')
     } else {
       error('로그인 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.')
     }

--- a/src/views/documents/PIPage.vue
+++ b/src/views/documents/PIPage.vue
@@ -911,7 +911,12 @@ function cancelDeleteApprovalRequest() {
 }
 
 function goToDetail(id) {
+  if (!id) return
   router.push({ name: 'pi-detail', params: { id } })
+}
+
+function handleRowClick(row) {
+  goToDetail(row?.id)
 }
 
 function handleClientSelect(client) {
@@ -1051,7 +1056,7 @@ function handleProductSelect(product) {
       clickable-rows
       empty-text="데이터가 없습니다."
       :footer-text="`총 ${filteredRows.length}건`"
-      @row-click="goToDetail($event.id)"
+      @row-click="handleRowClick"
     >
       <template #cell-id="{ value }">
         <button type="button" class="font-mono text-xs font-semibold text-brand-600 hover:underline" @click.stop="goToDetail(value)">

--- a/src/views/documents/POPage.vue
+++ b/src/views/documents/POPage.vue
@@ -1034,7 +1034,12 @@ function cancelDeleteApprovalRequest() {
 }
 
 function goToDetail(id) {
+  if (!id) return
   router.push({ name: 'po-detail', params: { id } })
+}
+
+function handleRowClick(row) {
+  goToDetail(row?.id)
 }
 
 function handlePiSelect(pi) {
@@ -1192,7 +1197,7 @@ function handleProductSelect(product) {
       clickable-rows
       empty-text="데이터가 없습니다."
       :footer-text="`총 ${filteredRows.length}건`"
-      @row-click="goToDetail($event.id)"
+      @row-click="handleRowClick"
     >
       <template #cell-id="{ value }">
         <button type="button" class="font-mono text-xs font-semibold text-brand-600 hover:underline" @click.stop="goToDetail(value)">

--- a/src/views/master/ClientDetailPage.vue
+++ b/src/views/master/ClientDetailPage.vue
@@ -60,6 +60,11 @@ const positionOptions = [
   { label: '팀원', value: '팀원' },
 ]
 
+function resolvePortLabel(portName, portId) {
+  const candidate = portName || getPortName(portId)
+  return candidate && candidate !== '-' ? candidate : '미등록'
+}
+
 function getEmptyBuyerForm() {
   return { name: '', position: '', email: '', tel: '' }
 }
@@ -79,7 +84,7 @@ const infoGroups = computed(() => {
       fields: [
         { label: '국가', value: client.value.countryName || getCountryName(client.value.countryId, { detailed: true }) },
         { label: '도시', value: client.value.clientCity },
-        { label: '도착항', value: client.value.portName || getPortName(client.value.portId) || '미등록' },
+        { label: '도착항', value: resolvePortLabel(client.value.portName, client.value.portId) },
         { label: '주소', value: client.value.clientAddress, wide: true },
       ],
     },

--- a/src/views/master/ClientListPage.vue
+++ b/src/views/master/ClientListPage.vue
@@ -343,7 +343,7 @@ function goToDetail(row) {
       </template>
 
       <template #cell-port="{ row }">
-        {{ row.portName || '미등록' }}
+        {{ row.portName && row.portName !== '-' ? row.portName : '미등록' }}
       </template>
 
       <template #cell-paymentTerms="{ row }">


### PR DESCRIPTION
## 📋 작업 내용

2차 QA 회귀 4건 + 신규 1건 일괄 대응.

| # | 변경 | 파일 |
|---|------|------|
| 신규(로그인 토스트) | 401/403 에 따라 구체적 메시지. 백엔드에 `GlobalExceptionHandler` 추가로 500 가려짐 해소 | `LoginPage.vue`, `team2-backend-auth@7125fb0` |
| #2 도착항 "-" | `getPortName` 이 리턴하는 literal "-" 도 "미등록"으로 처리 | `ClientListPage.vue`, `ClientDetailPage.vue` |
| #7 자사 정보 | `CompanyBootstrap` 이 빈 row(companyName blank) 도 시드값으로 UPDATE | `team2-backend-auth@7125fb0` |
| #9 권한 toast | sessionStorage flash + `router.afterEach` 에서 토스트 노출 (이전 DOM 언마운트 타이밍 유실 해소) | `main.js` |
| #10 PI/PO 행 클릭 | `@row-click="goToDetail($event.id)"` → `handleRowClick(row)` 함수 래핑 + id 가드 | `PIPage.vue`, `POPage.vue` |

## 🔗 관련 이슈
- closes #310

## 📸 스크린샷 (선택)
N/A

## ✅ 체크리스트
- [x] 정상 동작 확인 (`npx vite build` + auth `gradlew build` 통과)
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게
- #10 은 코드상으로는 이전 PR 상태가 이미 올바른 패턴이었으나, 인라인 `$event.id` 대신 함수 래핑으로 전환해 디버깅 용이성 확보
- 백엔드 `GlobalExceptionHandler` 는 auth 서비스 전체 scope — 다른 CRUD 에서 IllegalArgumentException 던지는 곳들이 모두 401 로 내려가게 됨. 도메인 별 더 세분화가 필요하면 후속 PR 에서