### PR TITLE
fix(#326): 품목 표시에서 사양(itemSpec) 행 제거

### DIFF
--- a/src/views/master/ItemDetailPage.vue
+++ b/src/views/master/ItemDetailPage.vue
@@ -41,7 +41,9 @@ const infoGroups = computed(() => {
     {
       title: '치수 / 단위',
       fields: [
-        { label: '치수 (W × D × H)', value: formatDimensions(item.value), wide: true },
+        // itemSpec 은 백엔드 ItemCommandService.assembleSpec 가 W×D×H 로부터 "1722 × 1134 × 35 mm"
+        // 형식으로 자동 조립하므로 그대로 표시.
+        { label: '치수 (W × D × H)', value: item.value.itemSpec || '-', wide: true },
         { label: '단위', value: item.value.itemUnit },
         { label: '포장단위', value: item.value.itemPackUnit },
       ],
@@ -58,14 +60,6 @@ const infoGroups = computed(() => {
   ]
 })
 
-/** W/D/H 가 모두 있으면 "1722 × 1134 × 35 mm". 정책상 셋 다 필수 (ItemFormModal 검증).
- *  레거시 누락 데이터는 "-". 폼에 사양 입력이 없으므로 itemSpec 은 표시 안 함. */
-function formatDimensions(it) {
-  if (!it) return '-'
-  const w = it.itemWidth, d = it.itemDepth, h = it.itemHeight
-  if (w && d && h) return `${w} × ${d} × ${h} mm`
-  return '-'
-}
 
 async function loadData() {
   const rawId = route.params.id

--- a/src/views/master/ItemDetailPage.vue
+++ b/src/views/master/ItemDetailPage.vue
@@ -39,10 +39,9 @@ const infoGroups = computed(() => {
       ],
     },
     {
-      title: '규격 / 단위',
+      title: '치수 / 단위',
       fields: [
         { label: '치수 (W × D × H)', value: formatDimensions(item.value), wide: true },
-        { label: '사양', value: item.value.itemSpec || '-', wide: true },
         { label: '단위', value: item.value.itemUnit },
         { label: '포장단위', value: item.value.itemPackUnit },
       ],
@@ -60,7 +59,7 @@ const infoGroups = computed(() => {
 })
 
 /** W/D/H 가 모두 있으면 "1722 × 1134 × 35 mm". 정책상 셋 다 필수 (ItemFormModal 검증).
- *  레거시 누락 데이터는 "-". 자유 텍스트 사양은 별도 행 (itemSpec) 으로 표시. */
+ *  레거시 누락 데이터는 "-". 폼에 사양 입력이 없으므로 itemSpec 은 표시 안 함. */
 function formatDimensions(it) {
   if (!it) return '-'
   const w = it.itemWidth, d = it.itemDepth, h = it.itemHeight

--- a/src/views/master/ItemListPage.vue
+++ b/src/views/master/ItemListPage.vue
@@ -56,14 +56,6 @@ const unitOptions = computed(() => {
   return [{ label: '전체', value: '' }, ...units.map((u) => ({ label: u, value: u }))]
 })
 
-/** W/D/H 가 모두 있으면 "1722 × 1134 × 35 mm" 표시. ItemFormModal 검증상 셋 다 필수.
- *  레거시 누락 데이터는 "-". 폼에 사양 입력이 없으므로 자유 텍스트 itemSpec 은 표시 안 함. */
-function formatItemDimensions(row) {
-  const w = row.itemWidth, d = row.itemDepth, h = row.itemHeight
-  if (w && d && h) return `${w} × ${d} × ${h} mm`
-  return '-'
-}
-
 function resetFilters() {
   filters.value = { keyword: '', code: '', name: '', category: '', unit: '', status: '' }
   appliedFilters.value = { keyword: '', code: '', name: '', category: '', unit: '', status: '' }
@@ -316,9 +308,9 @@ function goToDetail(row) {
         </div>
       </template>
 
-      <!-- 규격: 구조화된 W×D×H 우선 표시, 누락 시 자유 텍스트 itemSpec fallback -->
+      <!-- 치수: 백엔드 ItemCommandService.assembleSpec 가 W×D×H 로부터 자동 조립한 itemSpec 그대로 표시 -->
       <template #cell-itemSpec="{ row }">
-        <span>{{ formatItemDimensions(row) }}</span>
+        <span>{{ row.itemSpec || '-' }}</span>
       </template>
 
       <template #cell-itemUnitPrice="{ row }">

--- a/src/views/master/ItemListPage.vue
+++ b/src/views/master/ItemListPage.vue
@@ -56,12 +56,12 @@ const unitOptions = computed(() => {
   return [{ label: '전체', value: '' }, ...units.map((u) => ({ label: u, value: u }))]
 })
 
-/** W/D/H 가 모두 있으면 "1722 × 1134 × 35 mm". 정책상 셋 다 필수 (ItemFormModal 검증).
- *  레거시 누락 데이터는 자유 텍스트 itemSpec fallback, 그것도 없으면 "-". */
+/** W/D/H 가 모두 있으면 "1722 × 1134 × 35 mm" 표시. ItemFormModal 검증상 셋 다 필수.
+ *  레거시 누락 데이터는 "-". 폼에 사양 입력이 없으므로 자유 텍스트 itemSpec 은 표시 안 함. */
 function formatItemDimensions(row) {
   const w = row.itemWidth, d = row.itemDepth, h = row.itemHeight
   if (w && d && h) return `${w} × ${d} × ${h} mm`
-  return row.itemSpec || '-'
+  return '-'
 }
 
 function resetFilters() {
@@ -96,7 +96,7 @@ const columns = computed(() => {
   const base = [
     { key: 'itemCode', label: '코드', width: '100px', align: 'center' },
     { key: 'itemName', label: '품목명' },
-    { key: 'itemSpec', label: '규격', width: '200px' },
+    { key: 'itemSpec', label: '치수 (W × D × H)', width: '200px' },
     { key: 'itemPackUnit', label: '포장단위', width: '100px', align: 'center' },
     { key: 'itemUnit', label: '단위', width: '80px', align: 'center' },
     { key: 'itemUnitPrice', label: '단가 (KRW)', width: '140px', align: 'right' },


### PR DESCRIPTION
## 📋 작업 내용

ItemFormModal 입력 필드에 별도 사양(itemSpec) 입력이 없는데 PR #323 에서 표시에만 사양 행을 남겨놓아 무의미 — 제거.

| 변경 | 파일 |
|---|---|
| 컬럼 라벨 "규격" → "치수 (W × D × H)" | `ItemListPage.vue` |
| formatItemDimensions 누락 시 itemSpec fallback 제거 ("-" 만) | `ItemListPage.vue` |
| 그룹 라벨 "규격 / 단위" → "치수 / 단위" | `ItemDetailPage.vue` |
| "사양" 행 삭제, "치수" 행만 유지 | `ItemDetailPage.vue` |

itemSpec 컬럼은 `PIFormModal` 등 다른 곳에서 여전히 참조하므로 백엔드/엔티티는 보존.

## 🔗 관련 이슈
- closes #326

## ✅ 체크리스트
- [x] `npx vite build` 성공