### PR TITLE
fix: 결재자 드롭다운 타팀 팀장 노출 (authStore.user → currentUser)

### DIFF
--- a/src/components/domain/document/PIFormModal.vue
+++ b/src/components/domain/document/PIFormModal.vue
@@ -260,7 +260,7 @@ function mapBuyerLabel(buyer) {
 
 async function loadReferenceData() {
   try {
-    const teamId = authStore.user?.teamId ?? null
+    const teamId = authStore.currentUser?.teamId ?? null
     const [clientsData, countriesData, currenciesData, itemsData, approversData, incotermsData] = await Promise.all([
       fetchClients(),
       fetchCountries(),

--- a/src/components/domain/document/POFormModal.vue
+++ b/src/components/domain/document/POFormModal.vue
@@ -41,7 +41,7 @@ const isDeliveryDateLocked = computed(() => isLinkedToPi.value && !form.value.de
 async function loadApproverOptions() {
   try {
     // 결재자 후보: 우리팀 팀장 + ADMIN (셀프 결재 가능)
-    const teamId = authStore.user?.teamId ?? null
+    const teamId = authStore.currentUser?.teamId ?? null
     const approvers = await fetchApprovers(teamId)
     const names = (approvers ?? []).map((u) => u.userName).filter(Boolean)
     approverOptions.value = names


### PR DESCRIPTION
Closes #336

## Summary
- \`authStore.user\` 는 공개되지 않음 → \`authStore.currentUser\` 로 교체
- \`fetchApprovers(teamId)\` 에 정확한 본인 팀 teamId 가 전달되어 백엔드 필터링이 정상 동작

## Test plan
- [ ] SALES 계정 PI 작성 → 드롭다운에 본인 팀 팀장 + ADMIN 만 (타팀 팀장 제외)
- [ ] PO 작성 동일 검증
- [ ] 팀장 본인 포함 (셀프 결재 유지)
- [ ] ADMIN 본인 포함 (셀프 결재 유지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)