### PR TITLE
feat: 거래처 등록 시 바이어 정보 확장 + 결재자 드롭다운 팀장 연동

### DIFF
--- a/src/api/documents.js
+++ b/src/api/documents.js
@@ -64,3 +64,12 @@ export const updateCollection = (id, payload) =>
 // Approval Requests
 export const fetchApprovalRequests = () =>
   api.get('/approval-requests').then((r) => unwrapCollection(r.data))
+
+/**
+ * 결재자 후보 조회 (팀장 + ADMIN).
+ * @param {number|null} teamId — 현재 사용자의 팀 ID. null 이면 전 팀의 팀장 반환.
+ */
+export const fetchApprovers = (teamId = null) =>
+  api
+    .get('/approval-requests/approvers', { params: teamId != null ? { teamId } : {} })
+    .then((r) => (Array.isArray(r.data) ? r.data : unwrapCollection(r.data)))

--- a/src/components/domain/document/PIFormModal.vue
+++ b/src/components/domain/document/PIFormModal.vue
@@ -16,8 +16,9 @@ import {
   fetchIncoterms,
   fetchItems,
 } from '@/api/master'
-import { fetchAllUsers } from '@/api/auth'
+import { fetchApprovers } from '@/api/documents'
 import { useToast } from '@/composables/useToast'
