### PR TITLE
fix: QA 8차 프론트 배치 수정 (PI 자동입력/통화 placeholder/404/요청자명/국가검색)

### DIFF
--- a/src/components/domain/document/PIFormModal.vue
+++ b/src/components/domain/document/PIFormModal.vue
@@ -10,6 +10,7 @@ import BaseTextarea from '@/components/common/BaseTextarea.vue'
 import SearchableCombobox from '@/components/common/SearchableCombobox.vue'
 import {
   fetchBuyersByClient,
+  fetchClient,
   fetchClients,
   fetchCountries,
   fetchCurrencies,
@@ -280,9 +281,10 @@ async function loadReferenceData() {
       id: String(client.clientId),
       name: client.clientName,
       country: client.countryName ?? countryMap.get(String(client.countryId)) ?? '-',
-      address: client.clientCity ?? '',
-      tel: client.tel ?? '',
-      email: client.email ?? '',
+      // ClientListResponse 에는 주소/연락처/이메일이 없어 기본값만 채움 — 실제 값은 거래처 선택 시 fetchClient 로 보강
+      address: client.clientAddress ?? '',
+      tel: client.clientTel ?? '',
+      email: client.clientEmail ?? '',
     }))
 
     currencyOptions.value = currenciesData.map((currency) => currency.currencyCode ?? currency.code).filter(Boolean)
@@ -721,15 +723,32 @@ watch(
       return
     }
     form.value.clientName = client.name
-    form.value.clientAddress = client.address ?? ''
-    form.value.clientTel = client.tel ?? ''
-    form.value.clientEmail = client.email ?? ''
+    // 검색 모달이 넘겨주는 row 는 ClientListResponse 기반이라 주소/연락처/이메일이 비어 있다.
+    // 1차로 가능한 값을 채우고, 상세(/clients/{id})를 호출해 ClientResponse 로 보강한다.
+    form.value.clientAddress = client.address ?? client.clientAddress ?? ''
+    form.value.clientTel = client.tel ?? client.clientTel ?? ''
+    form.value.clientEmail = client.email ?? client.clientEmail ?? ''
     // 거래처 변경 시 이전 바이어 선택값 초기화 — 새 거래처 바이어 로드 후 단일 옵션이면 auto-pick
     form.value.buyerName = ''
     form.value.currency = client.currency ?? form.value.currency
     clearError('clientName')
     clearError('buyerName')
     clearError('currency')
