### PR TITLE
feat: 목록 조회 서버사이드 페이지네이션 적용

### DIFF
--- a/src/api/documents.js
+++ b/src/api/documents.js
@@ -1,9 +1,26 @@
 import { api } from '@/lib/api'
 import { unwrapCollection } from '@/utils/apiResponse'
+import { unwrapPaged } from '@/utils/pagedResponse'
 
-// Proforma Invoices
-export const fetchProformaInvoices = () =>
-  api.get('/proforma-invoices').then((r) => unwrapCollection(r.data))
+/**
+ * 문서 목록 조회 API.
+ *
+ * 백엔드(documents 서비스)가 HATEOAS PagedModel 로 응답한다:
+ *   { _embedded: { <xxxResponseList>: [...] }, _links, page: { size, number, totalElements, totalPages } }
+ *
+ * 두 가지 형태의 함수를 제공:
+ *  1. `fetchXxxPaged({ page, size })` → `{ content, page }` 형태 (서버사이드 페이지네이션 활용)
+ *  2. `fetchXxx()` → 배열 반환 (클라이언트사이드 필터/검색 사용하는 레거시 호출자 호환용.
+ *     내부적으로 size=1000 으로 paged 호출).
+ */
+
+// ── Proforma Invoices ────────────────────────────────────────
+export async function fetchProformaInvoicesPaged({ page = 0, size = 20 } = {}) {
+  const { data } = await api.get('/proforma-invoices', { params: { page, size } })
+  return unwrapPaged(data, { page, size, hintKey: 'proformaInvoiceResponseList' })
+}
+export const fetchProformaInvoices = async () =>
+  (await fetchProformaInvoicesPaged({ page: 0, size: 1000 })).content
 export const fetchProformaInvoice = (piId) =>
   api.get(`/proforma-invoices/${piId}`).then((r) => r.data)
 export const createProformaInvoice = (payload) =>
@@ -11,59 +28,91 @@ export const createProformaInvoice = (payload) =>
 export const requestPiRegistration = (payload) =>
   api.post('/proforma-invoices/request-registration', payload).then((r) => r.data)
 
-// Purchase Orders
-export const fetchPurchaseOrders = () =>
-  api.get('/purchase-orders').then((r) => unwrapCollection(r.data))
+// ── Purchase Orders ──────────────────────────────────────────
+export async function fetchPurchaseOrdersPaged({ page = 0, size = 20 } = {}) {
+  const { data } = await api.get('/purchase-orders', { params: { page, size } })
+  return unwrapPaged(data, { page, size, hintKey: 'purchaseOrderResponseList' })
+}
+export const fetchPurchaseOrders = async () =>
+  (await fetchPurchaseOrdersPaged({ page: 0, size: 1000 })).content
 export const fetchPurchaseOrder = (poId) =>
   api.get(`/purchase-orders/${poId}`).then((r) => r.data)
 export const createPurchaseOrder = (payload) =>
   api.post('/purchase-orders', payload).then((r) => r.data)
 
-// Commercial Invoices
-export const fetchCommercialInvoices = () =>
-  api.get('/commercial-invoices').then((r) => unwrapCollection(r.data))
+// ── Commercial Invoices ──────────────────────────────────────
+export async function fetchCommercialInvoicesPaged({ page = 0, size = 20 } = {}) {
+  const { data } = await api.get('/commercial-invoices', { params: { page, size } })
+  return unwrapPaged(data, { page, size, hintKey: 'commercialInvoiceResponseList' })
+}
+export const fetchCommercialInvoices = async () =>
+  (await fetchCommercialInvoicesPaged({ page: 0, size: 1000 })).content
 export const fetchCommercialInvoice = (ciId) =>
   api.get(`/commercial-invoices/${ciId}`).then((r) => r.data)
 
