### PR TITLE
refactor: 거래처 폼 담당 부서/팀 단일화 (#361)

### DIFF
--- a/src/components/domain/master/ClientFormModal.vue
+++ b/src/components/domain/master/ClientFormModal.vue
@@ -20,7 +20,6 @@ const props = defineProps({
   paymentTerms: { type: Array, default: () => [] },
   departments: { type: Array, default: () => [] },
   teams: { type: Array, default: () => [] },
-  defaultDepartmentId: { type: [Number, String], default: null },
   defaultTeamId: { type: [Number, String], default: null },
   lockTeam: { type: Boolean, default: false },
   allClients: { type: Array, default: () => [] },
@@ -94,30 +93,25 @@ function getInitialForm() {
     buyerPosition: '',
     buyerEmail: '',
     buyerTel: '',
-    departmentId: null,
     teamId: null,
-    status: 'active',
     sealImageUrl: '',
     sealImage: null,
   }
 }
 
+// 백엔드는 teamId 만 저장하므로 UI 도 담당 팀 단일 드롭다운으로 단순화.
+// 라벨은 "부서명 · 팀명" 형태로 조합해서 부서 구분도 동시 노출.
 const teamOptions = computed(() => {
-  const filtered = form.value.departmentId
-    ? props.teams.filter((t) => String(t.departmentId) === String(form.value.departmentId))
-    : props.teams
-  return filtered.map((t) => ({ label: t.teamName, value: t.teamId }))
-})
-
-const departmentOptions = computed(() =>
-  props.departments.map((d) => ({ label: d.departmentName ?? d.name, value: d.departmentId ?? d.id })),
-)
-
-watch(() => form.value.departmentId, (deptId) => {
-  const team = props.teams.find((t) => String(t.teamId) === String(form.value.teamId))
-  if (team && String(team.departmentId) !== String(deptId)) {
-    form.value.teamId = null
-  }
+  const deptMap = new Map(
+    props.departments.map((d) => [String(d.departmentId ?? d.id), d.departmentName ?? d.name]),
+  )
+  return props.teams.map((t) => {
+    const deptName = deptMap.get(String(t.departmentId))
+    return {
+      label: deptName ? `${deptName} · ${t.teamName}` : t.teamName,
+      value: t.teamId,
+    }
+  })
 })
 
 watch(
@@ -132,9 +126,6 @@ watch(
       const resolvedPortId = props.client.portId
         ?? props.ports.find((p) => p.portName === props.client.portName)?.id
         ?? null
-      const resolvedTeamId = props.client.teamId ?? null
-      const teamMatch = props.teams.find((t) => String(t.teamId) === String(resolvedTeamId))
-      const resolvedDeptId = teamMatch?.departmentId ?? props.client.departmentId ?? null
       form.value = {
         code: props.client.clientCode ?? '',
         name: props.client.clientName ?? '',
@@ -148,9 +139,7 @@ watch(
         paymentTermsId: props.client.paymentTermId ?? props.client.paymentTermsId ?? null,
         currencyId: props.client.currencyId ?? null,
         manager: props.client.clientManager ?? '',
-        departmentId: resolvedDeptId,
-        teamId: resolvedTeamId,
-        status: props.client.clientStatus ?? 'active',
+        teamId: props.client.teamId ?? null,
         sealImageUrl: props.client.sealImageUrl ?? '',
         sealImage: null,
       }
@@ -159,7 +148,6 @@ watch(
       form.value.code = generateNextCode()
       // 작성자(현재 로그인 사용자) 팀으로 기본값 채움
       if (props.defaultTeamId) form.value.teamId = props.defaultTeamId
-      if (props.defaultDepartmentId) form.value.departmentId = props.defaultDepartmentId
     }
   },
 )
@@ -250,10 +238,6 @@ function validate() {
 
   if (!form.value.currencyId) {
     e.currencyId = '통화를 선택하세요.'
-  }
-
-  if (!form.value.departmentId) {
-    e.departmentId = '담당 부서를 선택하세요.'
   }
 
   if (!form.value.teamId) {
@@ -421,21 +405,12 @@ function handleSave() {
           </span>
         </h4>
         <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
-          <FormField label="담당 부서" required>
-            <BaseSelect
-              v-model="form.departmentId"
-              :options="departmentOptions"
-              :disabled="lockTeam"
-              placeholder="부서를 선택하세요"
-            />
-            <p v-if="errors.departmentId" class="mt-1 text-xs text-red-500">{{ errors.departmentId }}</p>
-          </FormField>
           <FormField label="담당 팀" required>
             <BaseSelect
               v-model="form.teamId"
               :options="teamOptions"
-              :disabled="lockTeam || !form.departmentId"
-              :placeholder="form.departmentId ? '팀을 선택하세요' : '부서를 먼저 선택하세요'"
+              :disabled="lockTeam"
+              placeholder="부서 · 팀을 선택하세요"
             />
             <p v-if="errors.teamId" class="mt-1 text-xs text-red-500">{{ errors.teamId }}</p>
           </FormField>

--- a/src/views/master/ClientListPage.vue
+++ b/src/views/master/ClientListPage.vue
@@ -388,7 +388,6 @@ function goToDetail(row) {
       :payment-terms="paymentTerms"
       :departments="departments"
       :teams="teams"
-      :default-department-id="currentUser?.departmentId ?? null"
       :default-team-id="currentUser?.teamId ?? null"
       :lock-team="!isAdmin"
       :all-clients="clients"


### PR DESCRIPTION
## 📋 작업 내용

거래처 등록/수정 모달(\`ClientFormModal.vue\`)의 담당 부서 / 담당 팀 두 개 드롭다운을 **담당 팀 단일 드롭다운**으로 통합.

### 문제
- 백엔드 payload 는 \`teamId\` 만 전송 → 부서 드롭다운은 프론트 전용 \"팀 필터\" 역할의 중복 UI.
- form 에 \`departmentId\` / \`status\` 같은 쓰이지 않는 dead state 필드가 남아 있음.

### 수정
- **단일 드롭다운** — \`teamOptions\` 라벨을 \`부서명 · 팀명\` (\`영업부 · 영업1팀\`) 조합으로 변경해 부서 가시성 유지.
- 담당 부서 \`FormField\` / \`departmentOptions\` computed / 부서 변경 시 팀 리셋 watch / \`form.departmentId\` / \`defaultDepartmentId\` prop 제거.
- 호출부 \`ClientListPage.vue\` 의 \`:default-department-id\` prop 전달도 같이 정리.
- 죽은 \`status\` 필드 제거 — \`ClientCommandService.java:48\` 가 생성 시 \`ClientStatus.ACTIVE\` 하드코딩이므로 UI 에서 상태를 다룰 필요 없음.

## 🔗 관련 이슈

- closes #361

## ✅ 체크리스트

- [x] 정상 동작 확인 (코드 리뷰)
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

- \`departments\` prop 은 여전히 라벨 조회용으로 사용됨 (\`teamOptions\` 에서 departmentName 매핑). 호출부에서 계속 전달.
- 사용자 등록 폼(\`UserFormModal\`)의 부서/팀 통합은 별도 이슈(C-2)로 분리 — 사용자는 User→Team→Department 구조가 달라 별도 판단 필요.