### PR TITLE
fix(#328): 자사 정보 필드명 불일치 — 3차 연속 FAIL 근본 원인

### DIFF
--- a/src/components/domain/auth/CompanyInfoTab.vue
+++ b/src/components/domain/auth/CompanyInfoTab.vue
@@ -11,14 +11,18 @@ import { isValidEmail } from '@/utils/validators'
 const { success, error, warning } = useToast()
 
 
+// 백엔드 Company 엔티티 필드명 그대로 (companyName / companyAddressEn / companyAddressKr /
+// companyTel / companyFax / companyEmail / companyWebsite / companySealImageUrl).
+// 한글/영문 회사명 분리 컬럼 없음 — 단일 companyName 필드.
 const form = ref({
-  nameEn: '',
-  nameKr: '',
-  addressEn: '',
-  tel: '',
-  fax: '',
-  email: '',
-  sealImageUrl: '',
+  companyName: '',
+  companyAddressEn: '',
+  companyAddressKr: '',
+  companyTel: '',
+  companyFax: '',
+  companyEmail: '',
+  companyWebsite: '',
+  companySealImageUrl: '',
   sealImage: null,
 })
 const errors = ref({})
@@ -30,13 +34,14 @@ onMounted(async () => {
   try {
     const data = await fetchCompany()
     form.value = {
-      nameEn: data.nameEn ?? '',
-      nameKr: data.nameKr ?? '',
-      addressEn: data.addressEn ?? '',
-      tel: data.tel ?? '',
-      fax: data.fax ?? '',
-      email: data.email ?? '',
-      sealImageUrl: data.sealImageUrl ?? '',
+      companyName: data.companyName ?? '',
+      companyAddressEn: data.companyAddressEn ?? '',
+      companyAddressKr: data.companyAddressKr ?? '',
+      companyTel: data.companyTel ?? '',
+      companyFax: data.companyFax ?? '',
+      companyEmail: data.companyEmail ?? '',
+      companyWebsite: data.companyWebsite ?? '',
+      companySealImageUrl: data.companySealImageUrl ?? '',
       sealImage: null,
     }
   } catch (e) {
@@ -48,11 +53,11 @@ onMounted(async () => {
 
 function validate() {
   const e = {}
-  if (!form.value.nameEn.trim()) {
-    e.nameEn = '영문 회사명을 입력해주세요.'
+  if (!form.value.companyName.trim()) {
+    e.companyName = '회사명을 입력해주세요.'
   }
-  if (form.value.email && !isValidEmail(form.value.email)) {
-    e.email = '올바른 이메일 형식을 입력해주세요.'
+  if (form.value.companyEmail && !isValidEmail(form.value.companyEmail)) {
+    e.companyEmail = '올바른 이메일 형식을 입력해주세요.'
   }
   errors.value = e
   return Object.keys(e).length === 0
@@ -65,14 +70,16 @@ async function handleSave() {
   }
   saving.value = true
   try {
+    // 백엔드 UpdateCompanyRequest 는 prefix 없는 필드명 사용 (name/addressEn/... ).
     const payload = {
-      nameEn: form.value.nameEn.trim(),
-      nameKr: form.value.nameKr.trim(),
-      addressEn: form.value.addressEn.trim(),
-      tel: form.value.tel.trim(),
-      fax: form.value.fax.trim(),
-      email: form.value.email.trim(),
-      sealImageUrl: form.value.sealImageUrl,
+      name: form.value.companyName.trim(),
+      addressEn: form.value.companyAddressEn.trim(),
+      addressKr: form.value.companyAddressKr.trim(),
+      tel: form.value.companyTel.trim(),
+      fax: form.value.companyFax.trim(),
+      email: form.value.companyEmail.trim(),
+      website: form.value.companyWebsite.trim(),
+      sealImageUrl: form.value.companySealImageUrl,
       // TODO: sealImage 파일 업로드는 백엔드 연동 시 구현
     }
     await updateCompany(payload)
@@ -101,41 +108,46 @@ async function handleSave() {
     </div>
 
     <form v-else class="space-y-4" @submit.prevent="handleSave">
-      <!-- 2열: 회사명 -->
+      <!-- 1열: 회사명 -->
+      <FormField label="회사명" required :error="errors.companyName">
+        <BaseTextField v-model="form.companyName" placeholder="회사명" />
+      </FormField>
+
+      <!-- 2열: 주소 영문 / 한글 -->
       <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
-        <FormField label="영문 회사명" required :error="errors.nameEn">
-          <BaseTextField v-model="form.nameEn" placeholder="영문 회사명" />
+        <FormField label="영문 주소">
+          <BaseTextField v-model="form.companyAddressEn" placeholder="영문 주소" />
         </FormField>
-        <FormField label="한글 회사명">
-          <BaseTextField v-model="form.nameKr" placeholder="한글 회사명" />
+        <FormField label="한글 주소">
+          <BaseTextField v-model="form.companyAddressKr" placeholder="한글 주소" />
         </FormField>
       </div>
-
-      <!-- 1열: 주소 -->
-      <FormField label="영문 주소">
-        <BaseTextField v-model="form.addressEn" placeholder="영문 주소를 입력하세요" />
-      </FormField>
 
       <!-- 2열: TEL / FAX -->
       <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
         <FormField label="TEL">
-          <BaseTextField v-model="form.tel" placeholder="전화번호" />
+          <BaseTextField v-model="form.companyTel" placeholder="전화번호" />
         </FormField>
         <FormField label="FAX">
-          <BaseTextField v-model="form.fax" placeholder="팩스번호" />
+          <BaseTextField v-model="form.companyFax" placeholder="팩스번호" />
         </FormField>
       </div>
 
-      <!-- 1열: Email -->
-      <FormField label="Email" :error="errors.email">
-        <BaseTextField v-model="form.email" type="email" placeholder="이메일 주소" />
-      </FormField>
+      <!-- 2열: Email / Website -->
+      <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <FormField label="Email" :error="errors.companyEmail">
+          <BaseTextField v-model="form.companyEmail" type="email" placeholder="이메일 주소" />
+        </FormField>
+        <FormField label="Website">
+          <BaseTextField v-model="form.companyWebsite" placeholder="https://example.com" />
+        </FormField>
+      </div>
 
       <!-- 회사 도장 이미지 -->
       <div class="space-y-3">
         <img
-          v-if="form.sealImageUrl && !form.sealImage"
-          :src="form.sealImageUrl"
+          v-if="form.companySealImageUrl && !form.sealImage"
+          :src="form.companySealImageUrl"
           alt="현재 등록된 도장 이미지"
           class="h-20 w-20 rounded-lg border border-slate-200 object-contain"
         />


### PR DESCRIPTION
## 📋 작업 내용

3회 연속 QA FAIL 의 근본 원인 발견 — **프론트가 잘못된 필드명 사용**. DB·백엔드 모두 정상이었고 표시·저장 양쪽 모두 키 미스매치.

### 백엔드 (이미 정상)
- GET 응답: `companyName/companyAddressEn/companyAddressKr/companyTel/companyFax/companyEmail/companyWebsite/companySealImageUrl`
- PUT 요청: `name/addressEn/addressKr/tel/fax/email/website/sealImageUrl` (prefix 없음)
- 운영 DB: 19→1건 정리 + `uk_company_name` UNIQUE 적용 (Linux DB cleanup)

### 프론트 (이번 수정)
| 변경 | |
|---|---|
| form state | `nameEn/nameKr/addressEn/...` → `companyName/companyAddressEn/companyAddressKr/...` |
| onMounted 매핑 | `data.nameEn` 등 잘못된 키 → `data.companyName` 등 |
| handleSave payload | `nameEn/...` → `name/addressEn/addressKr/tel/fax/email/website/sealImageUrl` (UpdateCompanyRequest 형식) |
| 회사명 분리 입력 | "영문/한글 회사명" 두 칸 → 단일 "회사명" (백엔드 컬럼 1개) |
| 누락 입력 추가 | "한글 주소" / "Website" |

## 🔗 관련 이슈
- closes #328
- QA 5차 ISSUE #1 해소

## ✅ 체크리스트
- [x] `npx vite build` 성공