-// Packing Lists
-export const fetchPackingLists = () =>
-  api.get('/packing-lists').then((r) => unwrapCollection(r.data))
+// ── Packing Lists ────────────────────────────────────────────
+export async function fetchPackingListsPaged({ page = 0, size = 20 } = {}) {
+  const { data } = await api.get('/packing-lists', { params: { page, size } })
+  return unwrapPaged(data, { page, size, hintKey: 'packingListResponseList' })
+}
+export const fetchPackingLists = async () =>
+  (await fetchPackingListsPaged({ page: 0, size: 1000 })).content
 export const fetchPackingList = (plId) =>
   api.get(`/packing-lists/${plId}`).then((r) => r.data)
 
-// Production Orders
-export const fetchProductionOrders = () =>
-  api.get('/production-orders').then((r) => unwrapCollection(r.data))
+// ── Production Orders ────────────────────────────────────────
+export async function fetchProductionOrdersPaged({ page = 0, size = 20 } = {}) {
+  const { data } = await api.get('/production-orders', { params: { page, size } })
+  return unwrapPaged(data, { page, size, hintKey: 'productionOrderResponseList' })
+}
+export const fetchProductionOrders = async () =>
+  (await fetchProductionOrdersPaged({ page: 0, size: 1000 })).content
 export const fetchProductionOrder = (id) =>
   api.get(`/production-orders/${id}`).then((r) => r.data)
 export const completeProductionOrder = (productionOrderId) =>
   api.put(`/production-orders/${productionOrderId}/complete`).then((r) => r.data)
 
-// Shipment Orders
-export const fetchShipmentOrders = () =>
-  api.get('/shipment-orders').then((r) => unwrapCollection(r.data))
+// ── Shipment Orders ──────────────────────────────────────────
+export async function fetchShipmentOrdersPaged({ page = 0, size = 20 } = {}) {
+  const { data } = await api.get('/shipment-orders', { params: { page, size } })
+  return unwrapPaged(data, { page, size, hintKey: 'shipmentOrderResponseList' })
+}
+export const fetchShipmentOrders = async () =>
+  (await fetchShipmentOrdersPaged({ page: 0, size: 1000 })).content
 export const fetchShipmentOrder = (id) =>
   api.get(`/shipment-orders/${id}`).then((r) => r.data)
 
-// Shipments (출하현황)
-export const fetchShipments = () =>
-  api.get('/shipments').then((r) => unwrapCollection(r.data))
+// ── Shipments (출하현황) ──────────────────────────────────────
+export async function fetchShipmentsPaged({ page = 0, size = 20 } = {}) {
+  const { data } = await api.get('/shipments', { params: { page, size } })
+  return unwrapPaged(data, { page, size, hintKey: 'shipmentResponseList' })
+}
+export const fetchShipments = async () =>
+  (await fetchShipmentsPaged({ page: 0, size: 1000 })).content
 export const fetchShipment = (id) =>
   api.get(`/shipments/${id}`).then((r) => r.data)
 export const updateShipment = (id, payload) =>
   api.put(`/shipments/${id}`, payload).then((r) => r.data)
 
-// Collections (수금현황)
-export const fetchCollections = () =>
-  api.get('/collections').then((r) => unwrapCollection(r.data))
+// ── Collections (수금현황) ────────────────────────────────────
+export async function fetchCollectionsPaged({ page = 0, size = 20 } = {}) {
+  const { data } = await api.get('/collections', { params: { page, size } })
+  return unwrapPaged(data, { page, size, hintKey: 'collectionResponseList' })
+}
+export const fetchCollections = async () =>
+  (await fetchCollectionsPaged({ page: 0, size: 1000 })).content
 export const fetchCollection = (id) =>
   api.get(`/collections/${id}`).then((r) => r.data)
 export const updateCollection = (id, payload) =>
   api.put(`/collections/${id}`, payload).then((r) => r.data)
 
