### PR TITLE
fix: 대시보드 store 강제 재조회 (QA 8차 #4 #6)

### DIFF
--- a/src/views/DashboardPage.vue
+++ b/src/views/DashboardPage.vue
@@ -6,12 +6,12 @@ import BaseCard from '@/components/common/BaseCard.vue'
 import ConfirmModal from '@/components/common/ConfirmModal.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
 import { useAuthStore } from '@/stores/auth'
-import { useCiDocuments } from '@/stores/ciDocuments'
-import { usePiDocuments } from '@/stores/piDocuments'
-import { usePlDocuments } from '@/stores/plDocuments'
-import { usePoDocuments } from '@/stores/poDocuments'
-import { useProductionOrderDocuments } from '@/stores/productionOrderDocuments'
-import { useShipmentStatusDocuments } from '@/stores/shipmentStatusDocuments'
+import { useCiDocuments, loadCiDocuments } from '@/stores/ciDocuments'
+import { usePiDocuments, loadPiDocuments } from '@/stores/piDocuments'
+import { usePlDocuments, loadPlDocuments } from '@/stores/plDocuments'
+import { usePoDocuments, loadPoDocuments } from '@/stores/poDocuments'
+import { useProductionOrderDocuments, loadProductionOrderDocuments } from '@/stores/productionOrderDocuments'
+import { useShipmentStatusDocuments, loadShipmentStatusDocuments } from '@/stores/shipmentStatusDocuments'
 import { fetchActivities } from '@/api/activity'
 import { fetchClients } from '@/api/master'
 import { fetchPackages, deletePackage as deletePackageApi } from '@/api/package'
@@ -46,14 +46,22 @@ onMounted(async () => {
   const role = (authStore.currentUser?.role ?? '').toLowerCase()
   const canFetchPackages = role === 'admin' || role === 'sales'
 
-  const [clientsResult, activitiesResult, packagesResult] = await Promise.allSettled([
-    fetchClients(),
-    fetchActivities(),
-    canFetchPackages ? fetchPackages() : Promise.resolve(null),
+  // 대시보드는 진입할 때마다 문서 store 를 강제 재조회한다. 모듈 싱글톤 store 는
+  // 최초 1회만 자동 로드되므로, PI 등록/결재 후 대시보드 복귀 시 stale snapshot 이
+  // 그대로 노출되어 카운트·결재현황이 반영되지 않았음 (QA 8차 #4 / #6).
+  await Promise.allSettled([
+    fetchClients().then((v) => { clientsData.value = v ?? [] }),
+    fetchActivities().then((v) => { activitiesData.value = v ?? [] }),
+    canFetchPackages
+      ? fetchPackages().then((v) => { if (v) packagesData.value = v })
+      : Promise.resolve(null),
+    loadPiDocuments(),
+    loadPoDocuments(),
+    loadCiDocuments(),
+    loadPlDocuments(),
+    loadProductionOrderDocuments(),
+    loadShipmentStatusDocuments(),
   ])
-  if (clientsResult.status === 'fulfilled') clientsData.value = clientsResult.value ?? []
-  if (activitiesResult.status === 'fulfilled') activitiesData.value = activitiesResult.value ?? []
-  if (packagesResult.status === 'fulfilled' && packagesResult.value) packagesData.value = packagesResult.value
 })
 
 const currentUser = computed(() => authStore.currentUser ?? null)


### PR DESCRIPTION
## Summary
- 대시보드 진입 시마다 PI/PO/CI/PL/생산/출하 store 를 `load*Documents()` 로 명시 재조회.
- 모듈 싱글톤 store 가 `loading` 플래그로 최초 1회만 자동 로드되어, PI 등록·결재 요청 후 대시보드 복귀 시 카운트/결재현황이 stale 로 남던 문제 해결.
- 키프-얼라이브 없어 일반 네비게이션 복귀도 onMounted 재실행 → 자동 반영.

## Changes
- `src/views/DashboardPage.vue`
  - 관련 store 들에서 load 함수 import 추가
  - onMounted 의 `Promise.allSettled` 리스트에 load 함수들 포함

## Test plan
- [ ] 로컬 `npm run build` 통과 (확인 완료)
- [ ] QA: 영업팀장 로그인 → PI 등록 → 대시보드 복귀 → PI 카운트 +1 확인 (#6)
- [ ] QA: 영업팀원 PI 결재 요청 → ADMIN/팀장 대시보드 복귀 → 결재현황 항목 즉시 노출 (#4)
- [ ] QA: 다른 역할(생산/출하) 로그인해도 기존 카드/기능 이상 없음 확인

closes #348

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>