### PR TITLE
feat(#320): Bundle A — 출하/생산 완료 wire + PO 출하진행 표시

### DIFF
--- a/src/api/documents.js
+++ b/src/api/documents.js
@@ -36,6 +36,8 @@ export const fetchProductionOrders = () =>
   api.get('/production-orders').then((r) => unwrapCollection(r.data))
 export const fetchProductionOrder = (id) =>
   api.get(`/production-orders/${id}`).then((r) => r.data)
+export const completeProductionOrder = (productionOrderId) =>
+  api.put(`/production-orders/${productionOrderId}/complete`).then((r) => r.data)
 
 // Shipment Orders
 export const fetchShipmentOrders = () =>

--- a/src/stores/poDocuments.js
+++ b/src/stores/poDocuments.js
@@ -77,6 +77,9 @@ function mapPoResponse(row) {
     itemsSnapshot: row.itemsSnapshot ? parseJsonSafe(row.itemsSnapshot) : null,
     linkedDocuments: parseLinkedDocuments(row.linkedDocuments),
     revisionHistory: row.revisionHistory ? parseJsonSafe(row.revisionHistory, []) : [],
+    // 백엔드 PO 응답 enrich (LEFT JOIN shipments aggregate). null=출하전 / preparing / completed.
+    // sales 가 출하 모듈 직접 권한 없이도 본인 PO 의 출하 진행을 PO 화면에서 확인 가능.
+    shipmentStatus: row.shipmentStatus ?? null,
     items,
   }
 }