-// Approval Requests
-export const fetchApprovalRequests = () =>
-  api.get('/approval-requests').then((r) => unwrapCollection(r.data))
+// ── Approval Requests ────────────────────────────────────────
+export async function fetchApprovalRequestsPaged({ page = 0, size = 20 } = {}) {
+  const { data } = await api.get('/approval-requests', { params: { page, size } })
+  return unwrapPaged(data, { page, size, hintKey: 'approvalRequestResponseList' })
+}
+export const fetchApprovalRequests = async () =>
+  (await fetchApprovalRequestsPaged({ page: 0, size: 1000 })).content
 
 /**
  * 결재자 후보 조회 (팀장 + ADMIN).

--- a/src/api/master.js
+++ b/src/api/master.js
@@ -1,11 +1,25 @@
 import { api } from '@/lib/api'
 import { unwrapCollection } from '@/utils/apiResponse'
+import { unwrapPaged } from '@/utils/pagedResponse'
 
-// Clients
-// 서버가 PagedModel(default size 10) 를 반환하므로, 목록 화면은 클라이언트 페이지네이션을 쓰는
-// 상황에선 충분히 큰 size 로 한 번에 로드해서 전체를 확보한다.
-export const fetchClients = (params = { size: 1000 }) =>
-  api.get('/clients', { params }).then((r) => unwrapCollection(r.data, 'clientResponseList'))
+/**
+ * 기준정보 API.
+ *
+ * 거래처(clients) / 바이어(buyers) 서브리소스는 PagedModel HATEOAS 형식이다.
+ * 각 리소스는 두 가지 형태를 제공:
+ *   - `fetchXxxPaged({ page, size })` → `{ content, page }` (서버사이드 페이지네이션용)
+ *   - `fetchXxx()` → 배열 (클라이언트사이드 필터/검색 레거시 호환. size=1000).
+ */
+
+// ── Clients ─────────────────────────────────────────────────
+export async function fetchClientsPaged({ page = 0, size = 20, ...rest } = {}) {
+  const { data } = await api.get('/clients', { params: { page, size, ...rest } })
+  return unwrapPaged(data, { page, size, hintKey: 'clientResponseList' })
+}
+export const fetchClients = async (params = { size: 1000 }) => {
+  const { data } = await api.get('/clients', { params })
+  return unwrapCollection(data, 'clientResponseList')
+}
 export const fetchClient = (id) => api.get(`/clients/${id}`).then((r) => r.data)
 export const createClient = (client) => api.post('/clients', client).then((r) => r.data)
 export const updateClient = (id, client) => api.put(`/clients/${id}`, client).then((r) => r.data)
@@ -14,7 +28,16 @@ export async function changeClientStatus(id, status) {
   return data
 }
 
-// Items (ItemQueryController 는 PagedResponse 형식 유지)
+export async function fetchClientsByTeamPaged(teamId, { page = 0, size = 20 } = {}) {
+  const { data } = await api.get(`/clients/team/${teamId}`, { params: { page, size } })
+  return unwrapPaged(data, { page, size, hintKey: 'clientResponseList' })
+}
+export async function fetchClientsByDepartmentPaged(departmentId, { page = 0, size = 20 } = {}) {
+  const { data } = await api.get(`/clients/department/${departmentId}`, { params: { page, size } })
+  return unwrapPaged(data, { page, size, hintKey: 'clientResponseList' })
+}
+
+// ── Items (ItemQueryController 는 레거시 PagedResponse 유지) ──
 export const fetchItems = (params = { size: 1000 }) =>
   api.get('/items', { params }).then((r) => unwrapCollection(r.data, 'itemResponseList'))
 export const fetchItem = (id) => api.get(`/items/${id}`).then((r) => r.data)
@@ -25,15 +48,25 @@ export async function changeItemStatus(id, status) {
   return data
 }
 
