### PR TITLE
feat: PI/PO 삭제 백엔드 API 연동

### DIFF
--- a/src/api/documents.js
+++ b/src/api/documents.js
@@ -27,6 +27,10 @@ export const createProformaInvoice = (payload) =>
   api.post('/proforma-invoices', payload).then((r) => r.data)
 export const requestPiRegistration = (payload) =>
   api.post('/proforma-invoices/request-registration', payload).then((r) => r.data)
+export const validatePiDeletable = (piId) =>
+  api.post(`/proforma-invoices/${piId}/validate-deletable`).then((r) => r.data)
+export const requestPiDeletion = (payload) =>
+  api.post('/proforma-invoices/request-deletion', payload).then((r) => r.data)
 
 // ── Purchase Orders ──────────────────────────────────────────
 export async function fetchPurchaseOrdersPaged({ page = 0, size = 20 } = {}) {
@@ -39,6 +43,10 @@ export const fetchPurchaseOrder = (poId) =>
   api.get(`/purchase-orders/${poId}`).then((r) => r.data)
 export const createPurchaseOrder = (payload) =>
   api.post('/purchase-orders', payload).then((r) => r.data)
+export const validatePoDeletable = (poId) =>
+  api.post(`/purchase-orders/${poId}/validate-deletable`).then((r) => r.data)
+export const requestPoDeletion = (payload) =>
+  api.post('/purchase-orders/request-deletion', payload).then((r) => r.data)
 
 // ── Commercial Invoices ──────────────────────────────────────
 export async function fetchCommercialInvoicesPaged({ page = 0, size = 20 } = {}) {

--- a/src/views/documents/PIDetailPage.vue
+++ b/src/views/documents/PIDetailPage.vue
@@ -12,10 +12,11 @@ import { formatRevisionEntry } from '@/utils/revisionFormat'
 import DocumentPreviewModal from '@/components/domain/document/DocumentPreviewModal.vue'
 import PIDocumentTemplate from '@/components/domain/document/PIDocumentTemplate.vue'
 import PIFormModal from '@/components/domain/document/PIFormModal.vue'
+import { validatePiDeletable, requestPiDeletion } from '@/api/documents'
 import { fetchBuyers, fetchClients, fetchCountries, fetchCurrencies } from '@/api/master'
 import { useToast } from '@/composables/useToast'
 import { useAuthStore } from '@/stores/auth'
-import { usePiDocuments } from '@/stores/piDocuments'
+import { loadPiDocuments, usePiDocuments } from '@/stores/piDocuments'
 import { usePoDocuments } from '@/stores/poDocuments'
 import { useShipmentOrderDocuments } from '@/stores/shipmentOrderDocuments'
 import { useShipmentStatusDocuments } from '@/stores/shipmentStatusDocuments'
@@ -42,7 +43,7 @@ import { clientSearchColumns } from '@/utils/searchModalColumns'
 const route = useRoute()
 const router = useRouter()
 const authStore = useAuthStore()
-const { info, success, warning } = useToast()
+const { info, success, warning, error } = useToast()
 
 const previewOpen = ref(false)
 const formOpen = ref(false)
@@ -57,6 +58,8 @@ const piDocuments = usePiDocuments()
 const poDocuments = usePoDocuments()
 const shipmentOrderDocuments = useShipmentOrderDocuments()
 const shipmentStatusDocuments = useShipmentStatusDocuments()
+
+const isTeamLeader = computed(() => Number(authStore.currentUser?.positionId) === 1)
 
 const approvalItemColumns = [
   { key: 'name', label: '품목명', align: 'left' },
@@ -524,9 +527,28 @@ function handleEdit() {
   formOpen.value = true
 }
 
-function handleDelete() {
+async function handleDelete() {
   if (shipmentLockInfo.value.locked) {
     warning(shipmentLockMessage.value)
+    return
+  }
+
+  try {
+    await validatePiDeletable(sourceRow.value?.id)
+  } catch (e) {
+    error(e.response?.data?.message || e.response?.data || '후속 문서가 존재하여 삭제할 수 없습니다.')
+    return
+  }
+
+  if (isTeamLeader.value) {
+    try {
+      const userId = authStore.currentUser?.userId
+      await requestPiDeletion({ piId: sourceRow.value.id, userId })
+      await loadPiDocuments()
+      success(`${sourceRow.value.id} PI가 삭제되었습니다.`)
+    } catch (e) {
+      error(e.response?.data?.message || '삭제 처리 중 오류가 발생했습니다.')
+    }
     return
   }
 
@@ -678,7 +700,7 @@ function cancelEditApprovalRequest() {
   editApprovalRequestOpen.value = false
 }
 
-function confirmDeleteApprovalRequest() {
+async function confirmDeleteApprovalRequest() {
   if (!sourceRow.value) return
   if (shipmentLockInfo.value.locked) {
     warning(shipmentLockMessage.value)
@@ -686,36 +708,16 @@ function confirmDeleteApprovalRequest() {
     return
   }
 
-  const requesterName = getCurrentRequesterName()
-  const requestedAt = getRequestedAt()
-  const approvalReview = createApprovalReviewSnapshot({
-    title: 'PI 삭제 결재 검토',
-    message: '선택한 PI 삭제 요청 건입니다. 문서와 품목 정보를 확인한 뒤 승인 또는 반려를 결정합니다.',
-    requestRows: deleteApprovalRequestRows.value,
-    documentRows: deleteApprovalDocumentRows.value,
-    itemRows: deleteApprovalItemRows.value,
-    itemSummaryRows: deleteApprovalItemSummaryRows.value,
-    documentSectionTitle: '삭제 대상 PI 정보',
-    itemSectionTitle: '삭제 대상 PI 품목 정보',
-    helperText: '삭제 요청은 승인 전까지 실제 삭제되지 않으며, 승인 시 문서 상태가 취소로 전환됩니다.',
-  })
-
-  piDocuments.value = piDocuments.value.map((row) => (
-    row.id === sourceRow.value.id
-      ? {
-        ...row,
-        approvalReview,
-        ...createDeleteApprovalMeta({
-          approver: getDefaultDeleteApprover(sourceRow.value),
-          requesterName,
-          requestedAt,
-        }),
-      }
-      : row
-  ))
+  try {
+    const userId = authStore.currentUser?.userId
+    await requestPiDeletion({ piId: sourceRow.value.id, userId })
+    await loadPiDocuments()
+    success(`${sourceRow.value.id} 삭제 결재 요청이 전송되었습니다.`)
+  } catch (e) {
+    error(e.response?.data?.message || '삭제 결재 요청 중 오류가 발생했습니다.')
+  }
 
   deleteApprovalRequestOpen.value = false
-  success(`${sourceRow.value.id} 삭제 결재 요청이 전송되었습니다.`)
 }
 
 function cancelDeleteApprovalRequest() {

--- a/src/views/documents/PIPage.vue
+++ b/src/views/documents/PIPage.vue
@@ -17,13 +17,14 @@ import SearchableCombobox from '@/components/common/SearchableCombobox.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
 import TableActions from '@/components/common/TableActions.vue'
 import PIFormModal from '@/components/domain/document/PIFormModal.vue'
+import { validatePiDeletable, requestPiDeletion } from '@/api/documents'
 import { fetchBuyers, fetchClients, fetchCountries, fetchCurrencies } from '@/api/master'
 import { useDocumentFilter } from '@/composables/useDocumentFilter'
 import { usePagination } from '@/composables/usePagination'
 import { useSearchModalLookups } from '@/composables/useSearchModalLookups'
 import { useAuthStore } from '@/stores/auth'
 import { loadExchangeRates, clearExchangeRates } from '@/stores/exchangeRates'
-import { usePiDocuments } from '@/stores/piDocuments'
+import { loadPiDocuments, usePiDocuments } from '@/stores/piDocuments'
 import { usePoDocuments } from '@/stores/poDocuments'
 import { useShipmentOrderDocuments } from '@/stores/shipmentOrderDocuments'
 import { useShipmentStatusDocuments } from '@/stores/shipmentStatusDocuments'
@@ -52,7 +53,7 @@ import { buildSelectOptionsFromRows } from '@/utils/selectOptions'
 
 const router = useRouter()
 const authStore = useAuthStore()
-const { success, warning } = useToast()
+const { success, warning, error } = useToast()
 
 const isAdvancedOpen = ref(false)
 const formOpen = ref(false)
@@ -847,16 +848,29 @@ function handleSave(formValue) {
   editApprovalRequestOpen.value = true
 }
 
-function openDeleteApprovalRequest(row) {
+async function openDeleteApprovalRequest(row) {
   const shipmentLockInfo = shipmentLockInfoByPiId.value.get(row.id)
   if (shipmentLockInfo?.locked) {
     warning(formatPiShipmentLockMessage(shipmentLockInfo))
     return
   }
 
+  try {
+    await validatePiDeletable(row.id)
+  } catch (e) {
+    error(e.response?.data?.message || e.response?.data || '후속 문서가 존재하여 삭제할 수 없습니다.')
+    return
+  }
+
   if (isTeamLeader.value) {
-    rowsData.value = rowsData.value.filter((r) => r.id !== row.id)
-    success(`${row.id} PI가 삭제되었습니다.`)
+    try {
+      const userId = authStore.currentUser?.userId
+      await requestPiDeletion({ piId: row.id, userId })
+      await loadPiDocuments()
+      success(`${row.id} PI가 삭제되었습니다.`)
+    } catch (e) {
+      error(e.response?.data?.message || '삭제 처리 중 오류가 발생했습니다.')
+    }
     return
   }
 
@@ -864,7 +878,7 @@ function openDeleteApprovalRequest(row) {
   deleteApprovalRequestOpen.value = true
 }
 
-function confirmDeleteApprovalRequest() {
+async function confirmDeleteApprovalRequest() {
   if (!selectedRow.value) return
 
   const shipmentLockInfo = shipmentLockInfoByPiId.value.get(selectedRow.value.id)
@@ -875,35 +889,15 @@ function confirmDeleteApprovalRequest() {
     return
   }
 
-  const requesterName = getCurrentRequesterName()
-  const requestedAt = getRequestedAt()
-  const approvalReview = createApprovalReviewSnapshot({
-    title: 'PI 삭제 결재 검토',
-    message: '선택한 PI 삭제 요청 건입니다. 문서와 품목 정보를 확인한 뒤 승인 또는 반려를 결정합니다.',
-    requestRows: deleteApprovalRequestRows.value,
-    documentRows: deleteApprovalDocumentRows.value,
-    itemRows: deleteApprovalItemRows.value,
-    itemSummaryRows: deleteApprovalItemSummaryRows.value,
-    documentSectionTitle: '삭제 대상 PI 정보',
-    itemSectionTitle: '삭제 대상 PI 품목 정보',
-    helperText: '삭제 요청은 승인 전까지 실제 삭제되지 않으며, 승인 시 문서 상태가 취소로 전환됩니다.',
-  })
+  try {
+    const userId = authStore.currentUser?.userId
+    await requestPiDeletion({ piId: selectedRow.value.id, userId })
+    await loadPiDocuments()
+    success(`${selectedRow.value?.id} 삭제 결재 요청이 전송되었습니다.`)
+  } catch (e) {
+    error(e.response?.data?.message || '삭제 결재 요청 중 오류가 발생했습니다.')
+  }
 
-  rowsData.value = rowsData.value.map((row) => (
-    row.id === selectedRow.value?.id
-      ? {
-        ...row,
-        approvalReview,
-        ...createDeleteApprovalMeta({
-          approver: getDefaultDeleteApprover(selectedRow.value),
-          requesterName,
-          requestedAt,
-        }),
-      }
-      : row
-  ))
-
-  success(`${selectedRow.value?.id} 삭제 결재 요청이 전송되었습니다.`)
   deleteApprovalRequestOpen.value = false
   selectedRow.value = null
 }

--- a/src/views/documents/PODetailPage.vue
+++ b/src/views/documents/PODetailPage.vue
@@ -12,13 +12,14 @@ import { formatRevisionEntry } from '@/utils/revisionFormat'
 import DocumentPreviewModal from '@/components/domain/document/DocumentPreviewModal.vue'
 import PODocumentTemplate from '@/components/domain/document/PODocumentTemplate.vue'
 import POFormModal from '@/components/domain/document/POFormModal.vue'
+import { validatePoDeletable, requestPoDeletion } from '@/api/documents'
 import { useSearchModalLookups } from '@/composables/useSearchModalLookups'
 import { useToast } from '@/composables/useToast'
 import { useAuthStore } from '@/stores/auth'
 import { useCiDocuments } from '@/stores/ciDocuments'
 import { usePiDocuments } from '@/stores/piDocuments'
 import { usePlDocuments } from '@/stores/plDocuments'
-import { usePoDocuments } from '@/stores/poDocuments'
+import { loadPoDocuments, usePoDocuments } from '@/stores/poDocuments'
 import { useProductionOrderDocuments } from '@/stores/productionOrderDocuments'
 import { useShipmentOrderDocuments } from '@/stores/shipmentOrderDocuments'
 import { useShipmentStatusDocuments } from '@/stores/shipmentStatusDocuments'
@@ -47,7 +48,7 @@ import { clientSearchColumns } from '@/utils/searchModalColumns'
 const route = useRoute()
 const router = useRouter()
 const authStore = useAuthStore()
-const { info, success, warning } = useToast()
+const { info, success, warning, error } = useToast()
 
 const previewOpen = ref(false)
 const formOpen = ref(false)
@@ -71,6 +72,8 @@ const shipmentOrderDocuments = useShipmentOrderDocuments()
 const shipmentStatusDocuments = useShipmentStatusDocuments()
 
 const { createClientRows } = useSearchModalLookups()
+
+const isTeamLeader = computed(() => Number(authStore.currentUser?.positionId) === 1)
 
 const approvalItemColumns = [
   { key: 'name', label: '품목명', align: 'left' },
@@ -550,9 +553,28 @@ function handleEdit() {
   formOpen.value = true
 }
 
-function handleDelete() {
+async function handleDelete() {
   if (shipmentLockInfo.value.locked) {
     warning(shipmentLockMessage.value)
+    return
+  }
+
+  try {
+    await validatePoDeletable(sourceRow.value?.id)
+  } catch (e) {
+    error(e.response?.data?.message || e.response?.data || '후속 문서가 존재하여 삭제할 수 없습니다.')
+    return
+  }
+
+  if (isTeamLeader.value) {
+    try {
+      const userId = authStore.currentUser?.userId
+      await requestPoDeletion({ poId: sourceRow.value.id, userId })
+      await loadPoDocuments()
+      success(`${sourceRow.value.id} PO가 삭제되었습니다.`)
+    } catch (e) {
+      error(e.response?.data?.message || '삭제 처리 중 오류가 발생했습니다.')
+    }
     return
   }
 
@@ -852,7 +874,7 @@ function cancelEditApprovalRequest() {
   editApprovalRequestOpen.value = false
 }
 
-function confirmDeleteApprovalRequest() {
+async function confirmDeleteApprovalRequest() {
   if (!sourceRow.value) return
   if (shipmentLockInfo.value.locked) {
     warning(shipmentLockMessage.value)
@@ -860,38 +882,16 @@ function confirmDeleteApprovalRequest() {
     return
   }
 
-  const requesterName = getCurrentRequesterName()
-  const requestedAt = getRequestedAt()
-  const approvalReview = createApprovalReviewSnapshot({
-    title: 'PO 삭제 결재 검토',
-    message: '선택한 PO 삭제 요청 건입니다. 문서와 품목 정보를 확인한 뒤 승인 또는 반려를 결정합니다.',
-    requestRows: deleteApprovalRequestRows.value,
-    documentRows: deleteApprovalDocumentRows.value,
-    itemRows: deleteApprovalItemRows.value,
-    itemSummaryRows: deleteApprovalItemSummaryRows.value,
-    referenceRows: deleteApprovalReferenceRows.value,
-    documentSectionTitle: '삭제 대상 PO 정보',
-    itemSectionTitle: '삭제 대상 PO 품목 정보',
-    referenceSectionTitle: '연결 PI 정보',
-    helperText: '삭제 요청은 승인 전까지 실제 삭제되지 않으며, 승인 시 문서 상태가 취소로 전환됩니다.',
-  })
-
-  poDocuments.value = poDocuments.value.map((row) => (
-    row.id === sourceRow.value.id
-      ? {
-        ...row,
-        approvalReview,
-        ...createDeleteApprovalMeta({
-          approver: getDefaultDeleteApprover(sourceRow.value),
-          requesterName,
-          requestedAt,
-        }),
-      }
-      : row
-  ))
+  try {
+    const userId = authStore.currentUser?.userId
+    await requestPoDeletion({ poId: sourceRow.value.id, userId })
+    await loadPoDocuments()
+    success(`${sourceRow.value.id} 삭제 결재 요청이 전송되었습니다.`)
+  } catch (e) {
+    error(e.response?.data?.message || '삭제 결재 요청 중 오류가 발생했습니다.')
+  }
 
   deleteApprovalRequestOpen.value = false
-  success(`${sourceRow.value.id} 삭제 결재 요청이 전송되었습니다.`)
 }
 
 function cancelDeleteApprovalRequest() {

--- a/src/views/documents/POPage.vue
+++ b/src/views/documents/POPage.vue
@@ -17,6 +17,7 @@ import SearchableCombobox from '@/components/common/SearchableCombobox.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
 import TableActions from '@/components/common/TableActions.vue'
 import POFormModal from '@/components/domain/document/POFormModal.vue'
+import { validatePoDeletable, requestPoDeletion } from '@/api/documents'
 import { useDocumentFilter } from '@/composables/useDocumentFilter'
 import { usePagination } from '@/composables/usePagination'
 import { useSearchModalLookups } from '@/composables/useSearchModalLookups'
@@ -24,7 +25,7 @@ import { useAuthStore } from '@/stores/auth'
 import { useCiDocuments } from '@/stores/ciDocuments'
 import { usePiDocuments } from '@/stores/piDocuments'
 import { usePlDocuments } from '@/stores/plDocuments'
-import { usePoDocuments } from '@/stores/poDocuments'
+import { loadPoDocuments, usePoDocuments } from '@/stores/poDocuments'
 import { useProductionOrderDocuments } from '@/stores/productionOrderDocuments'
 import { useShipmentOrderDocuments } from '@/stores/shipmentOrderDocuments'
 import { useShipmentStatusDocuments } from '@/stores/shipmentStatusDocuments'
@@ -61,7 +62,7 @@ import { buildSelectOptionsFromRows } from '@/utils/selectOptions'
 
 const router = useRouter()
 const authStore = useAuthStore()
-const { success, warning } = useToast()
+const { success, warning, error } = useToast()
 
 const isAdvancedOpen = ref(false)
 const formOpen = ref(false)
@@ -965,18 +966,29 @@ function handleSave(formValue) {
   editApprovalRequestOpen.value = true
 }
 
-function openDeleteApprovalRequest(row) {
+async function openDeleteApprovalRequest(row) {
   const shipmentLockInfo = shipmentLockInfoByPoId.value.get(row.id)
   if (shipmentLockInfo?.locked) {
     warning(formatPoShipmentLockMessage(shipmentLockInfo))
     return
   }
 
+  try {
+    await validatePoDeletable(row.id)
+  } catch (e) {
+    error(e.response?.data?.message || e.response?.data || '후속 문서가 존재하여 삭제할 수 없습니다.')
+    return
+  }
+
   if (isTeamLeader.value) {
-    poRowsData.value = poRowsData.value.map((r) => (
-      r.id === row.id ? { ...r, status: '취소' } : r
-    ))
-    success(`${row.id} PO가 즉시 삭제(취소) 처리되었습니다.`)
+    try {
+      const userId = authStore.currentUser?.userId
+      await requestPoDeletion({ poId: row.id, userId })
+      await loadPoDocuments()
+      success(`${row.id} PO가 삭제되었습니다.`)
+    } catch (e) {
+      error(e.response?.data?.message || '삭제 처리 중 오류가 발생했습니다.')
+    }
     return
   }
 
@@ -984,7 +996,7 @@ function openDeleteApprovalRequest(row) {
   deleteApprovalRequestOpen.value = true
 }
 
-function confirmDeleteApprovalRequest() {
+async function confirmDeleteApprovalRequest() {
   if (!selectedRow.value) return
 
   const shipmentLockInfo = shipmentLockInfoByPoId.value.get(selectedRow.value.id)
@@ -995,37 +1007,15 @@ function confirmDeleteApprovalRequest() {
     return
   }
 
-  const requesterName = getCurrentRequesterName()
-  const requestedAt = getRequestedAt()
-  const approvalReview = createApprovalReviewSnapshot({
-    title: 'PO 삭제 결재 검토',
-    message: '선택한 PO 삭제 요청 건입니다. 연결 PI와 품목 정보를 확인한 뒤 승인 또는 반려를 결정합니다.',
-    requestRows: deleteApprovalRequestRows.value,
-    documentRows: deleteApprovalDocumentRows.value,
-    itemRows: deleteApprovalItemRows.value,
-    itemSummaryRows: deleteApprovalItemSummaryRows.value,
-    referenceRows: deleteApprovalReferenceRows.value,
-    documentSectionTitle: '삭제 대상 PO 정보',
-    itemSectionTitle: '삭제 대상 PO 품목 정보',
-    referenceSectionTitle: '연결 PI 정보',
-    helperText: '삭제 요청은 승인 전까지 실제 삭제되지 않으며, 승인 시 문서 상태가 취소로 전환됩니다.',
-  })
+  try {
+    const userId = authStore.currentUser?.userId
+    await requestPoDeletion({ poId: selectedRow.value.id, userId })
+    await loadPoDocuments()
+    success(`${selectedRow.value?.id} 삭제 결재 요청이 전송되었습니다.`)
+  } catch (e) {
+    error(e.response?.data?.message || '삭제 결재 요청 중 오류가 발생했습니다.')
+  }
 
-  poRowsData.value = poRowsData.value.map((row) => (
-    row.id === selectedRow.value?.id
-      ? {
-        ...row,
-        approvalReview,
-        ...createDeleteApprovalMeta({
-          approver: getDefaultDeleteApprover(selectedRow.value),
-          requesterName,
-          requestedAt,
-        }),
-      }
-      : row
-  ))
-
-  success(`${selectedRow.value?.id} 삭제 결재 요청이 전송되었습니다.`)
   deleteApprovalRequestOpen.value = false
   selectedRow.value = null
 }


### PR DESCRIPTION
## Summary

- PI/PO 삭제 시 기존 client-only(로컬 rowsData 직접 변경) 동작을 제거하고 백엔드 API 호출로 대체
- `validate-deletable` API로 삭제 가능 여부를 사전 검증한 뒤, `request-deletion` API로 삭제 요청 전송
- 삭제 완료 후 `loadPiDocuments()` / `loadPoDocuments()` store refresh로 UI 자동 반영

## Changes

| 파일 | 변경 내용 |
|------|----------|
| `src/api/documents.js` | `validatePiDeletable`, `requestPiDeletion`, `validatePoDeletable`, `requestPoDeletion` 4개 함수 추가 |
| `PIPage.vue` | `openDeleteApprovalRequest` / `confirmDeleteApprovalRequest` 백엔드 API 연동 |
| `PIDetailPage.vue` | `handleDelete` / `confirmDeleteApprovalRequest` 백엔드 API 연동, `isTeamLeader` computed 추가 |
| `POPage.vue` | `openDeleteApprovalRequest` / `confirmDeleteApprovalRequest` 백엔드 API 연동 |
| `PODetailPage.vue` | `handleDelete` / `confirmDeleteApprovalRequest` 백엔드 API 연동, `isTeamLeader` computed 추가 |

## Test plan

- [ ] PI 목록에서 팀장 계정으로 삭제 시 validate-deletable -> request-deletion API 호출 확인
- [ ] PI 목록에서 스태프 계정으로 삭제 시 validate-deletable 후 결재 모달 -> request-deletion 호출 확인
- [ ] PI 상세에서 동일 삭제 플로우 동작 확인
- [ ] PO 목록/상세에서 동일 삭제 플로우 동작 확인
- [ ] 후속 문서 존재 시 validate-deletable 실패 메시지 표시 확인
- [ ] 삭제 후 목록이 store refresh로 자동 갱신되는지 확인

closes #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)