+import { useAuthStore } from '@/stores/auth'
 import {
   fallbackIncotermsCatalog,
   formatIncotermsLabel,
@@ -46,7 +47,8 @@ const defaultBuyerOptions = [
   'Mr. Ahmad Razak (Purchasing Manager)',
   'Ms. Siti Nurhaliza (Director)',
 ]
-const defaultApproverOptions = ['김영업']
+const defaultApproverOptions = []
+const authStore = useAuthStore()
 const fallbackProductCatalog = [
   { id: '1', code: 'ITM001', name: 'Wireless Presenter', spec: '2.4GHz / 100m / USB Receiver / Laser Pointer', unit: 'EA', unitPrice: 55000 },
   { id: '2', code: 'ITM002', name: 'Tablet PC 10"', spec: '10.1" FHD / Octa-core / 4GB / 64GB / WiFi', unit: 'EA', unitPrice: 650000 },
@@ -258,12 +260,13 @@ function mapBuyerLabel(buyer) {
 
 async function loadReferenceData() {
   try {
-    const [clientsData, countriesData, currenciesData, itemsData, usersData, incotermsData] = await Promise.all([
+    const teamId = authStore.user?.teamId ?? null
+    const [clientsData, countriesData, currenciesData, itemsData, approversData, incotermsData] = await Promise.all([
       fetchClients(),
       fetchCountries(),
       fetchCurrencies(),
       fetchItems(),
-      fetchAllUsers(),
+      fetchApprovers(teamId).catch(() => []),
       fetchIncoterms(),
     ])
 
@@ -310,14 +313,13 @@ async function loadReferenceData() {
       }))
       .filter((item) => item.code)
 
-    const activeUsers = usersData
-      .filter((user) => user.userStatus === 'active')
-      .filter((user) => user.userRole === 'sales' && user.positionName === '사원')
+    // 결재자 후보: 우리팀 팀장 + ADMIN (팀장/ADMIN 본인이 포함되면 셀프 결재 테스트 가능)
+    const approverNames = (approversData ?? [])
       .map((user) => user.userName)
       .filter(Boolean)
 
-    if (activeUsers.length) {
-      approverOptions.value = activeUsers
+    if (approverNames.length) {
+      approverOptions.value = approverNames
     }
 
     if (!approverOptions.value.includes(form.value.approver)) {

--- a/src/components/domain/document/POFormModal.vue
+++ b/src/components/domain/document/POFormModal.vue
@@ -4,7 +4,8 @@ import { computed, ref, watch } from 'vue'
 import BaseButton from '@/components/common/BaseButton.vue'
 import BaseModal from '@/components/common/BaseModal.vue'
 import BaseSelect from '@/components/common/BaseSelect.vue'
-import { fetchAllUsers } from '@/api/auth'
+import { fetchApprovers } from '@/api/documents'
+import { useAuthStore } from '@/stores/auth'
 
 const props = defineProps({
   open: { type: Boolean, default: false },
@@ -15,7 +16,8 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['close', 'save', 'open-pi-search', 'open-client-search'])
-const defaultApproverOptions = ['김영업']
+const defaultApproverOptions = []
+const authStore = useAuthStore()
 
 function createInitialForm() {
   return {
@@ -26,7 +28,7 @@ function createInitialForm() {
     deliveryDate: '',
     sourceDeliveryDate: '',
     deliveryDateOverride: false,
-    approver: defaultApproverOptions[0],
+    approver: '',
   }
 }
 
@@ -38,22 +40,17 @@ const isDeliveryDateLocked = computed(() => isLinkedToPi.value && !form.value.de
 
 async function loadApproverOptions() {
   try {
-    const users = await fetchAllUsers()
-    const activeUsers = users
-      .filter((user) => user.userStatus === 'active')
-      .filter((user) => user.userRole === 'sales' && user.positionName === '사원')
-      .map((user) => user.userName)
-      .filter(Boolean)
-
-    if (activeUsers.length) {
-      approverOptions.value = activeUsers
-    }
+    // 결재자 후보: 우리팀 팀장 + ADMIN (셀프 결재 가능)
+    const teamId = authStore.user?.teamId ?? null
+    const approvers = await fetchApprovers(teamId)
+    const names = (approvers ?? []).map((u) => u.userName).filter(Boolean)
+    approverOptions.value = names
   } catch {
-    approverOptions.value = [...defaultApproverOptions]
+    approverOptions.value = []
   }
 
   if (!approverOptions.value.includes(form.value.approver)) {
-    form.value.approver = approverOptions.value[0] ?? defaultApproverOptions[0]
+    form.value.approver = approverOptions.value[0] ?? ''
   }
 }
 
@@ -73,7 +70,7 @@ watch(
         deliveryDate: props.document.deliveryDate?.replaceAll('/', '-') ?? '',
         sourceDeliveryDate: props.document.sourceDeliveryDate?.replaceAll('/', '-') ?? props.document.deliveryDate?.replaceAll('/', '-') ?? '',
         deliveryDateOverride: Boolean(props.document.deliveryDateOverride),
-        approver: props.document.approver ?? approverOptions.value[0] ?? defaultApproverOptions[0],
+        approver: props.document.approver ?? approverOptions.value[0] ?? '',
       }
       return
     }

--- a/src/components/domain/master/ClientFormModal.vue
+++ b/src/components/domain/master/ClientFormModal.vue
@@ -96,6 +96,9 @@ function getInitialForm() {
     paymentTermsId: null,
     currencyId: null,
     manager: '',
+    buyerPosition: '',
+    buyerEmail: '',
+    buyerTel: '',
     departmentId: null,
     teamId: null,
     status: 'active',
@@ -216,6 +219,18 @@ function validate() {
     e.manager = `담당자명은 ${MAX_LEN.MANAGER}자 이내로 입력하세요.`
   }
 
+  // 바이어 정보 — 신규 등록 시만 필수 (수정 시 Client 만 수정, Buyer 는 상세 페이지에서)
+  if (props.mode === 'create') {
+    if (!form.value.buyerEmail?.trim()) {
+      e.buyerEmail = '바이어 이메일을 입력하세요.'
+    } else if (!isValidEmail(form.value.buyerEmail)) {
+      e.buyerEmail = '올바른 이메일 형식을 입력하세요.'
+    }
+    if (form.value.buyerTel && !isValidTel(form.value.buyerTel)) {
+      e.buyerTel = '올바른 전화번호 형식을 입력하세요.'
+    }
+  }
+
   if (!form.value.tel?.trim()) {
     e.tel = '거래처 연락처를 입력하세요.'
   } else if (!isValidTel(form.value.tel)) {
@@ -264,6 +279,11 @@ function handleSave() {
     paymentTermId: form.value.paymentTermsId,
     currencyId: form.value.currencyId,
     clientManager: form.value.manager,
+    ...(props.mode === 'create' && {
+      buyerPosition: form.value.buyerPosition || null,
+      buyerEmail: form.value.buyerEmail,
+      buyerTel: form.value.buyerTel || null,
+    }),
     teamId: form.value.teamId,
   }
   emit('save', payload)
@@ -317,16 +337,11 @@ function handleSave() {
         </div>
       </div>
 
-      <!-- 거래처 연락처 -->
+      <!-- 거래처 대표 연락처 -->
       <div>
-        <h4 class="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400">거래처 연락처</h4>
+        <h4 class="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400">거래처 대표 연락처</h4>
         <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
-          <FormField label="거래처 담당자 (바이어)" required>
-            <BaseTextField v-model="form.manager" placeholder="거래처 측 바이어 이름 (예: Mr. Ahmad Razak)" />
-            <p v-if="errors.manager" class="mt-1 text-xs text-red-500">{{ errors.manager }}</p>
-            <p v-else class="mt-1 text-xs text-slate-400">거래처 내 주 연락 담당자(바이어). 추가 바이어는 상세 페이지에서 등록합니다.</p>
-          </FormField>
-          <FormField label="거래처 TEL (대표 연락처)" required>
+          <FormField label="거래처 TEL (대표)" required>
             <BaseTextField
               v-model="form.tel"
               :placeholder="phoneInfo.placeholder"
@@ -335,9 +350,48 @@ function handleSave() {
             />
             <p v-if="errors.tel" class="mt-1 text-xs text-red-500">{{ errors.tel }}</p>
           </FormField>
-          <FormField label="거래처 Email (대표 이메일)" required>
+          <FormField label="거래처 Email (대표)" required>
             <BaseTextField v-model="form.email" type="email" placeholder="contact@company.com" />
             <p v-if="errors.email" class="mt-1 text-xs text-red-500">{{ errors.email }}</p>
+          </FormField>
+        </div>
+      </div>
+
+      <!-- 최초 바이어 정보 (신규 등록 시만) -->
+      <div v-if="mode === 'create'">
+        <h4 class="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400">
+          최초 바이어 정보
+          <span class="ml-2 text-[11px] font-normal normal-case text-slate-400">
+            거래처 등록 시 대표 바이어 1명 자동 등록 — 추가 바이어는 상세 페이지에서.
+          </span>
+        </h4>
+        <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <FormField label="바이어 이름" required>
+            <BaseTextField v-model="form.manager" placeholder="예: Mr. Ahmad Razak" />
+            <p v-if="errors.manager" class="mt-1 text-xs text-red-500">{{ errors.manager }}</p>
+          </FormField>
+          <FormField label="바이어 직책">
+            <BaseTextField v-model="form.buyerPosition" placeholder="예: Purchasing Manager" />
+          </FormField>
+          <FormField label="바이어 Email" required>
+            <BaseTextField v-model="form.buyerEmail" type="email" placeholder="buyer@company.com" />
+            <p v-if="errors.buyerEmail" class="mt-1 text-xs text-red-500">{{ errors.buyerEmail }}</p>
+          </FormField>
+          <FormField label="바이어 TEL">
+            <BaseTextField v-model="form.buyerTel" :placeholder="phoneInfo.placeholder" />
+            <p v-if="errors.buyerTel" class="mt-1 text-xs text-red-500">{{ errors.buyerTel }}</p>
+          </FormField>
+        </div>
+      </div>
+
+      <!-- 수정 모드: 거래처 담당자명만 -->
+      <div v-else>
+        <h4 class="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400">거래처 담당자</h4>
+        <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <FormField label="거래처 담당자 (대표 바이어)" required>
+            <BaseTextField v-model="form.manager" placeholder="예: Mr. Ahmad Razak" />
+            <p v-if="errors.manager" class="mt-1 text-xs text-red-500">{{ errors.manager }}</p>
+            <p v-else class="mt-1 text-xs text-slate-400">바이어 세부 정보는 거래처 상세 페이지에서 수정합니다.</p>
           </FormField>
         </div>
       </div>


### PR DESCRIPTION
Closes #334

## Summary
- ClientFormModal 에 **최초 바이어 정보 섹션** (직책/이메일/전화) 추가 — 거래처 대표 연락처와 분리
- 백엔드 연동: 거래처 저장 payload 에 buyerPosition/buyerEmail/buyerTel 포함 → Client 저장과 동시에 Buyer 1건 생성 → Activity Contact sync 자동 동작
- PIFormModal / POFormModal 의 결재자 옵션을 \`GET /api/approval-requests/approvers?teamId=\` 결과로 치환
- 하드코딩 **'김영업'** / **'sales 사원 필터'** 완전 제거
- 팀장/ADMIN 본인이 리스트에 포함 → 셀프 결재 테스트 가능

## 연관 백엔드 커밋 (이미 main 푸시)
- master \`00a1c08\` — CreateClientRequest 확장 + Buyer 자동 생성
- auth \`6deccf5\` — /api/users/internal/approvers 추가
- documents \`bf51ee3\` — /api/approval-requests/approvers 프록시

## Test plan
- [ ] SALES 계정으로 거래처 신규 등록 → 목록에 표시되는지 확인 (ISSUE #1)
- [ ] 거래처 등록 후 본인 컨택리스트에 바이어 auto-sync 되는지 확인 (ISSUE #2)
- [ ] 같은 팀 다른 SALES 계정에도 컨택 auto-sync 되는지 확인
- [ ] PI/PO 등록 시 결재자 드롭다운에 우리팀 팀장 + ADMIN 만 노출
- [ ] 팀장 계정으로 PI 생성 시 본인이 결재자 리스트에 포함되어 셀프 결재 가능한지 확인
- [ ] ADMIN 계정으로 동일 확인
- [ ] 거래처 수정 모드에서 바이어 3필드 숨김 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)