-// Buyers
-export const fetchBuyers = () =>
-  api.get('/buyers').then((r) => unwrapCollection(r.data, 'buyerResponseList'))
-export const fetchBuyersByClient = (clientId) =>
-  api
-    .get(`/clients/${clientId}/buyers`)
-    .then((r) => unwrapCollection(r.data, 'buyerResponseList'))
+// ── Buyers ──────────────────────────────────────────────────
+export async function fetchBuyersPaged({ page = 0, size = 20 } = {}) {
+  const { data } = await api.get('/buyers', { params: { page, size } })
+  return unwrapPaged(data, { page, size, hintKey: 'buyerResponseList' })
+}
+export const fetchBuyers = async () => {
+  const { data } = await api.get('/buyers', { params: { size: 1000 } })
+  return unwrapCollection(data, 'buyerResponseList')
+}
+export async function fetchBuyersByClientPaged(clientId, { page = 0, size = 20 } = {}) {
+  const { data } = await api.get(`/clients/${clientId}/buyers`, { params: { page, size } })
+  return unwrapPaged(data, { page, size, hintKey: 'buyerResponseList' })
+}
+export const fetchBuyersByClient = async (clientId) => {
+  const { data } = await api.get(`/clients/${clientId}/buyers`, { params: { size: 1000 } })
+  return unwrapCollection(data, 'buyerResponseList')
+}
 
-// Reference data
+// ── Reference data (pagination 없음) ─────────────────────────
 export const fetchCountries = () =>
   api.get('/countries').then((r) => unwrapCollection(r.data, 'countryList'))
 export const fetchPorts = () =>

--- a/src/stores/ciDocuments.js
+++ b/src/stores/ciDocuments.js
@@ -1,6 +1,6 @@
 import { useAuthStore } from './auth'
 import { ref } from 'vue'
