### PR TITLE
feat: PO 폼 PI 드롭다운에 CONFIRMED 필터 추가

### DIFF
--- a/src/views/documents/POPage.vue
+++ b/src/views/documents/POPage.vue
@@ -181,7 +181,9 @@ const shipmentLockInfoByPoId = computed(() => (
 
 const availablePiRows = computed(() => (
   piRowsSource.value.filter((row) => (
-    getPiPoSelectionInfo(
+    // 결재 확정된(confirmed) PI 만 PO 연결 후보로 노출. draft/pending_approval/rejected/modification_requested 등은 제외.
+    row.status === 'confirmed'
+    && getPiPoSelectionInfo(
       row,
       poRowsData.value,
       shipmentOrderDocuments.value,


### PR DESCRIPTION
closes #354

## Summary
- PO 생성/수정 폼의 PI 연결 후보를 결재 확정(`confirmed`) 상태 PI 로만 제한
- `availablePiRows` computed 에 `row.status === 'confirmed'` 프리-필터 추가
- 기존 `getPiPoSelectionInfo().selectable` (중복 연결 방지) 는 그대로 유지

## 배경
`piRowsSource` 는 전체 PI 를 반환하므로 draft / pending_approval / modification_requested / rejected 상태 PI 까지 PO 연결 후보에 노출되던 상태. 결재받지 않은 PI 로 PO 생성을 막기 위해 UI 필터 추가.

백엔드 `ProformaInvoiceStatusConverter` 가 enum → lowercase dbValue ("confirmed", "draft", ...) 로 저장/반환하므로 프론트는 raw 값 그대로 비교.

## Test plan
- [ ] 개발 서버에서 PO 생성 폼 → PI 검색 창에 `confirmed` PI 만 뜨는지 확인
- [ ] draft / 결재대기 PI 는 검색 결과에서 제외되는지 확인
- [ ] 기존 CONFIRMED PI 선택 후 PO 생성 정상 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)