### PR TITLE
feat(#322): Bundle B — 품목 W×D×H 표시 + 사양 분리

### DIFF
--- a/src/views/master/ItemDetailPage.vue
+++ b/src/views/master/ItemDetailPage.vue
@@ -59,12 +59,12 @@ const infoGroups = computed(() => {
   ]
 })
 
-/** 구조화된 W/D/H 가 있으면 "1722 × 1134 × 40 mm", W/H 만 있으면 "1722 × 1134 mm",
- *  치수 정보가 없으면 "-". 자유 텍스트 사양은 별도 행 (itemSpec) 으로 표시. */
+/** W/D/H 가 모두 있으면 "1722 × 1134 × 35 mm". 정책상 셋 다 필수 (ItemFormModal 검증).
+ *  레거시 누락 데이터는 "-". 자유 텍스트 사양은 별도 행 (itemSpec) 으로 표시. */
 function formatDimensions(it) {
   if (!it) return '-'
   const w = it.itemWidth, d = it.itemDepth, h = it.itemHeight
-  if (w && h) return d ? `${w} × ${d} × ${h} mm` : `${w} × ${h} mm`
+  if (w && d && h) return `${w} × ${d} × ${h} mm`
   return '-'
 }
 

--- a/src/views/master/ItemDetailPage.vue
+++ b/src/views/master/ItemDetailPage.vue
@@ -41,7 +41,8 @@ const infoGroups = computed(() => {
     {
       title: '규격 / 단위',
       fields: [
-        { label: '규격', value: item.value.itemSpec, wide: true },
+        { label: '치수 (W × D × H)', value: formatDimensions(item.value), wide: true },
+        { label: '사양', value: item.value.itemSpec || '-', wide: true },
         { label: '단위', value: item.value.itemUnit },
         { label: '포장단위', value: item.value.itemPackUnit },
       ],
@@ -57,6 +58,15 @@ const infoGroups = computed(() => {
     },
   ]
 })
+
+/** 구조화된 W/D/H 가 있으면 "1722 × 1134 × 40 mm", W/H 만 있으면 "1722 × 1134 mm",
+ *  치수 정보가 없으면 "-". 자유 텍스트 사양은 별도 행 (itemSpec) 으로 표시. */
+function formatDimensions(it) {
+  if (!it) return '-'
+  const w = it.itemWidth, d = it.itemDepth, h = it.itemHeight
+  if (w && h) return d ? `${w} × ${d} × ${h} mm` : `${w} × ${h} mm`
+  return '-'
+}
 
 async function loadData() {
   const rawId = route.params.id

--- a/src/views/master/ItemListPage.vue
+++ b/src/views/master/ItemListPage.vue
@@ -56,6 +56,18 @@ const unitOptions = computed(() => {
   return [{ label: '전체', value: '' }, ...units.map((u) => ({ label: u, value: u }))]
 })
 
+/** WDH 컬럼이 있으면 "1722×1134×40 mm" 형식, W/H 만 있으면 "1722×1134 mm",
+ *  치수 정보가 없으면 자유 텍스트 itemSpec, 그것도 없으면 "-". */
+function formatItemDimensions(row) {
+  const w = row.itemWidth
+  const d = row.itemDepth
+  const h = row.itemHeight
+  if (w && h) {
+    return d ? `${w} × ${d} × ${h} mm` : `${w} × ${h} mm`
+  }
+  return row.itemSpec || '-'
+}
+
 function resetFilters() {
   filters.value = { keyword: '', code: '', name: '', category: '', unit: '', status: '' }
   appliedFilters.value = { keyword: '', code: '', name: '', category: '', unit: '', status: '' }
@@ -306,6 +318,11 @@ function goToDetail(row) {
           <p class="font-medium text-ink">{{ row.itemName }}</p>
           <p class="text-xs text-slate-500">{{ [row.itemNameKr, row.itemCategory].filter(Boolean).join(' · ') }}</p>
         </div>
+      </template>
+
+      <!-- 규격: 구조화된 W×D×H 우선 표시, 누락 시 자유 텍스트 itemSpec fallback -->
+      <template #cell-itemSpec="{ row }">
+        <span>{{ formatItemDimensions(row) }}</span>
       </template>
 
       <template #cell-itemUnitPrice="{ row }">

--- a/src/views/master/ItemListPage.vue
+++ b/src/views/master/ItemListPage.vue
@@ -56,15 +56,11 @@ const unitOptions = computed(() => {
   return [{ label: '전체', value: '' }, ...units.map((u) => ({ label: u, value: u }))]
 })
 
-/** WDH 컬럼이 있으면 "1722×1134×40 mm" 형식, W/H 만 있으면 "1722×1134 mm",
- *  치수 정보가 없으면 자유 텍스트 itemSpec, 그것도 없으면 "-". */
+/** W/D/H 가 모두 있으면 "1722 × 1134 × 35 mm". 정책상 셋 다 필수 (ItemFormModal 검증).
+ *  레거시 누락 데이터는 자유 텍스트 itemSpec fallback, 그것도 없으면 "-". */
 function formatItemDimensions(row) {
-  const w = row.itemWidth
-  const d = row.itemDepth
-  const h = row.itemHeight
-  if (w && h) {
-    return d ? `${w} × ${d} × ${h} mm` : `${w} × ${h} mm`
-  }
+  const w = row.itemWidth, d = row.itemDepth, h = row.itemHeight
+  if (w && d && h) return `${w} × ${d} × ${h} mm`
   return row.itemSpec || '-'
 }
 


### PR DESCRIPTION
## 📋 작업 내용 (Bundle B)

운영 DB 자유 텍스트 itemSpec 값이 일관되지 않아 발생한 표시 품질 저하 해결.

### 프론트
- ItemListPage "규격" 컬럼: 구조화된 W/D/H 우선 (`1722 × 1134 × 35 mm`), 없으면 itemSpec fallback
- ItemDetailPage "규격 / 단위" 그룹:
  - "치수 (W × D × H)" 행 (구조화)
  - "사양" 행 (자유 텍스트) 분리

### 백엔드 페어
`team2-backend-master` main `dbe4b2a`:
- `ItemSpecBackfillBootstrap` (`@EventListener(ApplicationReadyEvent.class)` + `@Transactional`)
- 솔라모듈 ITM010/011/012 + 강화유리 ITM006 의 W/D/H + itemSpec 을 canonical 값으로 강제
- `matchesCanonical` 검사로 idempotent

## 🔗 관련 이슈
- closes #322

## 회고
- 매핑된 4개 외 품목 (케이블/실란트/커넥터 등 W×D×H 가 의미 없는 것들) 은 무시 — 추후 운영팀이 admin 에서 직접 정리
- canonical 매핑된 품목은 매번 재시작마다 정정되므로, 운영팀이 admin 에서 자유롭게 편집하려면 매핑 제거 또는 ENV flag 도입 필요

## ✅ 체크리스트
- [x] master `gradlew compileJava` 성공
- [x] 프론트 `npx vite build` 성공