-import { fetchCommercialInvoices } from '@/api/documents'
+import { fetchCommercialInvoicesPaged } from '@/api/documents'
 
 function formatDate(value) {
   return String(value ?? '').replace(/-/g, '/')
@@ -71,12 +71,14 @@ function mapCiResponse(row) {
 }
 
 const ciDocuments = ref([])
+const ciPageInfo = ref({ size: 1000, number: 0, totalElements: 0, totalPages: 0 })
 let loading = null
 
-export async function loadCiDocuments() {
+export async function loadCiDocuments({ page = 0, size = 1000 } = {}) {
   try {
-    const data = await fetchCommercialInvoices()
-    ciDocuments.value = (Array.isArray(data) ? data : []).map(mapCiResponse)
+    const { content, page: pageInfo } = await fetchCommercialInvoicesPaged({ page, size })
+    ciDocuments.value = (Array.isArray(content) ? content : []).map(mapCiResponse)
+    ciPageInfo.value = pageInfo
   } catch (e) {
     console.error('Failed to load CI documents:', e)
   }
@@ -87,4 +89,8 @@ export function useCiDocuments() {
     loading = loadCiDocuments()
   }
   return ciDocuments
+}
+
+export function useCiPageInfo() {
+  return ciPageInfo
 }

--- a/src/stores/piDocuments.js
+++ b/src/stores/piDocuments.js
@@ -1,6 +1,6 @@
 import { useAuthStore } from './auth'
 import { ref } from 'vue'
-import { fetchProformaInvoices } from '@/api/documents'
+import { fetchProformaInvoicesPaged } from '@/api/documents'
 
 function tryParseJson(value, fallback = null) {
   if (typeof value !== 'string') return value ?? fallback
@@ -69,12 +69,19 @@ function mapPiResponse(row) {
 }
 
 const piDocuments = ref([])
+const piPageInfo = ref({ size: 1000, number: 0, totalElements: 0, totalPages: 0 })
 let loading = null
 
-export async function loadPiDocuments() {
+/**
+ * PI 목록 로드. 현재 목록 화면은 클라이언트 사이드 키워드 검색/필터를 사용하므로
+ * 기본 size=1000 으로 한 번에 로드한다. 서버사이드 페이지네이션이 필요한 호출자는
+ * `{ page, size }` 를 명시적으로 넘기면 된다.
+ */
+export async function loadPiDocuments({ page = 0, size = 1000 } = {}) {
   try {
-    const data = await fetchProformaInvoices()
-    piDocuments.value = (Array.isArray(data) ? data : []).map(mapPiResponse)
+    const { content, page: pageInfo } = await fetchProformaInvoicesPaged({ page, size })
+    piDocuments.value = (Array.isArray(content) ? content : []).map(mapPiResponse)
+    piPageInfo.value = pageInfo
   } catch (e) {
     console.error('Failed to load PI documents:', e)
   }
@@ -85,4 +92,8 @@ export function usePiDocuments() {
     loading = loadPiDocuments()
   }
   return piDocuments
+}
+
+export function usePiPageInfo() {
+  return piPageInfo
 }

--- a/src/stores/plDocuments.js
+++ b/src/stores/plDocuments.js
@@ -1,6 +1,6 @@
 import { useAuthStore } from './auth'
 import { ref } from 'vue'
-import { fetchPackingLists } from '@/api/documents'
+import { fetchPackingListsPaged } from '@/api/documents'
 
 function formatDate(value) {
   return String(value ?? '').replace(/-/g, '/')
@@ -71,12 +71,14 @@ function mapPlResponse(row) {
 }
 
 const plDocuments = ref([])
+const plPageInfo = ref({ size: 1000, number: 0, totalElements: 0, totalPages: 0 })
 let loading = null
 
-export async function loadPlDocuments() {
+export async function loadPlDocuments({ page = 0, size = 1000 } = {}) {
   try {
-    const data = await fetchPackingLists()
-    plDocuments.value = (Array.isArray(data) ? data : []).map(mapPlResponse)
+    const { content, page: pageInfo } = await fetchPackingListsPaged({ page, size })
+    plDocuments.value = (Array.isArray(content) ? content : []).map(mapPlResponse)
+    plPageInfo.value = pageInfo
   } catch (e) {
     console.error('Failed to load PL documents:', e)
   }
@@ -87,4 +89,8 @@ export function usePlDocuments() {
     loading = loadPlDocuments()
   }
   return plDocuments
+}
+
+export function usePlPageInfo() {
+  return plPageInfo
 }

--- a/src/stores/poDocuments.js
+++ b/src/stores/poDocuments.js
@@ -1,6 +1,6 @@
 import { useAuthStore } from './auth'
 import { ref } from 'vue'
-import { fetchPurchaseOrders } from '@/api/documents'
+import { fetchPurchaseOrdersPaged } from '@/api/documents'
 
 function formatDate(value) {
   return String(value ?? '').replace(/-/g, '/')
@@ -85,12 +85,14 @@ function mapPoResponse(row) {
 }
 
 const poDocuments = ref([])
+const poPageInfo = ref({ size: 1000, number: 0, totalElements: 0, totalPages: 0 })
 let loading = null
 
-export async function loadPoDocuments() {
+export async function loadPoDocuments({ page = 0, size = 1000 } = {}) {
   try {
-    const data = await fetchPurchaseOrders()
-    poDocuments.value = (Array.isArray(data) ? data : []).map(mapPoResponse)
+    const { content, page: pageInfo } = await fetchPurchaseOrdersPaged({ page, size })
+    poDocuments.value = (Array.isArray(content) ? content : []).map(mapPoResponse)
+    poPageInfo.value = pageInfo
   } catch (e) {
     console.error('Failed to load PO documents:', e)
   }
@@ -101,4 +103,8 @@ export function usePoDocuments() {
     loading = loadPoDocuments()
   }
   return poDocuments
+}
+
+export function usePoPageInfo() {
+  return poPageInfo
 }

--- a/src/stores/productionOrderDocuments.js
+++ b/src/stores/productionOrderDocuments.js
@@ -1,6 +1,6 @@
 import { useAuthStore } from './auth'
 import { ref } from 'vue'
-import { fetchProductionOrders } from '@/api/documents'
+import { fetchProductionOrdersPaged } from '@/api/documents'
 
 function formatDate(value) {
   return String(value ?? '').replace(/-/g, '/')
@@ -50,15 +50,21 @@ function mapProductionOrderResponse(row) {
 }
 
 const productionOrderDocuments = ref([])
+const productionOrderPageInfo = ref({ size: 1000, number: 0, totalElements: 0, totalPages: 0 })
 let loading = null
 
-export async function loadProductionOrderDocuments() {
+export async function loadProductionOrderDocuments({ page = 0, size = 1000 } = {}) {
   try {
-    const data = await fetchProductionOrders()
-    productionOrderDocuments.value = (Array.isArray(data) ? data : []).map(mapProductionOrderResponse)
+    const { content, page: pageInfo } = await fetchProductionOrdersPaged({ page, size })
+    productionOrderDocuments.value = (Array.isArray(content) ? content : []).map(mapProductionOrderResponse)
+    productionOrderPageInfo.value = pageInfo
   } catch (e) {
     console.error('Failed to load production order documents:', e)
   }
+}
+
+export function useProductionOrderPageInfo() {
+  return productionOrderPageInfo
 }
 
 export function useProductionOrderDocuments() {

--- a/src/stores/salesCollectionDocuments.js
+++ b/src/stores/salesCollectionDocuments.js
@@ -1,6 +1,6 @@
 import { useAuthStore } from './auth'
 import { ref } from 'vue'
-import { fetchCollections } from '@/api/documents'
+import { fetchCollectionsPaged } from '@/api/documents'
 
 function normalizeDocumentCode(value = '') {
   return String(value ?? '').replace(/[^A-Za-z0-9]/g, '')
@@ -15,12 +15,14 @@ function normalizeCollectionRow(row) {
 }
 
 const salesCollectionDocuments = ref([])
+const salesCollectionPageInfo = ref({ size: 1000, number: 0, totalElements: 0, totalPages: 0 })
 let loading = null
 
-async function loadSalesCollectionDocuments() {
+async function loadSalesCollectionDocuments({ page = 0, size = 1000 } = {}) {
   try {
-    const data = await fetchCollections()
-    salesCollectionDocuments.value = (Array.isArray(data) ? data : []).map(normalizeCollectionRow)
+    const { content, page: pageInfo } = await fetchCollectionsPaged({ page, size })
+    salesCollectionDocuments.value = (Array.isArray(content) ? content : []).map(normalizeCollectionRow)
+    salesCollectionPageInfo.value = pageInfo
   } catch (e) {
     console.error('Failed to load sales collection documents:', e)
   }
@@ -31,6 +33,10 @@ export function useSalesCollectionDocuments() {
     loading = loadSalesCollectionDocuments()
   }
   return salesCollectionDocuments
+}
+
+export function useSalesCollectionPageInfo() {
+  return salesCollectionPageInfo
 }
 
 export function normalizeSalesCollectionRow(row) {

--- a/src/stores/shipmentOrderDocuments.js
+++ b/src/stores/shipmentOrderDocuments.js
@@ -1,6 +1,6 @@
 import { useAuthStore } from './auth'
 import { ref } from 'vue'
-import { fetchShipmentOrders } from '@/api/documents'
+import { fetchShipmentOrdersPaged } from '@/api/documents'
 
 function formatDate(value) {
   return String(value ?? '').replace(/-/g, '/')
@@ -48,12 +48,14 @@ function mapShipmentOrderResponse(row) {
 }
 
 const shipmentOrderDocuments = ref([])
+const shipmentOrderPageInfo = ref({ size: 1000, number: 0, totalElements: 0, totalPages: 0 })
 let loading = null
 
-export async function loadShipmentOrderDocuments() {
+export async function loadShipmentOrderDocuments({ page = 0, size = 1000 } = {}) {
   try {
-    const data = await fetchShipmentOrders()
-    shipmentOrderDocuments.value = (Array.isArray(data) ? data : []).map(mapShipmentOrderResponse)
+    const { content, page: pageInfo } = await fetchShipmentOrdersPaged({ page, size })
+    shipmentOrderDocuments.value = (Array.isArray(content) ? content : []).map(mapShipmentOrderResponse)
+    shipmentOrderPageInfo.value = pageInfo
   } catch (e) {
     console.error('Failed to load shipment order documents:', e)
   }
@@ -64,4 +66,8 @@ export function useShipmentOrderDocuments() {
     loading = loadShipmentOrderDocuments()
   }
   return shipmentOrderDocuments
+}
+
+export function useShipmentOrderPageInfo() {
+  return shipmentOrderPageInfo
 }

--- a/src/stores/shipmentStatusDocuments.js
+++ b/src/stores/shipmentStatusDocuments.js
@@ -1,6 +1,6 @@
 import { useAuthStore } from './auth'
 import { ref } from 'vue'
-import { fetchShipments } from '@/api/documents'
+import { fetchShipmentsPaged } from '@/api/documents'
 
 function formatDate(value) {
   return String(value ?? '').replace(/-/g, '/')
@@ -25,15 +25,21 @@ function mapShipmentResponse(row) {
 }
 
 const shipmentStatusDocuments = ref([])
+const shipmentStatusPageInfo = ref({ size: 1000, number: 0, totalElements: 0, totalPages: 0 })
 let loading = null
 
-export async function loadShipmentStatusDocuments() {
+export async function loadShipmentStatusDocuments({ page = 0, size = 1000 } = {}) {
   try {
-    const data = await fetchShipments()
-    shipmentStatusDocuments.value = (Array.isArray(data) ? data : []).map(mapShipmentResponse)
+    const { content, page: pageInfo } = await fetchShipmentsPaged({ page, size })
+    shipmentStatusDocuments.value = (Array.isArray(content) ? content : []).map(mapShipmentResponse)
+    shipmentStatusPageInfo.value = pageInfo
   } catch (e) {
     console.error('Failed to load shipment status documents:', e)
   }
+}
+
+export function useShipmentStatusPageInfo() {
+  return shipmentStatusPageInfo
 }
 
 export function useShipmentStatusDocuments() {

--- a/src/utils/pagedResponse.js
+++ b/src/utils/pagedResponse.js
@@ -1,0 +1,63 @@
+/**
+ * 백엔드 PagedModel(HATEOAS) 응답 파서.
+ *
+ * 지원 shape:
+ *   {
+ *     _embedded: { <xxxList>: [...] },
+ *     _links: {...},
+ *     page: { size, number, totalElements, totalPages }
+ *   }
+ *
+ * 추가로 레거시 `{ content: [...] }` (Spring PageImpl 직렬화) 와
+ * 순수 배열 응답도 허용한다 (server/backend 가 size=1000 default 로 과거 호환을 유지하는 동안
+ * 호출자 코드가 깨지지 않도록).
+ *
+ * `_embedded` 안의 키 이름은 spring-hateoas 가 Response record 클래스명에서 자동 생성한다
+ * (예: ProformaInvoiceResponse → proformaInvoiceResponseList). key hint 없이도 안전하게
+ * 동작하도록 첫 번째 배열 value 를 fallback 으로 선택한다.
+ */
+export function extractEmbedded(data, hintKey) {
+  if (Array.isArray(data)) return data
+  const embedded = data?._embedded
+  if (embedded) {
+    if (hintKey && Array.isArray(embedded[hintKey])) return embedded[hintKey]
+    const first = Object.values(embedded).find((v) => Array.isArray(v))
+    if (first) return first
+  }
+  if (Array.isArray(data?.content)) return data.content
+  return []
+}
+
+/**
+ * 페이지 메타데이터 추출. 백엔드가 page 메타데이터를 주지 않거나 배열만 주는 경우
+ * content 길이 기반으로 싱글 페이지 메타를 합성한다.
+ */
+export function extractPageInfo(data, { page = 0, size = 20 } = {}) {
+  if (data?.page && typeof data.page === 'object') {
+    return {
+      size: data.page.size ?? size,
+      number: data.page.number ?? page,
+      totalElements: data.page.totalElements ?? 0,
+      totalPages: data.page.totalPages ?? 0,
+    }
+  }
+  // 레거시 PageImpl 또는 배열 응답 → 메타 없음
+  const content = Array.isArray(data) ? data : (data?.content ?? [])
+  const total = Array.isArray(content) ? content.length : 0
+  return {
+    size: size || total || 0,
+    number: page,
+    totalElements: total,
+    totalPages: total > 0 && size > 0 ? Math.max(1, Math.ceil(total / size)) : (total > 0 ? 1 : 0),
+  }
+}
+
+/**
+ * `{ content, page }` 형태로 unwrap.
+ */
+export function unwrapPaged(data, { page = 0, size = 20, hintKey } = {}) {
+  return {
+    content: extractEmbedded(data, hintKey),
+    page: extractPageInfo(data, { page, size }),
+  }
+}


### PR DESCRIPTION
closes #344

## Summary

- 백엔드 documents / master 서비스의 신규 PagedModel(HATEOAS) 기반 pagination 엔드포인트를 프론트 API / store 레이어에서 제대로 활용하도록 전환
- 공용 `utils/pagedResponse.js` 파서 추가 (`extractEmbedded`, `extractPageInfo`, `unwrapPaged`) — `_embedded` 키는 **hint + fallback** (첫 번째 배열 value 선택) 으로 안전 처리
- store 가 `{ content, page }` shape 을 소비하고 `pageInfo` 상태를 노출하도록 전환. 기존 caller 호환 유지 (`load()` 인자 없음 = size=1000)
- view 레벨 페이지네이션 UI 는 **이번 PR 에서 제외** — 이유: 현재 목록 화면들이 `useDocumentFilter` / `filteredClients` 로 **클라이언트 사이드 키워드 검색 + 복수 필터** 를 수행하는데, 서버사이드 페이지네이션으로 전환하면 현재 페이지 안에서만 검색이 동작해 UX 가 후퇴함. 백엔드가 아직 server-side search 를 지원하지 않으므로 후속 과제로 분리

## Changes

**API layer**
- `src/api/documents.js` — `fetchXxxPaged({ page, size })` 신설 (9개: PI / PO / CI / PL / production-orders / shipment-orders / shipments / collections / approval-requests). 레거시 `fetchXxx()` 은 size=1000 wrapper 로 호환 유지
- `src/api/master.js` — `fetchClientsPaged`, `fetchClientsByTeamPaged`, `fetchClientsByDepartmentPaged`, `fetchBuyersPaged`, `fetchBuyersByClientPaged` 추가. `fetchBuyers`, `fetchBuyersByClient` 은 paginated 엔드포인트에 맞춰 size=1000 파라미터 전달하도록 정리

**Util (신규)**
- `src/utils/pagedResponse.js` — `extractEmbedded(data, hintKey)`, `extractPageInfo(data, {page,size})`, `unwrapPaged(data, {page,size,hintKey})`. key hint 기반 선택 + 없으면 첫 번째 배열 fallback, 레거시 `{content: []}` / 순수 배열 응답도 허용

**Stores**
- `piDocuments.js`, `poDocuments.js`, `ciDocuments.js`, `plDocuments.js`
- `productionOrderDocuments.js`, `shipmentOrderDocuments.js`, `shipmentStatusDocuments.js`, `salesCollectionDocuments.js`
- 각 store 에 `pageInfo` ref 추가, `loadXxx({page,size})` 시그니처 확장, `useXxxPageInfo()` getter 추가. 기존 `useXxxDocuments()` / 인자 없는 `loadXxxDocuments()` 호출자 호환 유지 (default size=1000)

**View**
- 변경 없음 — 의도적으로 보수적 접근 유지 (요약 참조)

## Test plan

- [x] `vite build` 통과 (dist 정상 생성, 484 modules transformed, 5.34s)
- [ ] dev 서버에서 PI / PO / CI / PL 목록 진입 시 기존과 동일하게 데이터 렌더링
- [ ] 거래처 목록 진입 시 기존과 동일하게 렌더링 / RBAC 필터 정상 동작
- [ ] 네트워크 탭에서 `?page=0&size=1000` 파라미터로 요청이 나가는지 확인
- [ ] 후속 PR: 백엔드 server-side search 지원 후 목록 view 페이지네이션 UI 적용 (이슈 별도 발행 예정)