### PR TITLE
fix: PO 출력 미리보기 라벨 오버플로우 (#359)

### DIFF
--- a/src/components/domain/document/PODocumentTemplate.vue
+++ b/src/components/domain/document/PODocumentTemplate.vue
@@ -39,8 +39,8 @@ function resolvePiReference(linkedDocuments) {
     <table class="doc-info-table">
       <colgroup>
         <col style="width:140px">
-        <col style="width:36%">
-        <col style="width:160px">
+        <col style="width:34%">
+        <col style="width:180px">
         <col>
       </colgroup>
       <tbody>
@@ -76,8 +76,8 @@ function resolvePiReference(linkedDocuments) {
     <table class="doc-info-table shipping-info-table" style="margin-top:-1px">
       <colgroup>
         <col style="width:140px">
-        <col style="width:36%">
-        <col style="width:160px">
+        <col style="width:34%">
+        <col style="width:180px">
         <col>
       </colgroup>
       <tbody>
@@ -165,9 +165,6 @@ function resolvePiReference(linkedDocuments) {
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: #475569;
-  white-space: nowrap;
-}
-.shipping-info-table .info-label {
   white-space: normal;
   word-break: keep-all;
   line-height: 1.3;


### PR DESCRIPTION
## 📋 작업 내용

PO 출력 미리보기(\`PODocumentTemplate.vue\`) 상단 정보 테이블 / 배송조건 테이블의 좌측 라벨 컬럼 오버플로우 수정.

### 문제
\`.info-label { white-space: nowrap }\` 이라 \"REQUESTED DELIVERY\" / \"METHOD OF DISPATCH\" 같은 긴 라벨이 셀 경계를 침범하거나 값 영역을 잠식.

### 수정
- \`.info-label\` CSS: \`white-space: normal\` / \`word-break: keep-all\` / \`line-height: 1.3\` → 긴 라벨 자연 줄바꿈.
- 상단/배송 \`colgroup\` 라벨 컬럼 \`160px → 180px\`, 값 컬럼 \`36% → 34%\` 로 재조정해 밸런스 확보.
- 중복된 \`.shipping-info-table .info-label\` 셀렉터 제거 (base 규칙과 동일).

## 🔗 관련 이슈

- closes #359

## ✅ 체크리스트

- [x] 정상 동작 확인 (코드 리뷰)
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

PO 출력 미리보기만 영향. 다른 문서 템플릿(PI / CI / PL) 의 동일 패턴 여부는 후속 QA 에서 확인 예정.