### PR TITLE
feat: 등록/수정 form 두 단계 의존 UI 제어

### DIFF
--- a/src/components/domain/document/PIFormModal.vue
+++ b/src/components/domain/document/PIFormModal.vue
@@ -43,10 +43,6 @@ const emit = defineEmits(['close', 'save', 'open-client-search'])
 const { error } = useToast()
 
 const defaultCurrencyOptions = ['KRW', 'USD', 'EUR', 'JPY', 'GBP', 'AUD', 'CAD', 'SGD', 'AED', 'CNY', 'MYR', 'THB', 'VND', 'IDR', 'INR', 'SAR', 'BRL', 'SEK', 'CHF']
-const defaultBuyerOptions = [
-  'Mr. Ahmad Razak (Purchasing Manager)',
-  'Ms. Siti Nurhaliza (Director)',
-]
 const defaultApproverOptions = []
 const authStore = useAuthStore()
 const fallbackProductCatalog = [
@@ -139,7 +135,7 @@ function createEmptyItemRow(id = Date.now()) {
 const form = ref(createInitialForm())
 const validationErrors = ref({})
 const clientCatalog = ref([])
-const buyerRows = ref([...defaultBuyerOptions])
+const buyerRows = ref([])
 const currencyOptions = ref([...defaultCurrencyOptions])
 const approverOptions = ref([...defaultApproverOptions])
 const productCatalog = ref([...fallbackProductCatalog])
@@ -180,13 +176,19 @@ const itemTableColumns = computed(() => [
   { key: 'remark', label: '비고', width: '20%' },
 ])
 
+const isClientSelected = computed(() => Boolean(form.value.clientName?.trim()))
+
 const buyerOptions = computed(() => {
+  // 거래처 미선택 시 — 바이어 dropdown 을 비활성화하므로 옵션도 비워둠
+  if (!isClientSelected.value) return []
+
   const buyers = new Set(buyerRows.value)
 
   for (const buyer of props.selectedClient?.buyers ?? []) {
     buyers.add(buyer)
   }
 
+  // 수정 모드 등에서 현재 선택된 값이 목록에 없다면 포함시켜 표시 누락 방지
   if (form.value.buyerName) {
     buyers.add(form.value.buyerName)
   }
@@ -344,21 +346,18 @@ function resolveSelectedClientId() {
 async function loadBuyerOptions() {
   const clientId = resolveSelectedClientId()
 
+  // 거래처 미선택 시 바이어 목록은 무조건 비움 (독립 선택 방지)
   if (!clientId) {
-    buyerRows.value = props.selectedClient?.buyers?.length ? props.selectedClient.buyers : [...defaultBuyerOptions]
+    buyerRows.value = []
     return
   }
 
   try {
     const buyersData = await fetchBuyersByClient(clientId)
-    const nextBuyers = buyersData.map(mapBuyerLabel).filter(Boolean)
-    buyerRows.value = nextBuyers.length ? nextBuyers : [...defaultBuyerOptions]
+    buyerRows.value = buyersData.map(mapBuyerLabel).filter(Boolean)
   } catch {
-    buyerRows.value = props.selectedClient?.buyers?.length ? props.selectedClient.buyers : [...defaultBuyerOptions]
-  }
-
-  if (!form.value.buyerName && buyerRows.value.length) {
-    form.value.buyerName = buyerRows.value[0]
+    // 실패 시 selectedClient 에 딸려온 문자열 배열을 fallback 으로 사용
+    buyerRows.value = Array.isArray(props.selectedClient?.buyers) ? [...props.selectedClient.buyers] : []
   }
 }
 
@@ -630,7 +629,7 @@ async function initializeForm() {
       clientAddress: props.document.clientAddress ?? '',
       clientTel: props.document.clientTel ?? '',
       clientEmail: props.document.clientEmail ?? '',
-      buyerName: props.document.buyerName ?? 'Mr. Ahmad Razak (Purchasing Manager)',
+      buyerName: props.document.buyerName ?? '',
       currency: props.document.currency ?? 'USD',
       issueDate: props.document.issueDate?.replaceAll('/', '-') ?? getTodayDateInput(),
       deliveryDate: props.document.deliveryDate?.replaceAll('/', '-') ?? '',
@@ -715,17 +714,26 @@ function handleSave() {
 watch(
   () => props.selectedClient,
   async (client) => {
-    if (!client) return
+    if (!client) {
+      // 거래처 선택이 해제되면 연동 필드와 바이어 목록도 초기화
+      form.value.buyerName = ''
+      buyerRows.value = []
+      return
+    }
     form.value.clientName = client.name
     form.value.clientAddress = client.address ?? ''
     form.value.clientTel = client.tel ?? ''
     form.value.clientEmail = client.email ?? ''
-    form.value.buyerName = client.buyers?.[0] ?? ''
+    // 거래처 변경 시 이전 바이어 선택값 초기화 — 새 거래처 바이어 로드 후 단일 옵션이면 auto-pick
+    form.value.buyerName = ''
     form.value.currency = client.currency ?? form.value.currency
     clearError('clientName')
     clearError('buyerName')
     clearError('currency')
     await loadBuyerOptions()
+    if (buyerRows.value.length === 1) {
+      form.value.buyerName = buyerRows.value[0]
+    }
   },
 )
 
@@ -780,7 +788,8 @@ watch(
           <BaseSelect
             v-model="form.buyerName"
             :options="buyerOptions"
-            placeholder="바이어 선택"
+            :disabled="!isClientSelected"
+            :placeholder="isClientSelected ? (buyerOptions.length ? '바이어 선택' : '등록된 바이어가 없습니다') : '거래처를 먼저 선택하세요'"
             @update:modelValue="clearError('buyerName')"
           />
           <p v-if="getFieldError('buyerName')" class="mt-1 text-xs text-red-500">{{ getFieldError('buyerName') }}</p>

--- a/src/views/activity/ActivityCreatePage.vue
+++ b/src/views/activity/ActivityCreatePage.vue
@@ -33,7 +33,15 @@ const formContent = ref('')
 const formAuthor = ref('')
 const errors = ref({})
 
-watch(formClient, (val) => { if (val) errors.value.client = undefined })
+watch(formClient, (val, oldVal) => {
+  if (val) errors.value.client = undefined
+  // 거래처 변경/해제 시 — PO 의존이므로 선택값/표시값 초기화
+  if (oldVal !== undefined && val !== oldVal) {
+    formPoDisplay.value = ''
+    formPoId.value = ''
+    formAuthor.value = ''
+  }
+})
 watch(formType,   (val) => { if (val) errors.value.type   = undefined })
 watch(formDate,   (val) => { if (val) errors.value.date   = undefined })
 watch(formTitle,  (val) => { if (val.trim()) errors.value.title  = undefined })
@@ -292,16 +300,17 @@ async function handleSubmit() {
           </FormField>
         </div>
 
-        <!-- 2행: 수주건(PO) -->
+        <!-- 2행: 수주건(PO) — 거래처 선택 후 활성화 -->
         <FormField label="수주건">
           <div class="flex items-center gap-2">
             <BaseTextField
               v-model="formPoDisplay"
-              placeholder="수주건을 선택하세요 (PO 검색 클릭)"
+              :placeholder="formClient ? '수주건을 선택하세요 (PO 검색 클릭)' : '거래처를 먼저 선택하세요'"
               :readonly="true"
+              :disabled="!formClient"
               class="flex-1"
             />
-            <BaseButton variant="ghost" @click="openPoSearch">
+            <BaseButton variant="ghost" :disabled="!formClient" @click="openPoSearch">
               <template #leading>
                 <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                   <path fill-rule="evenodd" d="M9 3.5a5.5 5.5 0 1 0 3.473 9.766l3.63 3.63a.75.75 0 1 0 1.06-1.06l-3.63-3.63A5.5 5.5 0 0 0 9 3.5ZM5 9a4 4 0 1 1 8 0 4 4 0 0 1-8 0Z" clip-rule="evenodd" />
@@ -309,7 +318,7 @@ async function handleSubmit() {
               </template>
               PO 검색
             </BaseButton>
-            <BaseButton variant="secondary" @click="clearPo">
+            <BaseButton variant="secondary" :disabled="!formPoDisplay" @click="clearPo">
               <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                 <path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z" />
               </svg>


### PR DESCRIPTION
closes #342

## Summary
- 거래처 등록의 국가→항구 패턴을 표준으로 삼아, 상위 엔티티가 선택되기 전까지 하위 dropdown/버튼을 disabled 처리하고 상위 변경 시 하위 값을 reset + 옵션 재로드하도록 통일.
- PI 등록·수정의 거래처→바이어, 활동 등록의 거래처→PO 검색에서 누락돼 있던 두 단계 의존 UX를 보강.

## Changes
- `src/components/domain/document/PIFormModal.vue`
  - 거래처 미선택 시 바이어 `BaseSelect` 를 `:disabled` 처리하고 placeholder 를 단계별 안내 문구로 분기.
  - `selectedClient` watcher: 거래처 해제 시 `buyerName` / `buyerRows` 초기화, 변경 시 이전 선택값 비우고 `loadBuyerOptions` 후 옵션이 1개면 auto-pick.
  - 하드코딩된 `defaultBuyerOptions` 폴백 제거 — 거래처에 등록된 실제 바이어만 노출.
- `src/views/activity/ActivityCreatePage.vue`
  - 거래처 미선택 시 PO 검색 input/버튼 disabled, placeholder "거래처를 먼저 선택하세요" 로 변경.
  - 거래처 변경 시 선택된 PO·작성자 자동 reset.

## 이미 두 단계 의존이 정상 적용된 form (변경 없음)
- `ClientFormModal` 국가→항구·통화, 부서→팀 (참고 패턴 원본)
- `UserFormModal` 부서→팀
- `OrgStructureTab` 부서 선택 후 + 팀 추가 버튼 활성화

## Test plan
- [ ] PI 등록에서 거래처 미선택 시 바이어 select 가 비활성화 + "거래처를 먼저 선택하세요" 표시
- [ ] PI 등록에서 거래처 선택 후 해당 거래처 바이어만 옵션에 표시되고, 거래처 변경 시 이전 바이어 값이 초기화되고 새 거래처 바이어로 재조회됨
- [ ] PI 수정에서도 동일하게 동작
- [ ] 활동 등록에서 거래처 미선택 시 PO 검색 버튼/필드 disabled
- [ ] 활동 등록에서 거래처 변경 시 이전에 선택했던 PO 와 작성자 표시가 초기화됨
- [ ] 거래처 등록의 기존 국가→항구 패턴 회귀 없음