### PR TITLE
fix: PI 생성 시 환율 미로드 상태 저장 차단 (#367)

### DIFF
--- a/src/views/documents/PIPage.vue
+++ b/src/views/documents/PIPage.vue
@@ -862,6 +862,14 @@ async function handleSave(formValue) {
   }
 
   if (formMode.value === 'create') {
+    // 외화 선택 시 환율 데이터가 준비되지 않았다면 제출 차단
+    // (환율 CDN 응답 전에 저장하면 exchangeRate=null 로 전송되어 백엔드 400)
+    const currencyCode = formValue.currency || 'USD'
+    if (currencyCode !== 'KRW' && !getKrwRate(currencyCode)) {
+      warning(`${currencyCode} 환율 정보가 준비되지 않았습니다. 잠시 후 다시 시도해주세요.`)
+      return
+    }
+
     if (isTeamLeader.value) {
       // 팀장 셀프 등록: 백엔드가 MANAGER 권한 기준으로 즉시 확정 처리
       try {


### PR DESCRIPTION
## Summary
- PI 생성 저장 시 외화 통화에서 환율 데이터가 준비되지 않았으면 warning 토스트로 안내하고 제출 차단
- QA 9차에서 팀장 계정이 관측한 저장 실패(실제로는 백엔드 400) 경로 해소

## 원인
- `PIPage.vue:570` buildCreatePayload 에서 `!krwRate` 일 때 `exchangeRate: null` 로 전송
- 백엔드는 외화 PI 생성 시 exchangeRate 필수 검증 → 400 응답
- 환율 API(fawazahmed CDN) 응답이 느린 네트워크에서는 mount 직후 즉시 저장 시 미로드 상태

## 변경
- `PIPage.vue` handleSave create 분기 진입 직후 currencyCode 가 KRW 가 아닌데 getKrwRate 가 null 이면:
  - warning 토스트 "USD 환율 정보가 준비되지 않았습니다. 잠시 후 다시 시도해주세요."
  - return 하여 제출 차단
- 팀장 셀프 등록 / 비-팀장 결재 요청 양쪽 모두 동일 가드 적용

## Test plan
- [ ] PI 관리 페이지 진입 → 빠르게 거래처 선택 → 통화 USD 로 즉시 저장 시도
  - 환율 로드 완료 전이면 warning 토스트 표시 + 저장 차단 확인
- [ ] 환율 힌트 "1 USD = ... KRW" 표시 후 저장 → 정상 201
- [ ] 통화 KRW 는 가드 우회해 정상 저장 확인
- [ ] 네트워크 DevTools 로 환율 API 차단한 상태에서 외화 저장 시도 → 안내 후 차단 확인

## 관련
QA 9차 B-4 리포트에서 "401" 로 기재됐으나 curl 재현 결과 백엔드는 정상이며 exchangeRate 누락 시 400 반환. 실제 관측 status code 재확인 요청하되, 가장 유력한 root cause 에 대한 FE 가드를 선행 적용.

closes #367

🤖 Generated with [Claude Code](https://claude.com/claude-code)