### PR TITLE
fix: 활동기록 등록 실패 + 작성자 필드 고정 (#364)

### DIFF
--- a/src/views/activity/ActivityCreatePage.vue
+++ b/src/views/activity/ActivityCreatePage.vue
@@ -30,7 +30,7 @@ const formDate = ref(new Date().toISOString().slice(0, 10))
 const formPriority = ref('medium')
 const formTitle = ref('')
 const formContent = ref('')
-const formAuthor = ref('')
+const formAuthor = ref(authStore.currentUser?.userName ?? '')
 const errors = ref({})
 
 watch(formClient, (val, oldVal) => {
@@ -39,13 +39,11 @@ watch(formClient, (val, oldVal) => {
   if (oldVal !== undefined && val !== oldVal) {
     formPoDisplay.value = ''
     formPoId.value = ''
-    formAuthor.value = ''
   }
 })
 watch(formType,   (val) => { if (val) errors.value.type   = undefined })
 watch(formDate,   (val) => { if (val) errors.value.date   = undefined })
 watch(formTitle,  (val) => { if (val.trim()) errors.value.title  = undefined })
-watch(formAuthor, (val) => { if (val.trim()) errors.value.author = undefined })
 
 // ── options ────────────────────────────────────────────────
 const clientOptions = ref([])
@@ -61,10 +59,10 @@ onMounted(async () => {
 })
 
 const typeOptions = [
-  { label: '미팅/협의', value: '미팅/협의' },
-  { label: '이슈', value: '이슈' },
-  { label: '메모/노트', value: '메모/노트' },
-  { label: '일정', value: '일정' },
+  { label: '미팅/협의', value: 'meeting' },
+  { label: '이슈', value: 'issue' },
+  { label: '메모/노트', value: 'memo' },
+  { label: '일정', value: 'schedule' },
 ]
 
 const priorityOptions = [
@@ -73,9 +71,8 @@ const priorityOptions = [
 ]
 
 // ── computed ───────────────────────────────────────────────
-const isIssue    = computed(() => formType.value === '이슈')
-const isSchedule = computed(() => formType.value === '일정')
-const isAuthorLocked = computed(() => !!formPoDisplay.value)
+const isIssue    = computed(() => formType.value === 'issue')
+const isSchedule = computed(() => formType.value === 'schedule')
 
 // ── 일정 기간 선택 ─────────────────────────────────────────
 const formScheduleFrom = ref('')
@@ -83,7 +80,7 @@ const formScheduleTo   = ref('')
 
 // 일정 유형 해제 시 기간 초기화
 watch(formType, (val) => {
-  if (val !== '일정') {
+  if (val !== 'schedule') {
     formScheduleFrom.value = ''
     formScheduleTo.value   = ''
   }
@@ -217,14 +214,12 @@ async function openPoSearch() {
 function selectPO(po) {
   formPoDisplay.value = po.poId
   formPoId.value = po.poId
-  formAuthor.value = authStore.currentUser?.userName ?? ''
   isPoSearchOpen.value = false
 }
 
 function clearPo() {
   formPoDisplay.value = ''
   formPoId.value = ''
-  formAuthor.value = ''
 }
 
 function validate() {
@@ -334,9 +329,8 @@ async function handleSubmit() {
           <FormField label="작성자" :required="true" :error="errors.author">
             <BaseTextField
               v-model="formAuthor"
-              :placeholder="isAuthorLocked ? '' : 'PO 선택 시 자동 입력됩니다'"
-              :readonly="isAuthorLocked"
-              :class="isAuthorLocked ? 'cursor-not-allowed bg-slate-50 text-slate-500' : ''"
+              readonly
+              class="cursor-not-allowed bg-slate-50 text-slate-500"
             />
           </FormField>
         </div>


### PR DESCRIPTION
## Summary
- 활동기록 등록 시 `activityType` 매핑 실패 해소 — 한글 라벨 대신 backend displayName(`meeting`/`issue`/`memo`/`schedule`) 전송
- 작성자 필드를 로그인 사용자로 자동 채우고 readonly 고정 (수동 편집 불필요)

## 원인
- `ActivityCreatePage.vue:63-68` typeOptions value 가 한글 라벨(`미팅/협의` 등) → backend `ActivityType.from()` 이 displayName 기대 → 404 Unknown ActivityType
- `ActivityCreatePage.vue:334-341` 작성자 필드가 PO 선택 시에만 자동 채워지고 그 외엔 수동 편집 상태

## 변경
- typeOptions value 를 enum displayName 으로 교체
- isIssue/isSchedule 비교값을 신규 enum 코드로 갱신
- 일정 유형 해제 시 기간 초기화 watch 조건 갱신
- formAuthor 초기값을 `authStore.currentUser.userName` 로 설정
- 템플릿에서 작성자 필드를 항상 readonly + 회색 배경으로 고정
- PO 선택/해제 시 formAuthor 변경 로직 제거 (초기값이 이미 본인)

## Test plan
- [ ] 영업 계정 로그인 → 활동기록 → 신규 등록
- [ ] 작성자 필드에 로그인 사용자 이름이 자동 채워지고 편집 불가인지 확인
- [ ] 유형 "미팅/협의" 선택 → 저장 → 201 정상 생성
- [ ] 유형 "이슈" 선택 시 우선순위 필드 표시 확인
- [ ] 유형 "일정" 선택 시 기간 선택 UI 표시 확인
- [ ] 유형 변경 시 기간 선택값 초기화 확인

## 관련
backend-activity `ActivityType.from()` 을 case-insensitive + enum name 수락으로 확장하면 edit 경로 에서도 안전해짐 (별도 main 직접 수정 예정).

closes #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)