### PR TITLE
fix: 문서 상태별 버튼 라벨/조건 + CI/PL 상태 컬럼

### DIFF
--- a/src/views/documents/CIPage.vue
+++ b/src/views/documents/CIPage.vue
@@ -5,6 +5,7 @@ import { useRouter } from 'vue-router'
 import BaseButton from '@/components/common/BaseButton.vue'
 import BasePagination from '@/components/common/BasePagination.vue'
 import BaseTable from '@/components/common/BaseTable.vue'
+import StatusBadge from '@/components/common/StatusBadge.vue'
 import CollapsibleFilterCard from '@/components/common/CollapsibleFilterCard.vue'
 import DateField from '@/components/common/DateField.vue'
 import FilterToolbarCard from '@/components/common/FilterToolbarCard.vue'
@@ -58,6 +59,7 @@ const columns = [
   { key: 'country', label: '국가', align: 'center', width: '120px' },
   { key: 'itemName', label: '품목명', align: 'left', width: '220px' },
   { key: 'amount', label: '총액', align: 'right', width: '140px' },
+  { key: 'status', label: '상태', align: 'center', width: '120px' },
   { key: 'actions', label: '', align: 'center', width: '120px', sortable: false },
 ]
 
@@ -343,6 +345,10 @@ function handleProductSelect(row) {
         <button type="button" class="font-mono text-xs font-semibold text-brand-600 hover:underline" @click.stop="goToDetail(value)">
           {{ value }}
         </button>
+      </template>
+
+      <template #cell-status="{ value }">
+        <StatusBadge :value="value" />
       </template>
 
       <template #cell-actions="{ row }">

--- a/src/views/documents/PIDetailPage.vue
+++ b/src/views/documents/PIDetailPage.vue
@@ -733,17 +733,17 @@ function cancelDeleteApprovalRequest() {
     <div class="mb-6">
       <DetailPageHeader :title="detail.id" :status="detail.status" @back="goBack">
         <template #actions>
-          <BaseButton v-if="!shipmentLockInfo.locked" size="sm" @click="handleEdit">
+          <BaseButton v-if="!shipmentLockInfo.locked && detail.status !== '결재대기'" size="sm" @click="handleEdit">
             <template #leading>
               <i class="fas fa-edit text-xs" aria-hidden="true"></i>
             </template>
-            수정
+            {{ detail.status === '확정' ? '수정요청' : '수정' }}
           </BaseButton>
-          <BaseButton v-if="!shipmentLockInfo.locked" variant="secondary" size="sm" @click="handleDelete">
+          <BaseButton v-if="!shipmentLockInfo.locked && detail.status !== '결재대기'" variant="secondary" size="sm" @click="handleDelete">
             <template #leading>
               <i class="fas fa-trash text-xs" aria-hidden="true"></i>
             </template>
-            삭제
+            {{ detail.status === '확정' ? '삭제요청' : '삭제' }}
           </BaseButton>
           <BaseButton variant="secondary" size="sm" @click="openPreview">
             <template #leading>

--- a/src/views/documents/PLPage.vue
+++ b/src/views/documents/PLPage.vue
@@ -5,6 +5,7 @@ import { useRouter } from 'vue-router'
 import BaseButton from '@/components/common/BaseButton.vue'
 import BasePagination from '@/components/common/BasePagination.vue'
 import BaseTable from '@/components/common/BaseTable.vue'
+import StatusBadge from '@/components/common/StatusBadge.vue'
 import CollapsibleFilterCard from '@/components/common/CollapsibleFilterCard.vue'
 import DateField from '@/components/common/DateField.vue'
 import DocumentPreviewModal from '@/components/domain/document/DocumentPreviewModal.vue'
@@ -57,6 +58,7 @@ const columns = [
   { key: 'country', label: '국가', align: 'center', width: '120px' },
   { key: 'itemName', label: '품목명', align: 'left', width: '220px' },
   { key: 'grossWeight', label: '총중량(kg)', align: 'right', width: '150px' },
+  { key: 'status', label: '상태', align: 'center', width: '120px' },
   { key: 'actions', label: '', align: 'center', width: '120px', sortable: false },
 ]
 
@@ -339,6 +341,10 @@ function handleProductSelect(row) {
         <button type="button" class="font-mono text-xs font-semibold text-brand-600 hover:underline" @click.stop="goToDetail(value)">
           {{ value }}
         </button>
+      </template>
+
+      <template #cell-status="{ value }">
+        <StatusBadge :value="value" />
       </template>
 
       <template #cell-actions="{ row }">

--- a/src/views/documents/PODetailPage.vue
+++ b/src/views/documents/PODetailPage.vue
@@ -851,7 +851,7 @@ function cancelDeleteApprovalRequest() {
       <DetailPageHeader :title="detail.id" :status="detail.status" @back="goBack">
         <template #actions>
           <BaseButton
-            v-if="canIssueProductionOrder"
+            v-if="canIssueProductionOrder && detail.status !== '결재대기'"
             variant="secondary"
             size="sm"
             @click="openProductionIssueConfirm"
@@ -861,17 +861,17 @@ function cancelDeleteApprovalRequest() {
             </template>
             생산지시서 발행
           </BaseButton>
-          <BaseButton v-if="!shipmentLockInfo.locked" size="sm" @click="handleEdit">
+          <BaseButton v-if="!shipmentLockInfo.locked && detail.status !== '결재대기'" size="sm" @click="handleEdit">
             <template #leading>
               <i class="fas fa-edit text-xs" aria-hidden="true"></i>
             </template>
-            수정
+            {{ detail.status === '확정' ? '수정요청' : '수정' }}
           </BaseButton>
-          <BaseButton v-if="!shipmentLockInfo.locked" variant="secondary" size="sm" @click="handleDelete">
+          <BaseButton v-if="!shipmentLockInfo.locked && detail.status !== '결재대기'" variant="secondary" size="sm" @click="handleDelete">
             <template #leading>
               <i class="fas fa-trash text-xs" aria-hidden="true"></i>
             </template>
-            삭제
+            {{ detail.status === '확정' ? '삭제요청' : '삭제' }}
           </BaseButton>
           <BaseButton variant="secondary" size="sm" @click="openPreview">
             <template #leading>


### PR DESCRIPTION
## 📋 작업 내용

QA 10차 FAIL 5건 수정 (E-1, E-3, E-5, E-10)

- **E-1/E-3**: PI/PO 상세 페이지 버튼 상태 분기
  - 초안: "수정", "삭제" (직접 편집)
  - 확정: "수정요청", "삭제요청" (결재 플로우)
  - 결재대기: 수정/삭제/생산지시서 발행 숨김 (미리보기/PDF만)
- **E-5/E-10**: CI/PL 목록 페이지에 상태 컬럼 + StatusBadge 추가

## 🔗 관련 이슈

- closes #375

## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

- E-2(초안 PI 등록요청)는 현재 PIPage(목록)에서만 구현되어 있고, PIDetailPage에는 없음. 상세 페이지에 등록요청 추가하려면 별도 작업 필요.
- A-2(PI 중복선택)는 필터 로직이 코드상 정상이나 데이터 타이밍 이슈로 재현됨 — 추가 조사 필요.