### PR TITLE
fix(#316): 영업담당자 지시서 가시성 + 완료 처리 버튼 role 가드

### DIFF
--- a/src/composables/useToast.js
+++ b/src/composables/useToast.js
@@ -2,7 +2,7 @@ import { readonly, ref } from 'vue'
 
 const toasts = ref([])
 
-function showToast({ type = 'info', title = '', message = '', duration = 2500 }) {
+function showToast({ type = 'info', title = '', message = '', duration = 4000 }) {
   const id = Date.now() + Math.random()
   const toast = { id, type, title, message }
 
@@ -30,13 +30,13 @@ export function useToast() {
       return showToast({ type: 'success', title, message })
     },
     error(message, title = '오류') {
-      return showToast({ type: 'error', title, message, duration: 3500 })
+      return showToast({ type: 'error', title, message, duration: 5000 })
     },
     info(message, title = '알림') {
       return showToast({ type: 'info', title, message })
     },
     warning(message, title = '안내') {
-      return showToast({ type: 'warning', title, message, duration: 3000 })
+      return showToast({ type: 'warning', title, message, duration: 4500 })
     },
   }
 }

--- a/src/views/DashboardPage.vue
+++ b/src/views/DashboardPage.vue
@@ -41,14 +41,19 @@ onMounted(async () => {
   // 인증되지 않은 상태에서는 API 호출하지 않음 (k8s 전환 후 401 크래시 방지)
   if (!authStore.isLoggedIn) return
 
+  // /api/activity-packages 는 ActivityPackageQueryController @PreAuthorize 로 ADMIN/SALES 만
+  // 허용. production/shipping 에서 호출 시 403 + 콘솔 에러 → 권한 가드 후 호출.
+  const role = (authStore.currentUser?.role ?? '').toLowerCase()
+  const canFetchPackages = role === 'admin' || role === 'sales'
+
   const [clientsResult, activitiesResult, packagesResult] = await Promise.allSettled([
     fetchClients(),
     fetchActivities(),
-    fetchPackages(),
+    canFetchPackages ? fetchPackages() : Promise.resolve(null),
   ])
   if (clientsResult.status === 'fulfilled') clientsData.value = clientsResult.value ?? []
   if (activitiesResult.status === 'fulfilled') activitiesData.value = activitiesResult.value ?? []
-  if (packagesResult.status === 'fulfilled') packagesData.value = packagesResult.value ?? []
+  if (packagesResult.status === 'fulfilled' && packagesResult.value) packagesData.value = packagesResult.value
 })
 
 const currentUser = computed(() => authStore.currentUser ?? null)

--- a/src/views/documents/ProductionOrderDetailPage.vue
+++ b/src/views/documents/ProductionOrderDetailPage.vue
@@ -46,7 +46,9 @@ const detail = computed(() => {
 })
 const displayItems = computed(() => enrichDocumentItems(detail.value?.items ?? []))
 const isProductionUser = computed(() => authStore.currentUser?.role === 'production')
-const canCompleteProduction = computed(() => isProductionUser.value && detail.value?.status === '진행중')
+const isAdminUser = computed(() => authStore.currentUser?.role === 'admin')
+const canShowCompleteButton = computed(() => isProductionUser.value || isAdminUser.value)
+const canCompleteProduction = computed(() => canShowCompleteButton.value && detail.value?.status === '진행중')
 const totalQuantity = computed(() => (
   displayItems.value.reduce((sum, item) => sum + Number.parseInt(item.quantity, 10), 0)
 ))
@@ -174,7 +176,7 @@ onMounted(() => {
       <DetailPageHeader :title="detail.id" :status="detail.status" @back="goBack">
         <template #actions>
           <BaseButton
-            v-if="isProductionUser"
+            v-if="canShowCompleteButton"
             size="sm"
             :disabled="!canCompleteProduction"
             @click="openCompleteConfirm"

--- a/src/views/documents/ShipmentsDetailPage.vue
+++ b/src/views/documents/ShipmentsDetailPage.vue
@@ -44,6 +44,8 @@ const linkedShipmentOrder = computed(() => shipmentOrderDocuments.value.find((ro
 const displayItems = computed(() => enrichDocumentItems(detail.value?.items ?? []))
 
 const currentStep = computed(() => (detail.value?.status === '출하완료' ? 2 : 1))
+const currentRole = computed(() => (authStore.currentUser?.role ?? '').toLowerCase())
+const canCompleteShipment = computed(() => currentRole.value === 'admin' || currentRole.value === 'shipping')
 function parseNumericValue(value) {
   const numeric = Number.parseFloat(String(value ?? '').replace(/[^0-9.]/g, ''))
   return Number.isFinite(numeric) ? numeric : 0
@@ -132,6 +134,7 @@ onMounted(() => {
       <DetailPageHeader :title="detail.id" :status="detail.status" @back="goBack">
         <template #actions>
           <BaseButton
+            v-if="canCompleteShipment"
             size="sm"
             :disabled="detail.status === '출하완료'"
             @click="completeShipment"


### PR DESCRIPTION
## 📋 작업 내용

영업담당자가 본인 PO 의 후속 지시서(생산/출하) 진행 상황을 확인하고 CUD 까지 가능하게 하되, "완료 처리" 액션은 각 담당자만 가능하도록 정합.

| 변경 | 파일 |
|---|---|
| 대시보드 fetchPackages role 가드 (production/shipping 에서 403 차단) | `DashboardPage.vue` |
| Toast 자동 dismiss 시간 상향 (info 4s / warning 4.5s / error 5s) | `useToast.js` |
| 출하완료 처리 버튼 v-if (ADMIN/SHIPPING) | `ShipmentsDetailPage.vue` |
| 생산완료 처리 버튼 가드 ADMIN+PRODUCTION 확장 | `ProductionOrderDetailPage.vue` |

백엔드 페어: `team2-gateway` main `f76361a` — `/api/production-orders/**`, `/api/shipment-orders/**`, `/api/shipments/**` 를 `.authenticated()` 로 개방.

## 🔗 관련 이슈
- closes #316
- 이전 PR #313 (잘못된 방향 — sales 차단) 은 closed

## 회고 — 향후 작업
- 생산완료 처리 백엔드 endpoint 신설 (`PUT /api/production-orders/{id}/complete` + `@PreAuthorize ADMIN/PRODUCTION`)
- 출하완료 처리 프론트 로직을 `PUT /api/shipments/{id}` 호출하도록 wire (현재 frontend-only mock)

## ✅ 체크리스트
- [x] gateway `gradlew build -x test` 성공
- [x] 프론트 `npx vite build` 성공