### PR TITLE
fix: Full reload 거래처 0건 (nginx cache 정책 + 청크 실패 auto-reload)

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,7 +1,24 @@
 server {
     listen 80;
     root /usr/share/nginx/html;
+
+    # 해시 파일(/assets/Name-HASH.js|css) — 파일명 자체가 바뀌면 신규 요청되므로 1년 immutable 캐시.
+    location /assets/ {
+        expires 1y;
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        try_files $uri =404;
+    }
+
+    # index.html — 매 로드마다 서버 재검증. 배포 직후에도 구 index.html 이 지목하는
+    # 청크 불일치 문제 방지.
+    location = /index.html {
+        add_header Cache-Control "no-store, no-cache, must-revalidate";
+        expires -1;
+    }
+
+    # SPA fallback
     location / {
+        add_header Cache-Control "no-store, no-cache, must-revalidate";
         try_files $uri $uri/ /index.html;
     }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -64,6 +64,24 @@ router.beforeEach(async (to) => {
   return { name: 'login', query: { redirect: to.fullPath } }
 })
 
+// 배포 직후 브라우저에 캐시된 구 index.js 가 서버에 없는 옛 청크 파일명을 참조하면
+// dynamic import 실패 → 페이지가 렌더링되지 않음. 에러 감지 시 1회 강제 reload 하여
+// 최신 index.html + 청크 해시로 회복.
+const CHUNK_LOAD_ERROR_PATTERN = /Failed to fetch dynamically imported module|Importing a module script failed/i
+const RELOAD_FLAG = 'claude.chunkReloaded'
+router.onError((err) => {
+  if (CHUNK_LOAD_ERROR_PATTERN.test(err?.message ?? '')) {
+    if (sessionStorage.getItem(RELOAD_FLAG) !== '1') {
+      sessionStorage.setItem(RELOAD_FLAG, '1')
+      window.location.reload()
+    }
+  }
+})
+router.afterEach(() => {
+  // 정상 페이지 이동 완료 시 reload 플래그 해제 — 다음 배포 발생 시 다시 감지 가능하게.
+  try { sessionStorage.removeItem(RELOAD_FLAG) } catch {}
+})
+
 router.afterEach(() => {
   if (typeof sessionStorage === 'undefined') return
   if (sessionStorage.getItem('flash.denyAccess') === '1') {


### PR DESCRIPTION
Closes #338

## Summary
Full reload 시 구 index.html 캐시가 서버에 없는 옛 청크를 참조 → dynamic import 실패 → 컴포넌트 mount 실패 → empty state 고착.

## 변경사항
### nginx.conf
- \`/assets/*\` 에 \`Cache-Control: public, max-age=31536000, immutable\` (해시 기반 영구 캐시)
- \`/\`, \`/index.html\` 에 \`no-store, no-cache, must-revalidate\` (엔트리는 매 로드 재검증)

### src/main.js
- \`router.onError\` 로 dynamic import 실패 감지 → sessionStorage flag 체크 후 1회 \`location.reload()\` (루프 방지)
- 정상 navigation 시 flag 자동 해제

## Test plan
- [ ] 배포 후 /master/clients 에서 F5 새로고침 → 거래처 목록 정상 표시
- [ ] URL 직접 진입(새 탭) 동일 정상 동작
- [ ] 다음 배포 시 브라우저 Hard Reload 없이도 최신 청크 다운로드
- [ ] console 에 "Failed to fetch dynamically imported module" 에러 없음
- [ ] 기존 기능(로그인/라우팅/API 401 refresh) 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)