+
+    if (client.id) {
+      try {
+        const detail = await fetchClient(client.id)
+        if (detail) {
+          // 상세 응답은 clientAddress/clientTel/clientEmail 키를 사용
+          form.value.clientAddress = detail.clientAddress ?? form.value.clientAddress
+          form.value.clientTel = detail.clientTel ?? form.value.clientTel
+          form.value.clientEmail = detail.clientEmail ?? form.value.clientEmail
+        }
+      } catch {
+        // 상세 조회 실패 시 1차 값 유지 (대부분 빈 문자열)
+      }
+    }
+
     await loadBuyerOptions()
     if (buyerRows.value.length === 1) {
       form.value.buyerName = buyerRows.value[0]

--- a/src/components/domain/master/ClientFormModal.vue
+++ b/src/components/domain/master/ClientFormModal.vue
@@ -405,7 +405,7 @@ function handleSave() {
             <p v-if="errors.paymentTermsId" class="mt-1 text-xs text-red-500">{{ errors.paymentTermsId }}</p>
           </FormField>
           <FormField label="통화" required>
-            <BaseSelect v-model="form.currencyId" :options="currencyOptions" :disabled="!form.countryId" :placeholder="form.countryId ? '통화를 선택하세요' : '국가를 먼저 선택하세요'" />
+            <BaseSelect v-model="form.currencyId" :options="currencyOptions" placeholder="통화를 선택하세요" />
             <p v-if="errors.currencyId" class="mt-1 text-xs text-red-500">{{ errors.currencyId }}</p>
           </FormField>
           <FormField label="상태">

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -330,7 +330,19 @@ const routes = [
   },
   {
     path: '/:pathMatch(.*)*',
-    redirect: '/',
+    component: AppLayout,
+    children: [
+      {
+        path: '',
+        name: 'not-found',
+        component: () => import('@/views/NotFound.vue'),
+        meta: {
+          title: '404 Not Found',
+          serviceName: '페이지를 찾을 수 없습니다',
+          description: '존재하지 않는 경로입니다.',
+        },
+      },
+    ],
   },
 ]
 

--- a/src/views/NotFound.vue
+++ b/src/views/NotFound.vue
@@ -1,0 +1,43 @@
+<script setup>
+import { useRouter } from 'vue-router'
+import BaseButton from '@/components/common/BaseButton.vue'
+
+const router = useRouter()
+
+function goHome() {
+  router.replace('/')
+}
+
+function goBack() {
+  if (window.history.length > 1) {
+    router.back()
+  } else {
+    router.replace('/')
+  }
+}
+</script>
+
+<template>
+  <div class="flex min-h-[60vh] flex-col items-center justify-center px-6 py-16 text-center">
+    <div class="mb-6 flex h-20 w-20 items-center justify-center rounded-full bg-brand-50 text-brand-500">
+      <i class="fas fa-compass text-3xl" aria-hidden="true"></i>
+    </div>
+    <p class="mb-2 text-sm font-semibold tracking-wider text-brand-500">404 NOT FOUND</p>
+    <h1 class="mb-3 text-2xl font-bold text-slate-800">요청하신 페이지를 찾을 수 없습니다.</h1>
+    <p class="mb-8 max-w-md text-sm leading-relaxed text-slate-500">
+      입력하신 주소가 정확한지 다시 한 번 확인해주세요.
+      <br />
+      페이지가 이동되었거나 일시적으로 접근할 수 없는 상태일 수 있습니다.
+    </p>
+    <div class="flex flex-wrap items-center justify-center gap-3">
+      <BaseButton variant="secondary" @click="goBack">
+        <i class="fas fa-arrow-left mr-2" aria-hidden="true"></i>
+        이전 페이지
+      </BaseButton>
+      <BaseButton variant="primary" @click="goHome">
+        <i class="fas fa-home mr-2" aria-hidden="true"></i>
+        홈으로 이동
+      </BaseButton>
+    </div>
+  </div>
+</template>

--- a/src/views/documents/PIDetailPage.vue
+++ b/src/views/documents/PIDetailPage.vue
@@ -173,7 +173,8 @@ function buildLinkedDocuments(documentId) {
 }
 
 function getCurrentRequesterName() {
-  return authStore.currentUser?.name || '김영업'
+  // 백엔드 user 객체는 userName 필드를 사용한다.
+  return authStore.currentUser?.userName || authStore.currentUser?.name || '미지정'
 }
 
 function getRequestedAt() {
@@ -187,7 +188,7 @@ function getRequestedAt() {
 }
 
 function getDefaultDeleteApprover(row) {
-  return row?.approver || '김영업'
+  return row?.approver || ''
 }
 
 function createComparableItem(item) {

--- a/src/views/documents/PIPage.vue
+++ b/src/views/documents/PIPage.vue
@@ -465,11 +465,13 @@ function buildChangeRows(originalSnapshot, revisedSnapshot) {
 }
 
 function getCurrentRequesterName() {
-  return authStore.currentUser?.name || '김영업'
+  // 백엔드 user 객체는 userName 필드를 사용한다 — 과거 'name' 만 보던 구현 때문에
+  // 항상 fallback ('김영업') 으로 떨어지던 버그를 수정.
+  return authStore.currentUser?.userName || authStore.currentUser?.name || '미지정'
 }
 
 function getDefaultDeleteApprover(row) {
-  return row?.approver || '김영업'
+  return row?.approver || ''
 }
 
 function getRequestedAt() {

--- a/src/views/documents/PODetailPage.vue
+++ b/src/views/documents/PODetailPage.vue
@@ -148,7 +148,8 @@ function buildLinkedDocuments(row) {
 }
 
 function getCurrentRequesterName() {
-  return authStore.currentUser?.name || '김영업'
+  // 백엔드 user 객체는 userName 필드를 사용한다.
+  return authStore.currentUser?.userName || authStore.currentUser?.name || '미지정'
 }
 
 function getRequestedAt() {
@@ -162,7 +163,7 @@ function getRequestedAt() {
 }
 
 function getDefaultDeleteApprover(row) {
-  return row?.approver || '김영업'
+  return row?.approver || ''
 }
 
 function createComparableItem(item) {

--- a/src/views/documents/POPage.vue
+++ b/src/views/documents/POPage.vue
@@ -386,11 +386,12 @@ function buildRowPayload(formValue) {
 }
 
 function getCurrentRequesterName() {
-  return authStore.currentUser?.name || '김영업'
+  // 백엔드 user 객체는 userName 필드를 사용한다.
+  return authStore.currentUser?.userName || authStore.currentUser?.name || '미지정'
 }
 
 function getDefaultDeleteApprover(row) {
-  return row?.approver || '김영업'
+  return row?.approver || ''
 }
 
 function getRequestedAt() {

--- a/src/views/master/ClientListPage.vue
+++ b/src/views/master/ClientListPage.vue
@@ -34,6 +34,12 @@ const { success, error } = useToast()
 
 const { countries, ports, currencies, paymentTerms, loadReferenceData, getCountryName, getPortName, getPaymentTermsLabel, getCurrencyLabel } = useMasterLookup()
 
+// 국가 ID → 한글명 매핑 (영문/한글 양쪽 키워드 검색을 위해 사용)
+function getCountryNameKr(countryId) {
+  const found = countries.value.find((c) => String(c.countryId) === String(countryId))
+  return found?.countryNameKr ?? ''
+}
+
 const departments = ref([])
 const teams = ref([])
 const clients = ref([])
@@ -86,6 +92,7 @@ const enrichedClients = computed(() =>
   clients.value.map((c) => ({
     ...c,
     countryName: c.countryName ?? getCountryName(c.countryId),
+    countryNameKr: c.countryNameKr ?? getCountryNameKr(c.countryId),
     portName: c.portName ?? getPortName(c.portId),
     paymentTermsCode: getPaymentTermsLabel(c.paymentTermsId),
     currencyCode: getCurrencyLabel(c.currencyId),
@@ -130,7 +137,10 @@ const filteredClients = computed(() => {
       (c) =>
         c.clientName.toLowerCase().includes(kw) ||
         (c.clientNameKr && c.clientNameKr.includes(kw)) ||
-        c.clientCode.toLowerCase().includes(kw),
+        c.clientCode.toLowerCase().includes(kw) ||
+        // 국가명 영문/한글 매칭 — "Japan", "일본" 모두 검색되도록
+        (c.countryName && c.countryName.toLowerCase().includes(kw)) ||
+        (c.countryNameKr && c.countryNameKr.includes(kw)),
     )
   }
 


### PR DESCRIPTION
## 작업 내용

8차 QA 에서 발견된 프론트엔드 단독 수정 가능 5건을 일괄 처리.

### 1. PI 등록 모달 — 거래처 자동입력 누락
- 거래처 검색 모달에서 행을 선택해도 주소/연락처/이메일이 비어 있던 문제.
- 원인: 검색 모달이 사용하는 `fetchClients()` 는 `ClientListResponse` 라
  주소/연락처/이메일 필드 자체가 없음. PIFormModal 의 watcher 는
  `client.tel`, `client.email` 처럼 잘못된 키를 읽고 있었음.
- 조치: 거래처 선택 시 `fetchClient(id)` 로 ClientResponse 를 추가 조회해
  `clientAddress / clientTel / clientEmail` 을 보강. 1차 값이 빈 문자열이라도
  상세 조회 후 채워지도록 처리.

### 2. 거래처 등록/수정 통화 드롭다운 placeholder
- 통화 placeholder 가 \"국가를 먼저 선택하세요\" 로 표시돼 사용자가 의존
  관계가 있다고 오해. 실제로 통화 옵션은 국가와 무관하게 전체 통화.
- 조치: `disabled` 의존 제거, placeholder 를 \"통화를 선택하세요\" 로 교체.

### 3. 404 페이지 부재
- 기존 catch-all 라우트는 `/` 로 redirect 만 해서 잘못된 URL 인지 불가.
- 조치: `src/views/NotFound.vue` 신규 작성 (홈/이전 페이지 이동 버튼 제공),
  catch-all 을 component 라우트로 변경. AppLayout 안에 들어가 헤더/사이드바
  컨텍스트 유지.

### 4. PI/PO 결재 요청자명 \"김영업\" 하드코딩
- ADMIN 등으로 로그인해도 결재 요청 시 요청자명이 항상 \"김영업\" 으로 표시.
- 원인: `authStore.currentUser?.name` 을 사용하는데 백엔드 user 객체는
  `userName` 필드만 내려보내서 항상 fallback 으로 떨어짐.
- 조치: PIPage / PIDetailPage / POPage / PODetailPage 4 개 파일의
  `getCurrentRequesterName()` 를 `userName ?? name ?? '미지정'` 로 변경.
  `getDefaultDeleteApprover()` 의 \"김영업\" fallback 도 빈 문자열로 정리
  (드롭다운에서 명시적으로 다시 선택하도록).

### 5. 거래처 목록 영문 국가명 검색 불가
- 검색창에 \"Japan\" 입력 시 0 건, \"일본\" 만 검색됨.
- 원인: 키워드 필터가 거래처명/한글 거래처명/코드 만 매칭. 국가명 미포함.
  국가 ID → 한글명 매핑도 enrichedClients 에 없었음.
- 조치: `enrichedClients` 에 `countryNameKr` 추가, 키워드 필터에
  `countryName` (영문) / `countryNameKr` (한글) 매칭 추가.

## 관련 이슈

- closes #346

## 검증

- `npm run build` 성공 (vite 6.4.1, 5.5s, 19 chunks).
- 로컬 build 산출물 정상 생성 — `NotFound-*.js` 청크 확인.

## 체크리스트

- [x] 정상 동작 확인 (build)
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 리뷰어에게

- PIFormModal 의 거래처 선택 watcher 에서 추가 API 호출(`fetchClient`)이
  생겼습니다. 동일 거래처 반복 선택 시에도 매번 호출되므로 필요시 캐시
  레이어를 검토 부탁드립니다.
- 결재 요청자명 fallback 을 \"미지정\" 으로 두었는데, 정책상 다른 문구
  (예: 현재 로그인 사용자의 email prefix 등) 가 적절하다면 알려주세요.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>