### PR TITLE
fix: 사용자 등록 role 값 대문자 정규화 (#363)

### DIFF
--- a/src/components/domain/auth/UserListTab.vue
+++ b/src/components/domain/auth/UserListTab.vue
@@ -201,7 +201,7 @@ async function handleSave(formData) {
         name: formData.name,
         email: formData.email,
         password: 'password123',
-        role: formData.role,
+        role: String(formData.role).toUpperCase(),
       }
       await createUser(newUser)
       success('사용자가 등록되었습니다.')


### PR DESCRIPTION
## Summary
- 사용자 등록 POST payload 의 role 을 `toUpperCase()` 로 정규화
- backend Role enum (ADMIN/SALES/PRODUCTION/SHIPPING) 역직렬화 실패 해소

## 원인
- `UserFormModal.vue` 의 roleOptions value 가 소문자(sales 등)
- `UserListTab.vue:204` 에서 role 을 그대로 전송 → backend 400

## 변경
- `UserListTab.vue` handleSave create 분기에서 `String(formData.role).toUpperCase()` 로 변환 후 createUser 호출

## Test plan
- [ ] 관리자로 로그인 → 사용자 관리 → 신규 등록
- [ ] 역할 "영업" 선택 후 저장 → 201 정상 생성 확인
- [ ] 다른 역할(생산/출하/관리자) 도 정상 생성 확인
- [ ] 편집 모드 정상 동작 (role 전송 안 함)

closes #363

🤖 Generated with [Claude Code](https://claude.com/claude-code)