### PR TITLE
fix(#312): 대시보드 403 가드 + sales 사이드바 필터 + toast duration

### DIFF
--- a/src/composables/useToast.js
+++ b/src/composables/useToast.js
@@ -2,7 +2,7 @@ import { readonly, ref } from 'vue'
 
 const toasts = ref([])
 
-function showToast({ type = 'info', title = '', message = '', duration = 2500 }) {
+function showToast({ type = 'info', title = '', message = '', duration = 4000 }) {
   const id = Date.now() + Math.random()
   const toast = { id, type, title, message }
 
@@ -30,13 +30,13 @@ export function useToast() {
       return showToast({ type: 'success', title, message })
     },
     error(message, title = '오류') {
-      return showToast({ type: 'error', title, message, duration: 3500 })
+      return showToast({ type: 'error', title, message, duration: 5000 })
     },
     info(message, title = '알림') {
       return showToast({ type: 'info', title, message })
     },
     warning(message, title = '안내') {
-      return showToast({ type: 'warning', title, message, duration: 3000 })
+      return showToast({ type: 'warning', title, message, duration: 4500 })
     },
   }
 }

--- a/src/stores/productionOrderDocuments.js
+++ b/src/stores/productionOrderDocuments.js
@@ -64,8 +64,8 @@ export async function loadProductionOrderDocuments() {
 export function useProductionOrderDocuments() {
   const auth = useAuthStore()
   const role = auth.currentUser?.role
-  // 생산지시서는 admin/sales/production 만 조회 권한. shipping 에서 401/403 유발 방지.
-  const allowed = ['admin', 'sales', 'production'].includes(role)
+  // 생산지시서는 gateway 정책상 admin/production 만 허용. sales/shipping 에서 403 유발 방지.
+  const allowed = ['admin', 'production'].includes(role)
   if (!loading && auth.isLoggedIn && allowed) {
     loading = loadProductionOrderDocuments()
   }

--- a/src/stores/shipmentStatusDocuments.js
+++ b/src/stores/shipmentStatusDocuments.js
@@ -39,8 +39,8 @@ export async function loadShipmentStatusDocuments() {
 export function useShipmentStatusDocuments() {
   const auth = useAuthStore()
   const role = auth.currentUser?.role
-  // 출하현황은 admin/sales/shipping 만 조회 권한. production 에서 401/403 유발 방지.
-  const allowed = ['admin', 'sales', 'shipping'].includes(role)
+  // 출하현황은 gateway 정책상 admin/shipping 만 허용. sales/production 에서 403 유발 방지.
+  const allowed = ['admin', 'shipping'].includes(role)
   if (!loading && auth.isLoggedIn && allowed) {
     loading = loadShipmentStatusDocuments()
   }

--- a/src/utils/roleAccess.js
+++ b/src/utils/roleAccess.js
@@ -1,9 +1,20 @@
 const COMMON_ROUTE_NAMES = new Set(['dashboard'])
 
+// sales/admin 외 역할은 도메인 라우트만 접근 가능. sales 는 영업·문서·기준정보 한정.
 const ROLE_ROUTE_ALLOWLIST = {
   production: new Set(['dashboard', 'production', 'production-detail']),
   shipping: new Set(['dashboard', 'shipment-orders', 'shipment-order-detail', 'shipments', 'shipment-detail']),
 }
+
+// sales 차단 경로 — gateway 에서 ADMIN/PRODUCTION 또는 ADMIN/SHIPPING 만 허용하므로
+// 메뉴 노출/라우트 진입을 미리 막아 403 콘솔 에러와 빈 화면 노출 방지
+const SALES_BLOCKED_PATH_PREFIXES = ['/production', '/shipment-orders', '/shipments', '/users']
+const SALES_BLOCKED_ROUTE_NAMES = new Set([
+  'production', 'production-detail',
+  'shipment-orders', 'shipment-order-detail',
+  'shipments', 'shipment-detail',
+  'users',
+])
 
 // 백엔드 UPPER_CASE role → 기존 lowercase role 정규화
 function normalizeRole(role) {
@@ -23,8 +34,12 @@ export function canAccessRouteByRole(user, routeName) {
     return role === 'admin'
   }
 
-  if (role === 'admin' || role === 'sales') {
+  if (role === 'admin') {
     return true
+  }
+
+  if (role === 'sales') {
+    return !SALES_BLOCKED_ROUTE_NAMES.has(String(routeName))
   }
 
   const allowedRoutes = ROLE_ROUTE_ALLOWLIST[role]
@@ -43,8 +58,12 @@ export function canAccessPathByRole(user, path) {
     return role === 'admin'
   }
 
-  if (role === 'admin' || role === 'sales') {
+  if (role === 'admin') {
     return true
+  }
+
+  if (role === 'sales') {
+    return !SALES_BLOCKED_PATH_PREFIXES.some((prefix) => path.startsWith(prefix))
   }
 
   if (path === '/') {

--- a/src/views/DashboardPage.vue
+++ b/src/views/DashboardPage.vue
@@ -41,14 +41,19 @@ onMounted(async () => {
   // 인증되지 않은 상태에서는 API 호출하지 않음 (k8s 전환 후 401 크래시 방지)
   if (!authStore.isLoggedIn) return
 
+  // /api/activity-packages 는 ActivityPackageQueryController @PreAuthorize 로 ADMIN/SALES 만
+  // 허용. production/shipping 에서 호출 시 403 + 콘솔 에러 → 권한 가드 후 호출.
+  const role = (authStore.currentUser?.role ?? '').toLowerCase()
+  const canFetchPackages = role === 'admin' || role === 'sales'
+
   const [clientsResult, activitiesResult, packagesResult] = await Promise.allSettled([
     fetchClients(),
     fetchActivities(),
-    fetchPackages(),
+    canFetchPackages ? fetchPackages() : Promise.resolve(null),
   ])
   if (clientsResult.status === 'fulfilled') clientsData.value = clientsResult.value ?? []
   if (activitiesResult.status === 'fulfilled') activitiesData.value = activitiesResult.value ?? []
-  if (packagesResult.status === 'fulfilled') packagesData.value = packagesResult.value ?? []
+  if (packagesResult.status === 'fulfilled' && packagesResult.value) packagesData.value = packagesResult.value
 })
 
 const currentUser = computed(() => authStore.currentUser ?? null)


### PR DESCRIPTION
## 📋 작업 내용

| # | 변경 | 파일 |
|---|------|------|
| #2 대시보드 403 | production/shipping 에서 `fetchPackages` 스킵, sales 에서 production-orders·shipments fetch 스킵 | `DashboardPage.vue`, `productionOrderDocuments.js`, `shipmentStatusDocuments.js` |
| #3 sales 사이드바 | sales 차단 경로/라우트 명단 추가 — production/shipment/users 메뉴 미노출 + 라우트 가드 | `roleAccess.js` |
| #4 toast duration | info 4s / warning 4.5s / error 5s (기존 2.5/3/3.5) | `useToast.js` |

## 🔗 관련 이슈
- closes #312

## 💬 리뷰어에게
gateway 의 `hasAnyRole("ADMIN","PRODUCTION")` / `("ADMIN","SHIPPING")` 정책에 프론트 store 가드 정합화. activity-packages 는 backend `@PreAuthorize("hasAnyRole('ADMIN','SALES')")` 정책 따름.

## ✅ 체크리스트
- [x] `npx vite build` 성공