### PR TITLE
fix: QA 9차 FAIL 4건 수정 (A-1, A-2, B-3, C-2)

### DIFF
--- a/src/components/domain/auth/UserFormModal.vue
+++ b/src/components/domain/auth/UserFormModal.vue
@@ -31,8 +31,6 @@ const showResetConfirm = ref(false)
 
 const roleOptions = [
   { label: '영업', value: 'sales' },
-  { label: '생산', value: 'production' },
-  { label: '출하', value: 'shipping' },
   { label: '관리자', value: 'admin' },
 ]
 
@@ -88,19 +86,19 @@ watch(
   },
 )
 
-// 부서 변경 시 팀 초기화 (매칭 안 되는 팀이면)
-watch(() => form.value.departmentId, (deptId) => {
-  const team = props.teams.find((t) => String(t.teamId) === String(form.value.teamId))
-  if (team && String(team.departmentId) !== String(deptId)) {
-    form.value.teamId = ''
-  }
+// 부서+팀 통합 옵션: "부서명 > 팀명" 형식으로 teamId 에 직접 매핑
+const teamOptionsGrouped = computed(() => {
+  const deptMap = new Map(props.departments.map((d) => [String(d.departmentId ?? d.id), d.departmentName ?? d.name]))
+  return props.teams.map((t) => {
+    const deptName = deptMap.get(String(t.departmentId)) ?? ''
+    return { label: deptName ? `${deptName} > ${t.teamName}` : t.teamName, value: String(t.teamId) }
+  })
 })
 
-const teamOptions = computed(() => {
-  const filtered = form.value.departmentId
-    ? props.teams.filter((t) => String(t.departmentId) === String(form.value.departmentId))
-    : props.teams
-  return filtered.map((t) => ({ label: t.teamName, value: String(t.teamId) }))
+// teamId 변경 시 departmentId 자동 파생 (내부용)
+watch(() => form.value.teamId, (teamId) => {
+  const team = props.teams.find((t) => String(t.teamId) === String(teamId))
+  form.value.departmentId = team ? String(team.departmentId) : ''
 })
 
 function validate() {
@@ -123,8 +121,7 @@ function validate() {
 
   if (!form.value.positionId) e.positionId = '직급을 선택해주세요.'
   if (!form.value.role) e.role = '역할을 선택해주세요.'
-  if (!form.value.departmentId) e.departmentId = '부서를 선택해주세요.'
-  if (!form.value.teamId) e.teamId = '팀을 선택해주세요.'
+  if (!form.value.teamId) e.teamId = '소속을 선택해주세요.'
 
   errors.value = e
   return Object.keys(e).length === 0
@@ -188,20 +185,11 @@ const currentTeamName = computed(() => {
           <BaseSelect v-model="form.role" :options="roleOptions" placeholder="역할을 선택하세요" />
         </FormField>
 
-        <FormField label="부서" required :error="errors.departmentId">
-          <BaseSelect
-            v-model="form.departmentId"
-            :options="departments.map((d) => ({ label: d.departmentName ?? d.name, value: String(d.departmentId ?? d.id) }))"
-            placeholder="부서를 선택하세요"
-          />
-        </FormField>
-
-        <FormField label="팀" required :error="errors.teamId">
+        <FormField label="소속" required :error="errors.teamId">
           <BaseSelect
             v-model="form.teamId"
-            :options="teamOptions"
-            :placeholder="form.departmentId ? '팀을 선택하세요' : '먼저 부서를 선택하세요'"
-            :disabled="!form.departmentId"
+            :options="teamOptionsGrouped"
+            placeholder="소속을 선택하세요"
           />
         </FormField>
 

--- a/src/components/domain/auth/UserListTab.vue
+++ b/src/components/domain/auth/UserListTab.vue
@@ -202,6 +202,8 @@ async function handleSave(formData) {
         email: formData.email,
         password: 'password123',
         role: String(formData.role).toUpperCase(),
+        teamId: formData.teamId ? Number(formData.teamId) : undefined,
+        positionId: formData.positionId ? Number(formData.positionId) : undefined,
       }
       await createUser(newUser)
       success('사용자가 등록되었습니다.')

--- a/src/views/activity/ActivityCreatePage.vue
+++ b/src/views/activity/ActivityCreatePage.vue
@@ -242,10 +242,15 @@ async function handleSubmit() {
   isSubmitting.value = true
   try {
     await createActivity({
-      clientId:     formClient.value,
-      activityType: formType.value,
-      activityDate: formDate.value,
-      activityTitle: formTitle.value,
+      clientId:             formClient.value,
+      activityType:         formType.value,
+      activityDate:         formDate.value,
+      activityTitle:        formTitle.value,
+      activityContent:      isSchedule.value ? formTitle.value : formContent.value,
+      poId:                 formPoId.value || undefined,
+      activityPriority:     isIssue.value ? formPriority.value : undefined,
+      activityScheduleFrom: isSchedule.value ? formScheduleFrom.value : undefined,
+      activityScheduleTo:   isSchedule.value ? formScheduleTo.value : undefined,
     })
     router.push('/activities')
   } catch (e) {

--- a/src/views/documents/POPage.vue
+++ b/src/views/documents/POPage.vue
@@ -1165,7 +1165,7 @@ function handleProductSelect(product) {
       :document="selectedRow"
       :selected-pi="selectedPi"
       :selected-client="selectedClient"
-      @open-pi-search="piSearchOpen = true"
+      @open-pi-search="loadPoDocuments().then(() => { piSearchOpen = true })"
       @open-client-search="openClientSearch('form')"
       @close="closeForm"
       @save="handleSave"


### PR DESCRIPTION
## 📋 작업 내용

QA 9차 검증에서 FAIL 판정된 4건 수정

- **A-1**: `roleOptions`에서 production/shipping 제거 → 영업/관리자만 노출
- **A-2**: PI 검색 모달 오픈 전 `loadPoDocuments()` await → PO 데이터 타이밍 이슈 해소
- **B-3**: `createActivity` 페이로드에 `poId`, `activityContent`, `activityPriority`, `activityScheduleFrom/To` 추가
- **C-2**: 부서+팀 2개 드롭다운 → "소속" 단일 드롭다운 통합 (`부서명 > 팀명` 형식) + `createUser`에 `teamId`/`positionId` 포함

## 🔗 관련 이슈

- closes #371

## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

- B-3 수정은 백엔드(`team2-backend-activity`) ActivityCreateRequest DTO 변경과 함께 적용 필요 (poId/@NotBlank 제거, schedule/@NotNull 제거, activityContent/activityPriority 필드 추가). 백엔드는 main 직접 푸시 예정.
- C-2: departmentId는 form 내부에서 teamId로부터 자동 파생되며, 실제 API에는 teamId만 전송됩니다.