--- a/src/views/documents/PODetailPage.vue
+++ b/src/views/documents/PODetailPage.vue
@@ -318,6 +318,15 @@ const sourceRow = computed(() => (
 
 const detail = computed(() => normalizeDetail(sourceRow.value))
 
+// 백엔드 PO 응답의 shipmentStatus 필드 (LEFT JOIN shipments aggregate)
+// null=출하전 / preparing=출하준비 / completed=출하완료
+const shipmentStatusLabel = computed(() => {
+  const raw = sourceRow.value?.shipmentStatus
+  if (raw === 'completed') return '출하완료'
+  if (raw === 'preparing') return '출하준비'
+  return '출하 전'
+})
+
 const approvalInfoRows = computed(() => buildApprovalInfoRows(detail.value))
 const shipmentLockInfo = computed(() => (
   getPoShipmentLockInfo(
@@ -985,6 +994,10 @@ function cancelDeleteApprovalRequest() {
             <div>
               <span class="text-slate-500">PO 번호</span>
               <div class="mt-0.5 font-medium">{{ detail.id }}</div>
+            </div>
+            <div>
+              <span class="text-slate-500">출하 진행</span>
+              <div class="mt-0.5 font-medium">{{ shipmentStatusLabel }}</div>
             </div>
           </div>
         </div>

--- a/src/views/documents/ProductionOrderDetailPage.vue
+++ b/src/views/documents/ProductionOrderDetailPage.vue
@@ -9,6 +9,7 @@ import StatusBadge from '@/components/common/StatusBadge.vue'
 import DocumentPreviewModal from '@/components/domain/document/DocumentPreviewModal.vue'
 import ProductionOrderTemplate from '@/components/domain/document/ProductionOrderTemplate.vue'
 import { useDocumentItemCatalog } from '@/composables/useDocumentItemCatalog'
+import { completeProductionOrder } from '@/api/documents'
 import { useAuthStore } from '@/stores/auth'
 import { usePoDocuments } from '@/stores/poDocuments'
 import { useToast } from '@/composables/useToast'
@@ -118,9 +119,23 @@ function closeCompleteConfirm() {
   completeConfirmOpen.value = false
 }
 
-function confirmCompleteProduction() {
+async function confirmCompleteProduction() {
   if (!detail.value || !canCompleteProduction.value) return
 
+  try {
+    // 백엔드 PUT /api/production-orders/{id}/complete (controller @PreAuthorize ADMIN/PRODUCTION)
+    await completeProductionOrder(detail.value.id)
+  } catch (e) {
+    if (e.response?.status === 403) {
+      toast.error('생산완료 처리 권한이 없습니다.')
+    } else {
+      toast.error('생산완료 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.')
+    }
+    completeConfirmOpen.value = false
+    return
+  }
+
+  // 성공 시 로컬 store 동기화
   productionOrderDocuments.value = productionOrderDocuments.value.map((row) => (
     row.id === detail.value.id
       ? { ...row, status: '생산완료' }

--- a/src/views/documents/ShipmentsDetailPage.vue
+++ b/src/views/documents/ShipmentsDetailPage.vue
@@ -6,6 +6,7 @@ import BaseButton from '@/components/common/BaseButton.vue'
 import DetailPageHeader from '@/components/common/DetailPageHeader.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
 import { useDocumentItemCatalog } from '@/composables/useDocumentItemCatalog'
+import { updateShipment } from '@/api/documents'
 import { useAuthStore } from '@/stores/auth'
 import { usePoDocuments } from '@/stores/poDocuments'
 import { useShipmentOrderDocuments } from '@/stores/shipmentOrderDocuments'
@@ -85,11 +86,23 @@ function goToShipmentOrder() {
   router.push({ name: 'shipment-order-detail', params: { id: detail.value?.shipmentOrderId } })
 }
 
-function completeShipment() {
+async function completeShipment() {
   if (!detail.value || detail.value.status === '출하완료') return
+  try {
+    // 백엔드 PUT /api/shipments/{id} (controller @PreAuthorize ADMIN/SHIPPING)
+    await updateShipment(detail.value.id, { status: 'completed' })
+  } catch (e) {
+    if (e.response?.status === 403) {
+      toast.error('출하완료 처리 권한이 없습니다.')
+    } else {
+      toast.error('출하완료 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.')
+    }
+    return
+  }
+  // 성공 시 로컬 store 동기화 (대시보드/목록 즉시 반영)
   shipmentStatusDocuments.value = shipmentStatusDocuments.value.map((row) => (
     row.id === detail.value.id
-      ? { ...row, status: '출하완료', updatedAt: '2026/03/31 10:00' }
+      ? { ...row, status: '출하완료' }
       : row
   ))
   shipmentOrderDocuments.value = shipmentOrderDocuments.value.map((row) => (


### PR DESCRIPTION
## 📋 작업 내용 (Bundle A)

영업담당자 출하/생산 가시성 + 완료 처리 백엔드 wire.

### 1. 완료 처리 백엔드 wire (이전엔 frontend-only mock)
- `completeShipment()` → `PUT /api/shipments/{id}` 호출 후 store 동기화
- `confirmCompleteProduction()` → `PUT /api/production-orders/{id}/complete` 호출 후 store 동기화
- 403/실패 시 toast 안내

### 2. PO 응답 shipmentStatus enrich → PO 상세 표시
- 백엔드 `PurchaseOrderQueryMapper` LEFT JOIN shipments aggregate
  - null=출하전 / preparing=출하준비 / completed=출하완료
- `poDocuments` mapper 매핑
- `PODetailPage` "문서 기본정보" 카드에 "출하 진행" 행 추가
- 영업담당자가 출하 모듈 직접 권한 없이도 본인 PO 의 진행 확인 가능

## 백엔드 페어
`team2-backend-documents` main `4d7c1b0`:
- `ProductionOrderCommandService.complete()` + `PUT /api/production-orders/{id}/complete` (`@PreAuthorize ADMIN/PRODUCTION`)
- `PurchaseOrderQueryMapper` LEFT JOIN shipments aggregate
- `PurchaseOrderView`/`Response` 에 `shipmentStatus` 필드 추가

## 🔗 관련 이슈
- closes #320

## ✅ 체크리스트
- [x] documents `gradlew build -x test` 성공
- [x] 프론트 `npx vite build` 성공