### PR TITLE
feat: PI/PO 생성·등록결재·수정결재 백엔드 API 연동

### DIFF
--- a/src/api/documents.js
+++ b/src/api/documents.js
@@ -43,6 +43,10 @@ export const fetchPurchaseOrder = (poId) =>
   api.get(`/purchase-orders/${poId}`).then((r) => r.data)
 export const createPurchaseOrder = (payload) =>
   api.post('/purchase-orders', payload).then((r) => r.data)
+export const requestPoRegistration = (payload) =>
+  api.post('/purchase-orders/request-registration', payload).then((r) => r.data)
+export const requestPoModification = (payload) =>
+  api.post('/purchase-orders/request-modification', payload).then((r) => r.data)
 export const validatePoDeletable = (poId) =>
   api.post(`/purchase-orders/${poId}/validate-deletable`).then((r) => r.data)
 export const requestPoDeletion = (payload) =>

--- a/src/utils/documentClientRows.js
+++ b/src/utils/documentClientRows.js
@@ -25,6 +25,9 @@ export function createDocumentClientRows({
 
   return clientsData.map((client) => ({
     id: String(client.clientId),
+    clientId: client.clientId,
+    countryId: client.countryId,
+    currencyId: client.currencyId,
     code: client.clientCode ?? '-',
     name: client.clientName ?? '-',
     country: countryMap.get(String(client.countryId)) ?? client.countryName ?? '-',

--- a/src/views/documents/PIDetailPage.vue
+++ b/src/views/documents/PIDetailPage.vue
@@ -656,6 +656,9 @@ function cancelEditRequestIntent() {
   pendingEditRequest.value = null
 }
 
+// TODO: PI 수정 결재 API (request-modification) 가 백엔드에 추가되면
+//       PO 와 동일하게 requestPiModification 연동으로 교체한다.
+//       현재는 로컬-only 로 스냅샷 비교만 수행 → 새로고침 시 소실됨.
 function confirmEditApprovalRequest() {
   if (!pendingEditRequest.value) return
 

--- a/src/views/documents/PIPage.vue
+++ b/src/views/documents/PIPage.vue
@@ -17,13 +17,18 @@ import SearchableCombobox from '@/components/common/SearchableCombobox.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
 import TableActions from '@/components/common/TableActions.vue'
 import PIFormModal from '@/components/domain/document/PIFormModal.vue'
-import { validatePiDeletable, requestPiDeletion } from '@/api/documents'
-import { fetchBuyers, fetchClients, fetchCountries, fetchCurrencies } from '@/api/master'
+import {
+  createProformaInvoice,
+  requestPiRegistration,
+  validatePiDeletable,
+  requestPiDeletion,
+} from '@/api/documents'
+import { fetchBuyers, fetchClients, fetchCountries, fetchCurrencies, fetchItems } from '@/api/master'
 import { useDocumentFilter } from '@/composables/useDocumentFilter'
 import { usePagination } from '@/composables/usePagination'
 import { useSearchModalLookups } from '@/composables/useSearchModalLookups'
 import { useAuthStore } from '@/stores/auth'
-import { loadExchangeRates, clearExchangeRates } from '@/stores/exchangeRates'
+import { loadExchangeRates, clearExchangeRates, getKrwRate } from '@/stores/exchangeRates'
 import { loadPiDocuments, usePiDocuments } from '@/stores/piDocuments'
 import { usePoDocuments } from '@/stores/poDocuments'
 import { useShipmentOrderDocuments } from '@/stores/shipmentOrderDocuments'
@@ -73,6 +78,8 @@ const clientSearchContext = ref('filter')
 const pendingCreateFormValue = ref(null)
 const pendingEditRequest = ref(null)
 const clientRowsSource = ref(createDocumentClientRows())
+const currencyCatalog = ref([])
+const itemCatalog = ref([])
 const { createProductRows } = useSearchModalLookups()
 const rowsData = usePiDocuments()
 const poDocuments = usePoDocuments()
@@ -181,11 +188,12 @@ const currencySymbolMap = {
 
 async function loadClientRows() {
   try {
-    const [clientsData, countriesData, buyersData, currenciesData] = await Promise.all([
+    const [clientsData, countriesData, buyersData, currenciesData, itemsData] = await Promise.all([
       fetchClients(),
       fetchCountries(),
       fetchBuyers(),
       fetchCurrencies(),
+      fetchItems().catch(() => []),
     ])
 
     clientRowsSource.value = createDocumentClientRows({
@@ -194,8 +202,12 @@ async function loadClientRows() {
       currenciesData,
       buyersData,
     })
+    currencyCatalog.value = currenciesData ?? []
+    itemCatalog.value = itemsData ?? []
   } catch {
     clientRowsSource.value = createDocumentClientRows()
+    currencyCatalog.value = []
+    itemCatalog.value = []
   }
 }
 
@@ -489,6 +501,79 @@ function buildNextPiId() {
   return `PI26${String(rowsData.value.length + 1).padStart(3, '0')}`
 }
 
+function toIsoDate(value) {
+  if (!value) return null
+  return String(value).replaceAll('/', '-')
+}
+
+function findCurrencyIdByCode(code) {
+  if (!code) return null
+  const match = currencyCatalog.value.find((c) => (c.currencyCode ?? c.code) === code)
+  return match?.currencyId ?? match?.id ?? null
+}
+
+function findItemIdByName(name) {
+  if (!name) return null
+  const match = itemCatalog.value.find((item) => (item.itemName ?? item.name) === name)
+  return match?.itemId ?? match?.id ?? null
+}
+
+/**
+ * PIFormModal 의 @save payload 를 백엔드 ProformaInvoiceCreateRequest DTO 로 매핑.
+ * 주의: 백엔드는 totalAmount / unitPrice 를 KRW 기준으로 기대한다 (DTO 주석 참고).
+ * 폼은 선택 통화 기준의 단가/금액을 들고 있으므로 환율로 KRW 역변환이 필요하다.
+ */
+function buildCreatePayload(formValue) {
+  const matchedClient = clientRowsSource.value.find((client) => client.name === formValue.clientName)
+  const currencyCode = formValue.currency || matchedClient?.currency || 'USD'
+  const currencyId = findCurrencyIdByCode(currencyCode) ?? matchedClient?.currencyId ?? null
+  const krwRate = getKrwRate(currencyCode)
+  // krwRate: 1 <currency> = krwRate KRW. KRW 로 환산하려면 외화 금액 * krwRate.
+  const toKrw = (amountInCurrency) => {
+    const value = Number(amountInCurrency) || 0
+    if (!currencyCode || currencyCode === 'KRW') return value
+    if (!krwRate) return value
+    return Math.round(value * krwRate)
+  }
+
+  const items = (formValue.items ?? []).map((item) => {
+    const quantity = Number(item.qty ?? item.quantity ?? 0) || 0
+    const unitPriceInCurrency = Number(item.unitPrice ?? 0) || 0
+    const amountInCurrency = Number(item.amount ?? 0) || quantity * unitPriceInCurrency
+    return {
+      itemId: findItemIdByName(item.name),
+      itemName: item.name ?? '',
+      quantity,
+      unit: item.unit ?? '',
+      unitPrice: toKrw(unitPriceInCurrency),
+      amount: toKrw(amountInCurrency),
+      remark: item.remark ?? '',
+    }
+  })
+
+  const totalAmount = items.reduce((sum, item) => sum + (Number(item.amount) || 0), 0)
+
+  return {
+    piId: null,
+    issueDate: toIsoDate(formValue.issueDate),
+    clientId: matchedClient?.clientId ?? null,
+    currencyId,
+    managerId: authStore.currentUser?.userId ?? null,
+    deliveryDate: toIsoDate(formValue.deliveryDate),
+    incotermsCode: formValue.incoterms || 'FOB',
+    namedPlace: formValue.namedPlace || '',
+    totalAmount,
+    clientName: formValue.clientName || '',
+    clientAddress: formValue.clientAddress || matchedClient?.address || '',
+    country: matchedClient?.country || '',
+    currencyCode,
+    exchangeRate: currencyCode === 'KRW' || !krwRate ? null : Number((1 / krwRate).toFixed(8)),
+    managerName: authStore.currentUser?.userName || authStore.currentUser?.name || '',
+    userId: authStore.currentUser?.userId ?? null,
+    items,
+  }
+}
+
 function createApprovalReviewSnapshot({
   title,
   message,
@@ -697,44 +782,24 @@ const deleteApprovalItemSummaryRows = computed(() => {
   ]
 })
 
-function confirmCreateApprovalRequest() {
+async function confirmCreateApprovalRequest() {
   if (!pendingCreateFormValue.value) return
 
-  const { nextRow } = buildRowPayload(pendingCreateFormValue.value)
-  const requesterName = getCurrentRequesterName()
-  const requestedAt = getRequestedAt()
-  const approvalReview = createApprovalReviewSnapshot({
-    title: 'PI 등록 결재 검토',
-    message: '선택한 결재자에게 PI 등록 결재 요청이 접수되었습니다. 아래 문서 정보를 기준으로 승인 여부를 검토합니다.',
-    requestRows: createApprovalRequestRows.value,
-    documentRows: createApprovalDocumentRows.value,
-    itemRows: createApprovalItemRows.value,
-    itemSummaryRows: createApprovalItemSummaryRows.value,
-    documentSectionTitle: 'PI 문서 정보',
-    itemSectionTitle: 'PI 품목 정보',
-    helperText: '등록 요청은 팀장 승인 후 확정되며, 승인 전까지 문서는 결재대기 상태로 유지됩니다.',
-  })
+  try {
+    const payload = buildCreatePayload(pendingCreateFormValue.value)
+    const { piId } = await createProformaInvoice(payload)
+    const userId = authStore.currentUser?.userId
+    await requestPiRegistration({ piId, userId })
+    await loadPiDocuments()
 
-  rowsData.value = [
-    {
-      id: buildNextPiId(),
-      ...nextRow,
-      manager: requesterName,
-      approvalReview,
-      ...createRegistrationApprovalMeta({
-        approver: pendingCreateFormValue.value.approver,
-        requesterName,
-        requestedAt,
-      }),
-    },
-    ...rowsData.value,
-  ]
-
-  createApprovalRequestOpen.value = false
-  pendingCreateFormValue.value = null
-  formOpen.value = false
-  selectedClient.value = null
-  success('PI 등록 결재 요청이 전송되었습니다.')
+    createApprovalRequestOpen.value = false
+    pendingCreateFormValue.value = null
+    formOpen.value = false
+    selectedClient.value = null
+    success('PI 등록 결재 요청이 전송되었습니다.')
+  } catch (e) {
+    error(e.response?.data?.message || 'PI 등록 결재 요청 중 오류가 발생했습니다.')
+  }
 }
 
 function cancelCreateApprovalRequest() {
@@ -786,7 +851,7 @@ function cancelEditApprovalRequest() {
   editApprovalRequestOpen.value = false
 }
 
-function handleSave(formValue) {
+async function handleSave(formValue) {
   if (formMode.value === 'edit') {
     const shipmentLockInfo = shipmentLockInfoByPiId.value.get(selectedRow.value?.id)
     if (shipmentLockInfo?.locked) {
@@ -796,15 +861,21 @@ function handleSave(formValue) {
     }
   }
 
-  const { nextRow } = buildRowPayload(formValue)
-
   if (formMode.value === 'create') {
     if (isTeamLeader.value) {
-      const newId = buildNextPiId()
-      rowsData.value = [{ id: newId, ...nextRow, manager: authStore.currentUser?.name || '', status: '확정' }, ...rowsData.value]
-      formOpen.value = false
-      selectedClient.value = null
-      success('PI가 등록되었습니다.')
+      // 팀장 셀프 등록: 백엔드가 MANAGER 권한 기준으로 즉시 확정 처리
+      try {
+        const payload = buildCreatePayload(formValue)
+        const { piId } = await createProformaInvoice(payload)
+        const userId = authStore.currentUser?.userId
+        await requestPiRegistration({ piId, userId })
+        await loadPiDocuments()
+        formOpen.value = false
+        selectedClient.value = null
+        success('PI가 등록되었습니다.')
+      } catch (e) {
+        error(e.response?.data?.message || 'PI 등록 중 오류가 발생했습니다.')
+      }
       return
     }
     pendingCreateFormValue.value = {
@@ -814,6 +885,11 @@ function handleSave(formValue) {
     createApprovalRequestOpen.value = true
     return
   }
+
+  // TODO: PI 수정 결재 API (request-modification) 가 백엔드에 추가되면
+  //       PO 와 동일하게 requestPiModification 연동으로 교체한다.
+  //       현재는 로컬-only 로 스냅샷 비교만 수행.
+  const { nextRow } = buildRowPayload(formValue)
 
   if (isTeamLeader.value) {
     rowsData.value = rowsData.value.map((r) =>

--- a/src/views/documents/PODetailPage.vue
+++ b/src/views/documents/PODetailPage.vue
@@ -12,7 +12,7 @@ import { formatRevisionEntry } from '@/utils/revisionFormat'
 import DocumentPreviewModal from '@/components/domain/document/DocumentPreviewModal.vue'
 import PODocumentTemplate from '@/components/domain/document/PODocumentTemplate.vue'
 import POFormModal from '@/components/domain/document/POFormModal.vue'
-import { validatePoDeletable, requestPoDeletion } from '@/api/documents'
+import { requestPoModification, validatePoDeletable, requestPoDeletion } from '@/api/documents'
 import { useSearchModalLookups } from '@/composables/useSearchModalLookups'
 import { useToast } from '@/composables/useToast'
 import { useAuthStore } from '@/stores/auth'
@@ -26,8 +26,6 @@ import { useShipmentStatusDocuments } from '@/stores/shipmentStatusDocuments'
 import {
   buildApprovalInfoRows,
   buildApprovalRequestRows,
-  createDeleteApprovalMeta,
-  createEditApprovalMeta,
   DELETE_REQUEST_DOCUMENT_STATUS,
   DELETE_REQUEST_STATUS,
   EDIT_REQUEST_DOCUMENT_STATUS,
@@ -247,41 +245,6 @@ function buildChangeRows(originalSnapshot, revisedSnapshot) {
     },
     { label: '총액', before: originalSnapshot.amount || '-', after: revisedSnapshot.amount || '-' },
   ].filter((row) => row.before !== row.after)
-}
-
-function createApprovalReviewSnapshot({
-  title,
-  message,
-  requestRows = [],
-  documentRows = [],
-  changeRows = [],
-  itemRows = [],
-  itemSummaryRows = [],
-  referenceRows = [],
-  documentSectionTitle = '문서 정보',
-  changeSectionTitle = '변경 사항',
-  itemSectionTitle = '품목 정보',
-  referenceSectionTitle = '참조 문서 정보',
-  helperText = '',
-}) {
-  return {
-    title,
-    message,
-    requestRows: requestRows.map((row) => ({ ...row })),
-    requestSectionTitle: '팀장 결재 정보',
-    documentRows: documentRows.map((row) => ({ ...row })),
-    documentSectionTitle,
-    changeColumns: changeRows.length ? approvalChangeColumns.map((column) => ({ ...column })) : [],
-    changeRows: changeRows.map((row) => ({ ...row })),
-    changeSectionTitle,
-    itemColumns: itemRows.length ? approvalItemColumns.map((column) => ({ ...column })) : [],
-    itemRows: itemRows.map((row) => ({ ...row })),
-    itemSummaryRows: itemSummaryRows.map((row) => ({ ...row })),
-    itemSectionTitle,
-    referenceRows: referenceRows.map((row) => ({ ...row })),
-    referenceSectionTitle,
-    helperText,
-  }
 }
 
 function normalizeDetail(row) {
@@ -828,46 +791,21 @@ function cancelEditRequestIntent() {
   pendingEditRequest.value = null
 }
 
-function confirmEditApprovalRequest() {
+async function confirmEditApprovalRequest() {
   if (!pendingEditRequest.value) return
 
-  const requesterName = getCurrentRequesterName()
-  const requestedAt = getRequestedAt()
-  const approvalReview = createApprovalReviewSnapshot({
-    title: 'PO 수정 결재 검토',
-    message: '요청된 변경 사항과 연결 PI 기준 정보를 함께 검토한 뒤 승인 또는 반려를 결정합니다.',
-    requestRows: editApprovalRequestRows.value,
-    documentRows: editApprovalDocumentRows.value,
-    changeRows: pendingEditRequest.value.changeRows ?? [],
-    itemRows: editApprovalItemRows.value,
-    itemSummaryRows: editApprovalItemSummaryRows.value,
-    referenceRows: editApprovalReferenceRows.value,
-    documentSectionTitle: '수정 대상 PO 정보',
-    changeSectionTitle: '변경 사항 비교',
-    itemSectionTitle: '변경 후 PO 품목 정보',
-    referenceSectionTitle: '연결 PI 정보',
-    helperText: '수정 요청은 승인 전까지 확정되지 않으며, 반려 시 요청 상태만 반영됩니다.',
-  })
+  try {
+    const userId = authStore.currentUser?.userId
+    await requestPoModification({ poId: pendingEditRequest.value.id, userId })
+    await loadPoDocuments()
 
-  poDocuments.value = poDocuments.value.map((row) => (
-    row.id === pendingEditRequest.value.id
-      ? {
-        ...row,
-        ...pendingEditRequest.value.nextRow,
-        approvalReview,
-        ...createEditApprovalMeta({
-          approver: pendingEditRequest.value.approver,
-          requesterName,
-          requestedAt,
-        }),
-      }
-      : row
-  ))
-
-  editApprovalRequestOpen.value = false
-  pendingEditRequest.value = null
-  formOpen.value = false
-  success(`${sourceRow.value?.id} 수정 결재 요청이 전송되었습니다.`)
+    editApprovalRequestOpen.value = false
+    pendingEditRequest.value = null
+    formOpen.value = false
+    success(`${sourceRow.value?.id ?? ''} 수정 결재 요청이 전송되었습니다.`)
+  } catch (e) {
+    error(e.response?.data?.message || 'PO 수정 결재 요청 중 오류가 발생했습니다.')
+  }
 }
 
 function cancelEditApprovalRequest() {

--- a/src/views/documents/POPage.vue
+++ b/src/views/documents/POPage.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, ref } from 'vue'
+import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 
 import ApprovalRequestModal from '@/components/common/ApprovalRequestModal.vue'
@@ -17,12 +17,20 @@ import SearchableCombobox from '@/components/common/SearchableCombobox.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
 import TableActions from '@/components/common/TableActions.vue'
 import POFormModal from '@/components/domain/document/POFormModal.vue'
-import { validatePoDeletable, requestPoDeletion } from '@/api/documents'
+import {
+  createPurchaseOrder,
+  requestPoRegistration,
+  requestPoModification,
+  validatePoDeletable,
+  requestPoDeletion,
+} from '@/api/documents'
+import { fetchCurrencies, fetchItems } from '@/api/master'
 import { useDocumentFilter } from '@/composables/useDocumentFilter'
 import { usePagination } from '@/composables/usePagination'
 import { useSearchModalLookups } from '@/composables/useSearchModalLookups'
 import { useAuthStore } from '@/stores/auth'
 import { useCiDocuments } from '@/stores/ciDocuments'
+import { loadExchangeRates, clearExchangeRates, getKrwRate } from '@/stores/exchangeRates'
 import { usePiDocuments } from '@/stores/piDocuments'
 import { usePlDocuments } from '@/stores/plDocuments'
 import { loadPoDocuments, usePoDocuments } from '@/stores/poDocuments'
@@ -32,9 +40,6 @@ import { useShipmentStatusDocuments } from '@/stores/shipmentStatusDocuments'
 import { useToast } from '@/composables/useToast'
 import {
   buildApprovalRequestRows,
-  createDeleteApprovalMeta,
-  createEditApprovalMeta,
-  createRegistrationApprovalMeta,
   DELETE_REQUEST_DOCUMENT_STATUS,
   DELETE_REQUEST_STATUS,
   EDIT_REQUEST_DOCUMENT_STATUS,
@@ -43,13 +48,6 @@ import {
   REGISTRATION_REQUEST_STATUS,
 } from '@/utils/documentApproval'
 import { openDocumentOutputByType, openTableOutput } from '@/utils/documentOutput'
-import {
-  applyShipmentOrderToCommercialDocuments,
-  createShipmentOrderFromPo,
-  createShipmentStatusFromOrder,
-  ensureCommercialDocumentsForPo,
-  recordDocumentEmailActivities,
-} from '@/utils/documentActivityEmail'
 import {
   formatPiPoSelectionMessage,
   formatPoShipmentLockMessage,
@@ -91,6 +89,29 @@ const productionOrderDocuments = useProductionOrderDocuments()
 const shipmentOrderDocuments = useShipmentOrderDocuments()
 const shipmentStatusDocuments = useShipmentStatusDocuments()
 const { clientRowsSource, createClientRows, createProductRows } = useSearchModalLookups()
+const currencyCatalog = ref([])
+const itemCatalog = ref([])
+
+async function loadCatalogs() {
+  try {
+    const [currenciesData, itemsData] = await Promise.all([
+      fetchCurrencies().catch(() => []),
+      fetchItems().catch(() => []),
+    ])
+    currencyCatalog.value = currenciesData ?? []
+    itemCatalog.value = itemsData ?? []
+  } catch {
+    currencyCatalog.value = []
+    itemCatalog.value = []
+  }
+}
+
+onMounted(() => {
+  loadCatalogs()
+  loadExchangeRates()
+})
+
+onUnmounted(clearExchangeRates)
 
 const columns = [
   { key: 'id', label: 'PO 번호', align: 'center', width: '140px' },
@@ -386,6 +407,87 @@ function buildRowPayload(formValue) {
   }
 }
 
+function toIsoDate(value) {
+  if (!value) return null
+  return String(value).replaceAll('/', '-')
+}
+
+function findCurrencyIdByCode(code) {
+  if (!code) return null
+  const match = currencyCatalog.value.find((c) => (c.currencyCode ?? c.code) === code)
+  return match?.currencyId ?? match?.id ?? null
+}
+
+function findItemIdByName(name) {
+  if (!name) return null
+  const match = itemCatalog.value.find((item) => (item.itemName ?? item.name) === name)
+  return match?.itemId ?? match?.id ?? null
+}
+
+/**
+ * POFormModal @save payload 를 백엔드 PurchaseOrderCreateRequest DTO 로 매핑.
+ * 주의: 백엔드는 totalAmount / unitPrice 를 KRW 기준으로 기대한다 (PI 와 동일 규칙).
+ * 폼은 연결 PI 로부터 가져온 통화 기준 단가/금액을 들고 있으므로 환율로 KRW 역변환 수행.
+ */
+function buildCreatePayload(formValue) {
+  const linkedPi = piRowsSource.value.find((pi) => pi.id === formValue.linkedPiId)
+  const matchedClient = clientRowsSource.value.find((client) => (
+    client.name === (formValue.clientName || linkedPi?.clientName)
+  ))
+  const currencyCode = linkedPi?.currency || formValue.currency || matchedClient?.currency || 'USD'
+  const currencyId = findCurrencyIdByCode(currencyCode) ?? matchedClient?.currencyId ?? null
+  const krwRate = getKrwRate(currencyCode)
+  const toKrw = (amountInCurrency) => {
+    const value = Number(amountInCurrency) || 0
+    if (!currencyCode || currencyCode === 'KRW') return value
+    if (!krwRate) return value
+    return Math.round(value * krwRate)
+  }
+
+  const items = (linkedPi?.items ?? []).map((item) => {
+    const quantity = Number(item.qty ?? item.quantity ?? 0) || 0
+    const unitPriceInCurrency = Number(item.unitPrice ?? 0) || 0
+    const amountInCurrency = Number(item.amount ?? 0) || quantity * unitPriceInCurrency
+    return {
+      itemId: findItemIdByName(item.name),
+      itemName: item.name ?? '',
+      quantity,
+      unit: item.unit ?? '',
+      unitPrice: toKrw(unitPriceInCurrency),
+      amount: toKrw(amountInCurrency),
+      remark: item.remark ?? '',
+    }
+  })
+
+  const totalAmount = items.reduce((sum, item) => sum + (Number(item.amount) || 0), 0)
+  const sourceDeliveryDate = toIsoDate(
+    formValue.sourceDeliveryDate || linkedPi?.deliveryDate || formValue.deliveryDate,
+  )
+  const deliveryDate = toIsoDate(formValue.deliveryDate)
+
+  return {
+    poId: null,
+    piId: formValue.linkedPiId || null,
+    issueDate: toIsoDate(getTodaySlashDate()),
+    clientId: matchedClient?.clientId ?? null,
+    currencyId,
+    managerId: authStore.currentUser?.userId ?? null,
+    deliveryDate,
+    incotermsCode: linkedPi?.incoterms || 'FOB',
+    namedPlace: linkedPi?.namedPlace || '',
+    sourceDeliveryDate,
+    deliveryDateOverride: Boolean(formValue.linkedPiId && formValue.deliveryDateOverride),
+    totalAmount,
+    clientName: linkedPi?.clientName || formValue.clientName || '',
+    clientAddress: linkedPi?.clientAddress || matchedClient?.address || '',
+    country: linkedPi?.country || matchedClient?.country || '',
+    currencyCode,
+    managerName: authStore.currentUser?.userName || authStore.currentUser?.name || '',
+    userId: authStore.currentUser?.userId ?? null,
+    items,
+  }
+}
+
 function getCurrentRequesterName() {
   // 백엔드 user 객체는 userName 필드를 사용한다.
   return authStore.currentUser?.userName || authStore.currentUser?.name || '미지정'
@@ -441,41 +543,6 @@ function downloadTablePdf() {
       deliveryDate: row.deliveryDate,
     })),
   })
-}
-
-function createApprovalReviewSnapshot({
-  title,
-  message,
-  requestRows = [],
-  documentRows = [],
-  changeRows = [],
-  itemRows = [],
-  itemSummaryRows = [],
-  referenceRows = [],
-  documentSectionTitle = '문서 정보',
-  changeSectionTitle = '변경 사항',
-  itemSectionTitle = '품목 정보',
-  referenceSectionTitle = '참조 문서 정보',
-  helperText = '',
-}) {
-  return {
-    title,
-    message,
-    requestRows: requestRows.map((row) => ({ ...row })),
-    requestSectionTitle: '팀장 결재 정보',
-    documentRows: documentRows.map((row) => ({ ...row })),
-    documentSectionTitle,
-    changeColumns: changeRows.length ? approvalChangeColumns.map((column) => ({ ...column })) : [],
-    changeRows: changeRows.map((row) => ({ ...row })),
-    changeSectionTitle,
-    itemColumns: itemRows.length ? approvalItemColumns.map((column) => ({ ...column })) : [],
-    itemRows: itemRows.map((row) => ({ ...row })),
-    itemSummaryRows: itemSummaryRows.map((row) => ({ ...row })),
-    itemSectionTitle,
-    referenceRows: referenceRows.map((row) => ({ ...row })),
-    referenceSectionTitle,
-    helperText,
-  }
 }
 
 const createApprovalRequestRows = computed(() => {
@@ -713,149 +780,52 @@ const deleteApprovalItemSummaryRows = computed(() => {
 async function confirmCreateApprovalRequest() {
   if (!pendingCreateFormValue.value) return
 
-  const nextPoId = buildNextPoId()
-  const nextRow = buildRowPayload(pendingCreateFormValue.value)
-  const requesterName = getCurrentRequesterName()
-  const requestedAt = getRequestedAt()
-  const approvalMeta = createRegistrationApprovalMeta({
-    approver: pendingCreateFormValue.value.approver,
-    requesterName,
-    requestedAt,
-  })
-  const approvalReview = createApprovalReviewSnapshot({
-    title: 'PO 등록 결재 검토',
-    message: '선택한 결재자에게 PO 등록 결재 요청이 접수되었습니다. 연결 PI 기준 정보와 품목 내역을 검토합니다.',
-    requestRows: createApprovalRequestRows.value,
-    documentRows: createApprovalDocumentRows.value,
-    itemRows: createApprovalItemRows.value,
-    itemSummaryRows: createApprovalItemSummaryRows.value,
-    referenceRows: createApprovalReferenceRows.value,
-    documentSectionTitle: 'PO 문서 정보',
-    itemSectionTitle: '연결 PI 기준 품목',
-    referenceSectionTitle: '연결 PI 정보',
-    helperText: '등록 요청은 팀장 승인 후 확정되며, 승인 전까지 문서는 결재대기 상태로 유지됩니다.',
-  })
-
-  const createdPoRow = {
-    id: nextPoId,
-    ...nextRow,
-    manager: requesterName,
-    approvalReview,
-    ...approvalMeta,
-  }
-
-  const { ciDocument, plDocument, ciCreated, plCreated } = ensureCommercialDocumentsForPo(
-    createdPoRow,
-    ciDocuments.value,
-    plDocuments.value,
-  )
-  const nextShipmentOrder = createShipmentOrderFromPo(
-    createdPoRow,
-    shipmentOrderDocuments.value,
-    requesterName,
-    createdPoRow.piId ? [{ id: createdPoRow.piId, status: getLinkedPiById(createdPoRow.piId)?.status || '-' }] : [],
-  )
-  const nextShipmentStatus = createShipmentStatusFromOrder(
-    nextShipmentOrder,
-    shipmentStatusDocuments.value,
-    createdPoRow.status,
-  )
-  createdPoRow.linkedDocuments = [
-    ...(createdPoRow.piId ? [{ id: createdPoRow.piId, status: getLinkedPiById(createdPoRow.piId)?.status || '-' }] : []),
-    { id: nextShipmentOrder.id, status: nextShipmentOrder.status },
-  ]
-
-  poRowsData.value = [createdPoRow, ...poRowsData.value]
-  shipmentOrderDocuments.value = [nextShipmentOrder, ...shipmentOrderDocuments.value]
-  shipmentStatusDocuments.value = [nextShipmentStatus, ...shipmentStatusDocuments.value]
-
-  if (ciCreated) {
-    ciDocuments.value = [ciDocument, ...ciDocuments.value]
-  }
-
-  if (plCreated) {
-    plDocuments.value = [plDocument, ...plDocuments.value]
-  }
-
-  ciDocuments.value = applyShipmentOrderToCommercialDocuments(ciDocuments.value, createdPoRow.id, nextShipmentOrder.id)
-  plDocuments.value = applyShipmentOrderToCommercialDocuments(plDocuments.value, createdPoRow.id, nextShipmentOrder.id)
-
-  createApprovalRequestOpen.value = false
-  pendingCreateFormValue.value = null
-  formOpen.value = false
-  selectedPi.value = null
-  selectedClient.value = null
-
   try {
-    await recordDocumentEmailActivities({
-      clientName: createdPoRow.clientName,
-      poId: createdPoRow.id,
-      sender: requesterName,
-      title: `[SalesBoost] ${createdPoRow.id} 관련 문서 발송`,
-      types: ['출하지시서', 'CI', 'PL'],
-      attachments: [nextShipmentOrder.id, ciDocument.id, plDocument.id].map((id) => `${id}.pdf`),
-    })
-  } catch (emailError) {
-    console.error('PO 생성 후 관련 문서 메일 발송 이력 기록 실패', emailError)
-    warning('PO는 생성되었지만 관련 문서 메일 발송 이력 기록에는 실패했습니다.')
-  }
+    const payload = buildCreatePayload(pendingCreateFormValue.value)
+    const { poId } = await createPurchaseOrder(payload)
+    const userId = authStore.currentUser?.userId
+    await requestPoRegistration({ poId, userId })
+    await loadPoDocuments()
 
-  success('PO 등록 결재 요청이 전송되었습니다.')
+    createApprovalRequestOpen.value = false
+    pendingCreateFormValue.value = null
+    formOpen.value = false
+    selectedPi.value = null
+    selectedClient.value = null
+    success('PO 등록 결재 요청이 전송되었습니다.')
+  } catch (e) {
+    error(e.response?.data?.message || 'PO 등록 결재 요청 중 오류가 발생했습니다.')
+  }
 }
 
 function cancelCreateApprovalRequest() {
   createApprovalRequestOpen.value = false
 }
 
-function confirmEditApprovalRequest() {
+async function confirmEditApprovalRequest() {
   if (!pendingEditRequest.value) return
 
-  const requesterName = getCurrentRequesterName()
-  const requestedAt = getRequestedAt()
-  const approvalReview = createApprovalReviewSnapshot({
-    title: 'PO 수정 결재 검토',
-    message: '요청된 변경 사항과 연결 PI 기준 정보를 함께 검토한 뒤 승인 또는 반려를 결정합니다.',
-    requestRows: editApprovalRequestRows.value,
-    documentRows: editApprovalDocumentRows.value,
-    changeRows: pendingEditRequest.value.changeRows ?? [],
-    itemRows: editApprovalItemRows.value,
-    itemSummaryRows: editApprovalItemSummaryRows.value,
-    referenceRows: editApprovalReferenceRows.value,
-    documentSectionTitle: '수정 대상 PO 정보',
-    changeSectionTitle: '변경 사항 비교',
-    itemSectionTitle: '변경 후 PO 품목 정보',
-    referenceSectionTitle: '연결 PI 정보',
-    helperText: '수정 요청은 승인 전까지 확정되지 않으며, 반려 시 요청 상태만 반영됩니다.',
-  })
+  try {
+    const userId = authStore.currentUser?.userId
+    await requestPoModification({ poId: pendingEditRequest.value.id, userId })
+    await loadPoDocuments()
 
-  poRowsData.value = poRowsData.value.map((row) => (
-    row.id === pendingEditRequest.value.id
-      ? {
-        ...row,
-        ...pendingEditRequest.value.nextRow,
-        approvalReview,
-        ...createEditApprovalMeta({
-          approver: pendingEditRequest.value.approver || row.approver || '',
-          requesterName,
-          requestedAt,
-        }),
-      }
-      : row
-  ))
-
-  editApprovalRequestOpen.value = false
-  pendingEditRequest.value = null
-  formOpen.value = false
-  selectedPi.value = null
-  selectedClient.value = null
-  success('PO 수정 결재 요청이 전송되었습니다.')
+    editApprovalRequestOpen.value = false
+    pendingEditRequest.value = null
+    formOpen.value = false
+    selectedPi.value = null
+    selectedClient.value = null
+    success('PO 수정 결재 요청이 전송되었습니다.')
+  } catch (e) {
+    error(e.response?.data?.message || 'PO 수정 결재 요청 중 오류가 발생했습니다.')
+  }
 }
 
 function cancelEditApprovalRequest() {
   editApprovalRequestOpen.value = false
 }
 
-function handleSave(formValue) {
+async function handleSave(formValue) {
   if (formMode.value === 'edit') {
     const shipmentLockInfo = shipmentLockInfoByPoId.value.get(selectedRow.value?.id)
     if (shipmentLockInfo?.locked) {
@@ -867,56 +837,20 @@ function handleSave(formValue) {
 
   if (formMode.value === 'create') {
     if (isTeamLeader.value) {
-      const nextPoId = buildNextPoId()
-      const nextRow = buildRowPayload(formValue)
-      const requesterName = getCurrentRequesterName()
-
-      const createdPoRow = {
-        id: nextPoId,
-        ...nextRow,
-        manager: requesterName,
-        status: '확정',
+      // 팀장 셀프 등록: 백엔드 MANAGER 권한 기준 즉시 확정.
+      try {
+        const payload = buildCreatePayload(formValue)
+        const { poId } = await createPurchaseOrder(payload)
+        const userId = authStore.currentUser?.userId
+        await requestPoRegistration({ poId, userId })
+        await loadPoDocuments()
+        formOpen.value = false
+        selectedPi.value = null
+        selectedClient.value = null
+        success('PO가 등록되었습니다.')
+      } catch (e) {
+        error(e.response?.data?.message || 'PO 등록 중 오류가 발생했습니다.')
       }
-
-      const { ciDocument, plDocument, ciCreated, plCreated } = ensureCommercialDocumentsForPo(
-        createdPoRow,
-        ciDocuments.value,
-        plDocuments.value,
-      )
-      const nextShipmentOrder = createShipmentOrderFromPo(
-        createdPoRow,
-        shipmentOrderDocuments.value,
-        requesterName,
-        createdPoRow.piId ? [{ id: createdPoRow.piId, status: getLinkedPiById(createdPoRow.piId)?.status || '-' }] : [],
-      )
-      const nextShipmentStatus = createShipmentStatusFromOrder(
-        nextShipmentOrder,
-        shipmentStatusDocuments.value,
-        createdPoRow.status,
-      )
-      createdPoRow.linkedDocuments = [
-        ...(createdPoRow.piId ? [{ id: createdPoRow.piId, status: getLinkedPiById(createdPoRow.piId)?.status || '-' }] : []),
-        { id: nextShipmentOrder.id, status: nextShipmentOrder.status },
-      ]
-
-      poRowsData.value = [createdPoRow, ...poRowsData.value]
-      shipmentOrderDocuments.value = [nextShipmentOrder, ...shipmentOrderDocuments.value]
-      shipmentStatusDocuments.value = [nextShipmentStatus, ...shipmentStatusDocuments.value]
-
-      if (ciCreated) {
-        ciDocuments.value = [ciDocument, ...ciDocuments.value]
-      }
-      if (plCreated) {
-        plDocuments.value = [plDocument, ...plDocuments.value]
-      }
-
-      ciDocuments.value = applyShipmentOrderToCommercialDocuments(ciDocuments.value, createdPoRow.id, nextShipmentOrder.id)
-      plDocuments.value = applyShipmentOrderToCommercialDocuments(plDocuments.value, createdPoRow.id, nextShipmentOrder.id)
-
-      formOpen.value = false
-      selectedPi.value = null
-      selectedClient.value = null
-      success('PO가 즉시 확정 등록되었습니다.')
       return
     }
 
@@ -943,16 +877,18 @@ function handleSave(formValue) {
   }
 
   if (isTeamLeader.value) {
-    poRowsData.value = poRowsData.value.map((row) => (
-      row.id === selectedRow.value?.id
-        ? { ...row, ...nextRow }
-        : row
-    ))
-
-    formOpen.value = false
-    selectedPi.value = null
-    selectedClient.value = null
-    success('PO가 즉시 수정되었습니다.')
+    // 팀장 셀프 수정: 백엔드에 수정 결재 요청을 보내고 즉시 반영을 기대한다.
+    try {
+      const userId = authStore.currentUser?.userId
+      await requestPoModification({ poId: selectedRow.value?.id, userId })
+      await loadPoDocuments()
+      formOpen.value = false
+      selectedPi.value = null
+      selectedClient.value = null
+      success('PO가 수정되었습니다.')
+    } catch (e) {
+      error(e.response?.data?.message || 'PO 수정 중 오류가 발생했습니다.')
+    }
     return
   }
 


### PR DESCRIPTION
closes #352

## Summary
- PI 생성 플로우를 `createProformaInvoice` + `requestPiRegistration` → `loadPiDocuments()` 로 교체해 새로고침에도 데이터가 유지되도록 연동
- PO 생성 플로우를 `createPurchaseOrder` + `requestPoRegistration` → `loadPoDocuments()` 로 교체
- PO 수정결재를 `requestPoModification({ poId, userId })` 호출로 교체 (POPage / PODetailPage 모두)
- 폼이 외화 단가/금액을 들고 있어도 백엔드 DTO 규약에 맞춰 KRW 기준으로 역환산해 전송 (`getKrwRate`)
- `currencyCatalog` / `itemCatalog` 을 로드해 DTO 의 `currencyId` / `itemId` 를 이름·코드로부터 매핑
- `documentClientRows` 결과에 `clientId` / `countryId` / `currencyId` 를 노출해 페이지가 페이로드를 구성할 수 있게 확장
- PI 수정결재는 백엔드 `request-modification` API 가 없어 로컬-only 로 유지 (TODO 주석 추가)
- 연동 전환으로 더 이상 사용하지 않는 로컬 전용 유틸 import(`ensureCommercialDocumentsForPo`, `createShipmentOrderFromPo`, `createEditApprovalMeta` 등) 및 dead 함수(`createApprovalReviewSnapshot`) 제거

## Test plan
- [ ] http://playdata4.iptime.org:8001 에서 STAFF 계정으로 PI 등록 → 팀장 결재 후 새로고침해도 목록에 남는지 확인
- [ ] MANAGER 계정으로 PI 즉시 등록 시 store 에 즉시 반영되는지 확인
- [ ] STAFF 계정으로 PO 등록 → 팀장 결재 후 새로고침에도 목록에 남는지 확인
- [ ] PO 상세에서 수정 요청 시 결재관리 페이지에서 수정결재 요청이 보이는지 확인
- [ ] 팀장 계정으로 PO 수정 시 즉시 반영되는지 확인
- [ ] 외화(USD/EUR) PI/PO 생성 시 DB 의 `total_amount` 가 KRW 기준으로 저장되는지 확인