### PR TITLE
feat(#324): Bundle C — 컨택리스트 작성자 기준 조회 (개인 인맥)

### DIFF
--- a/src/api/contacts.js
+++ b/src/api/contacts.js
@@ -1,4 +1,5 @@
 import { api } from '@/lib/api'
+import { unwrapCollection } from '@/utils/apiResponse'
 
 /**
  * master 백엔드 `/buyers` 는 HATEOAS CollectionModel 형식
@@ -9,6 +10,16 @@ export async function fetchBuyers() {
   const { data } = await api.get('/buyers')
   if (Array.isArray(data)) return data
   return data?._embedded?.buyerResponseList ?? []
+}
+
+/**
+ * activity 백엔드 `/api/contacts` — 작성자(writerId) 기준 본인 컨택 (admin 은 전체).
+ * 같은 팀이 buyer 등록 시 sync 가 각 팀원에게 별도 row 를 만들어주므로 자동으로 보임.
+ * 응답: PagedModel HATEOAS — `{ _embedded: { contactResponseList: [...] }, page: {...} }`
+ */
+export async function fetchContacts({ size = 200 } = {}) {
+  const { data } = await api.get('/contacts', { params: { size } })
+  return unwrapCollection(data)
 }
 
 export async function createBuyer(buyer) {

--- a/src/views/contacts/ContactListPage.vue
+++ b/src/views/contacts/ContactListPage.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { computed, onMounted, ref, watch } from 'vue'
 import { useToast } from '@/composables/useToast'
-import { fetchBuyers, createBuyer, updateBuyer, deleteBuyer } from '@/api/contacts'
+import { fetchContacts, createBuyer, updateBuyer, deleteBuyer } from '@/api/contacts'
 import { fetchClients } from '@/api/master'
 import { useAuthStore } from '@/stores/auth'
 import BaseButton from '@/components/common/BaseButton.vue'
@@ -25,20 +25,39 @@ const isAdmin = computed(() => currentUser.value?.userRole === 'admin')
 const clients = ref([])
 const contacts = ref([])
 
-// 관리자는 전체, 일반 사용자는 본인 등록 연락처만
-const myContacts = computed(() => {
-  if (isAdmin.value) return contacts.value
-  return contacts.value.filter((c) => c.createdBy === currentUser.value?.userId)
-})
+// /api/contacts 가 이미 서버 단에서 ADMIN 전체 / 그 외 본인 writerId 로 필터해서 반환.
+// 같은 팀의 buyer 등록은 sync 단계에서 본인 writerId 의 Contact row 로 들어오므로
+// 자동으로 보임. 클라이언트 단 추가 필터 불필요.
+const myContacts = computed(() => contacts.value)
+
+/**
+ * Activity Contact 응답 → 페이지가 사용하는 buyer 형태로 normalize.
+ * (CRUD 는 여전히 master /buyers 호출 — buyer 등록 시 sync 가 contacts 로 자동 반영)
+ */
+function normalizeContact(c) {
+  return {
+    ...c,
+    buyerId: c.contactId ?? c.buyerId,
+    buyerName: c.contactName ?? c.buyerName,
+    buyerPosition: c.contactPosition ?? c.buyerPosition,
+    buyerEmail: c.contactEmail ?? c.buyerEmail,
+    buyerTel: c.contactTel ?? c.buyerTel,
+    createdBy: c.writerId ?? c.createdBy,
+  }
+}
+
+async function loadContacts() {
+  const data = await fetchContacts()
+  contacts.value = (Array.isArray(data) ? data : []).map(normalizeContact)
+}
 
 onMounted(async () => {
   try {
-    const [clientData, buyerData] = await Promise.all([
+    const [clientData] = await Promise.all([
       fetchClients(),
-      fetchBuyers(),
+      loadContacts(),
     ])
     clients.value = clientData
-    contacts.value = buyerData
   } catch (e) {
     console.error('데이터 로드 실패', e)
     error('데이터를 불러오지 못했습니다. 페이지를 새로고침해주세요.')
@@ -169,13 +188,12 @@ async function handleFormSubmit() {
   }
   try {
     if (isEditMode.value) {
-      const updated = await updateBuyer(editingId.value, { id: editingId.value, ...payload })
-      const idx = contacts.value.findIndex((c) => c.id === editingId.value)
-      if (idx !== -1) contacts.value[idx] = updated
+      await updateBuyer(editingId.value, { id: editingId.value, ...payload })
     } else {
-      const created = await createBuyer(payload)
-      contacts.value.push(created)
+      await createBuyer(payload)
     }
+    // CRUD 후 /api/contacts 재조회 — sync 단계에서 contacts row 가 갱신/추가됨
+    await loadContacts()
     closeForm()
   } catch (e) {
     console.error('연락처 저장 실패', e)
@@ -205,7 +223,7 @@ function closeDelete() {
 async function handleDelete() {
   try {
     await deleteBuyer(deleteTarget.value.id)
-    contacts.value = contacts.value.filter((c) => c.id !== deleteTarget.value.id)
+    await loadContacts()
     closeDelete()
   } catch (e) {
     console.error('연락처 삭제 실패', e)

--- a/src/views/master/ItemDetailPage.vue
+++ b/src/views/master/ItemDetailPage.vue
@@ -59,12 +59,12 @@ const infoGroups = computed(() => {
   ]
 })
 
-/** 구조화된 W/D/H 가 있으면 "1722 × 1134 × 40 mm", W/H 만 있으면 "1722 × 1134 mm",
- *  치수 정보가 없으면 "-". 자유 텍스트 사양은 별도 행 (itemSpec) 으로 표시. */
+/** W/D/H 가 모두 있으면 "1722 × 1134 × 35 mm". 정책상 셋 다 필수 (ItemFormModal 검증).
+ *  레거시 누락 데이터는 "-". 자유 텍스트 사양은 별도 행 (itemSpec) 으로 표시. */
 function formatDimensions(it) {
   if (!it) return '-'
   const w = it.itemWidth, d = it.itemDepth, h = it.itemHeight
-  if (w && h) return d ? `${w} × ${d} × ${h} mm` : `${w} × ${h} mm`
+  if (w && d && h) return `${w} × ${d} × ${h} mm`
   return '-'
 }
 

--- a/src/views/master/ItemDetailPage.vue
+++ b/src/views/master/ItemDetailPage.vue
@@ -41,7 +41,8 @@ const infoGroups = computed(() => {
     {
       title: '규격 / 단위',
       fields: [
-        { label: '규격', value: item.value.itemSpec, wide: true },
+        { label: '치수 (W × D × H)', value: formatDimensions(item.value), wide: true },
+        { label: '사양', value: item.value.itemSpec || '-', wide: true },
         { label: '단위', value: item.value.itemUnit },
         { label: '포장단위', value: item.value.itemPackUnit },
       ],
@@ -57,6 +58,15 @@ const infoGroups = computed(() => {
     },
   ]
 })
+
+/** 구조화된 W/D/H 가 있으면 "1722 × 1134 × 40 mm", W/H 만 있으면 "1722 × 1134 mm",
+ *  치수 정보가 없으면 "-". 자유 텍스트 사양은 별도 행 (itemSpec) 으로 표시. */
+function formatDimensions(it) {
+  if (!it) return '-'
+  const w = it.itemWidth, d = it.itemDepth, h = it.itemHeight
+  if (w && h) return d ? `${w} × ${d} × ${h} mm` : `${w} × ${h} mm`
+  return '-'
+}
 
 async function loadData() {
   const rawId = route.params.id

--- a/src/views/master/ItemListPage.vue
+++ b/src/views/master/ItemListPage.vue
@@ -56,6 +56,18 @@ const unitOptions = computed(() => {
   return [{ label: '전체', value: '' }, ...units.map((u) => ({ label: u, value: u }))]
 })
 
+/** WDH 컬럼이 있으면 "1722×1134×40 mm" 형식, W/H 만 있으면 "1722×1134 mm",
+ *  치수 정보가 없으면 자유 텍스트 itemSpec, 그것도 없으면 "-". */
+function formatItemDimensions(row) {
+  const w = row.itemWidth
+  const d = row.itemDepth
+  const h = row.itemHeight
+  if (w && h) {
+    return d ? `${w} × ${d} × ${h} mm` : `${w} × ${h} mm`
+  }
+  return row.itemSpec || '-'
+}
+
 function resetFilters() {
   filters.value = { keyword: '', code: '', name: '', category: '', unit: '', status: '' }
   appliedFilters.value = { keyword: '', code: '', name: '', category: '', unit: '', status: '' }
@@ -306,6 +318,11 @@ function goToDetail(row) {
           <p class="font-medium text-ink">{{ row.itemName }}</p>
           <p class="text-xs text-slate-500">{{ [row.itemNameKr, row.itemCategory].filter(Boolean).join(' · ') }}</p>
         </div>
+      </template>
+
+      <!-- 규격: 구조화된 W×D×H 우선 표시, 누락 시 자유 텍스트 itemSpec fallback -->
+      <template #cell-itemSpec="{ row }">
+        <span>{{ formatItemDimensions(row) }}</span>
       </template>
 
       <template #cell-itemUnitPrice="{ row }">

--- a/src/views/master/ItemListPage.vue
+++ b/src/views/master/ItemListPage.vue
@@ -56,15 +56,11 @@ const unitOptions = computed(() => {
   return [{ label: '전체', value: '' }, ...units.map((u) => ({ label: u, value: u }))]
 })
 
-/** WDH 컬럼이 있으면 "1722×1134×40 mm" 형식, W/H 만 있으면 "1722×1134 mm",
- *  치수 정보가 없으면 자유 텍스트 itemSpec, 그것도 없으면 "-". */
+/** W/D/H 가 모두 있으면 "1722 × 1134 × 35 mm". 정책상 셋 다 필수 (ItemFormModal 검증).
+ *  레거시 누락 데이터는 자유 텍스트 itemSpec fallback, 그것도 없으면 "-". */
 function formatItemDimensions(row) {
-  const w = row.itemWidth
-  const d = row.itemDepth
-  const h = row.itemHeight
-  if (w && h) {
-    return d ? `${w} × ${d} × ${h} mm` : `${w} × ${h} mm`
-  }
+  const w = row.itemWidth, d = row.itemDepth, h = row.itemHeight
+  if (w && d && h) return `${w} × ${d} × ${h} mm`
   return row.itemSpec || '-'
 }
 


### PR DESCRIPTION
## 📋 작업 내용 (Bundle C)

컨택리스트는 영업담당자 개인의 인맥 자산. 작성자(writerId) 기준 조회로 전환.

같은 팀의 buyer 등록은 BuyerCommandService.syncToActivityContacts 에서
팀원 각각에게 별도 Contact row 를 만들어주므로, 각자 본인 writerId 필터링만 해도
자동으로 팀이 추가한 컨택이 보임 (일방적 / 작성자 본인만).

### 프론트
- `api/contacts.js`: `fetchContacts()` (activity `/api/contacts` PagedModel)
- `ContactListPage`:
  - 데이터 소스 `fetchBuyers` → `fetchContacts`
  - `normalizeContact` 로 Contact 응답 필드를 기존 buyer 형태로 매핑 — UI/CRUD 변경 최소화
  - CRUD 후 `loadContacts()` 재호출 (sync 결과 즉시 반영)
  - 클라이언트 단 `createdBy` 필터 제거 — 서버 단 `writerId` 필터로 대체

### 백엔드 페어
`team2-backend-activity` main `d24fd0a`:
- `ContactQueryController.getContacts`: `@AuthenticationPrincipal Jwt` 추출, ADMIN 이 아니면 `writerId=jwt.subject` 필터
- `ContactQueryService/Mapper`: `writerId` 파라미터 추가
- `ContactQueryMapper.xml`: `contactFilterConditions` 에 `writer_id` 조건

## 🔗 관련 이슈
- closes #324

## ✅ 체크리스트
- [x] activity `gradlew assemble` 성공
- [x] 프론트 `npx vite build` 성공