### PR TITLE
fix: PO 폼 PI 드롭다운 '확정' 상태만 노출 (#354)

### DIFF
--- a/src/views/documents/PODetailPage.vue
+++ b/src/views/documents/PODetailPage.vue
@@ -88,9 +88,17 @@ const approvalChangeColumns = [
   { key: 'after', label: '변경값', align: 'left' },
 ]
 
+// PO 는 결재 확정(CONFIRMED) PI 만 연결 가능. 초안·결재대기·수정요청 상태의 PI 가
+// 드롭다운에 노출되면 결재받지 않은 초안으로 PO 수정이 가능해지므로 프론트에서 먼저 차단.
+function isConfirmedPi(row) {
+  const status = String(row?.status ?? '').trim().toLowerCase()
+  return status === 'confirmed' || status === '확정'
+}
+
 const availablePiRows = computed(() => (
   piDocuments.value.filter((row) => (
-    getPiPoSelectionInfo(
+    isConfirmedPi(row)
+    && getPiPoSelectionInfo(
       row,
       poDocuments.value,
       shipmentOrderDocuments.value,

--- a/src/views/documents/POPage.vue
+++ b/src/views/documents/POPage.vue
@@ -179,9 +179,17 @@ const shipmentLockInfoByPoId = computed(() => (
   )
 ))
 
+// PO 는 결재 확정(CONFIRMED) PI 만 연결 가능. 초안·결재대기·수정요청 상태의 PI 가
+// 드롭다운에 노출되면 결재받지 않은 초안으로 PO 생성이 가능해지므로 프론트에서 먼저 차단.
+function isConfirmedPi(row) {
+  const status = String(row?.status ?? '').trim().toLowerCase()
+  return status === 'confirmed' || status === '확정'
+}
+
 const availablePiRows = computed(() => (
   piRowsSource.value.filter((row) => (
-    getPiPoSelectionInfo(
+    isConfirmedPi(row)
+    && getPiPoSelectionInfo(
       row,
       poRowsData.value,
       shipmentOrderDocuments.value,


### PR DESCRIPTION
## 📋 작업 내용

PO 생성/수정 폼의 PI 드롭다운에 **결재 확정(CONFIRMED) 상태** PI 만 노출되도록 제한.

### 문제

기존 `availablePiRows` 는 `getPiPoSelectionInfo().selectable` (중복 연결·락 체크) 만 확인하고 PI status 는 보지 않았음. 그 결과 draft / pending_approval / modification_requested 상태의 PI 도 후보에 노출되어 **결재받지 않은 초안 PI 로 PO 를 생성**할 수 있는 상태였음.

### 수정

- `POPage.vue` / `PODetailPage.vue` 의 `availablePiRows` computed 에 `isConfirmedPi` 필터 추가.
- 대소문자 / 한국어 라벨(`confirmed` / `CONFIRMED` / `확정`) 모두 방어적으로 처리.
- 후속문서 연결을 기준으로 PO 삭제가 막히듯, 상위 문서(PI) 도 **확정된 것만** 연결 허용하는 정책 일관성.

## 🔗 관련 이슈

- closes #354

## ✅ 체크리스트

- [x] 정상 동작 확인 (코드 리뷰)
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

서버(`PurchaseOrderCreationService`) 도 CONFIRMED PI 기준으로 최종 검증하고 있어 프론트 필터는 UX 방어선. 혹시 status 값 표기가 또 달라지면 `isConfirmedPi` 한 곳만 수정하면 됨.