### PR TITLE
fix: 활동기록 CRUD — 수정 id 누락/유형 한글화/우선순위/중복요청

### DIFF
--- a/src/components/domain/activity/ActivityEditModal.vue
+++ b/src/components/domain/activity/ActivityEditModal.vue
@@ -7,6 +7,7 @@ import BaseTextarea from '@/components/common/BaseTextarea.vue'
 import BaseTextField from '@/components/common/BaseTextField.vue'
 import DateField from '@/components/common/DateField.vue'
 import FormField from '@/components/common/FormField.vue'
+import BaseSelect from '@/components/common/BaseSelect.vue'
 import { useToast } from '@/composables/useToast'
 
 const props = defineProps({
@@ -23,15 +24,23 @@ const props = defineProps({
 const emit = defineEmits(['close', 'save'])
 const { warning } = useToast()
 
+const priorityOptions = [
+  { label: '보통', value: 'medium' },
+  { label: '높음', value: 'high' },
+]
+
 // ── 폼 상태 ────────────────────────────────────────────────
 const formDate         = ref('')
 const formTitle        = ref('')
 const formContent      = ref('')
+const formPriority     = ref('')
 const formScheduleFrom = ref('')
 const formScheduleTo   = ref('')
 const errors           = ref({})
 
-const isSchedule = computed(() => props.activity?.type === '일정')
+const activityType = computed(() => props.activity?.type ?? props.activity?.activityType ?? '')
+const isSchedule = computed(() => activityType.value === '일정' || activityType.value === 'schedule')
+const isIssue    = computed(() => activityType.value === '이슈' || activityType.value === 'issue')
 
 // ── 달력 (range picker) — watch 보다 먼저 선언 ────────────
 const calYear  = ref(new Date().getFullYear())
@@ -117,6 +126,7 @@ function initForm(val) {
   formDate.value         = (val?.date         ?? '').replaceAll('/', '-')
   formTitle.value        = val?.title        ?? ''
   formContent.value      = val?.content      ?? ''
+  formPriority.value     = val?.priority     ?? val?.activityPriority ?? 'medium'
   formScheduleFrom.value = (val?.scheduleFrom ?? '').replaceAll('/', '-')
   formScheduleTo.value   = (val?.scheduleTo   ?? '').replaceAll('/', '-')
   errors.value           = {}
@@ -158,11 +168,11 @@ function handleSave() {
   }
   emit('save', {
     activityDate:         formDate.value,
-    activityType:         props.activity.type ?? props.activity.activityType,
+    activityType:         activityType.value,
     activityTitle:        formTitle.value,
     activityContent:      isSchedule.value ? formTitle.value : formContent.value,
     poId:                 props.activity.poId,
-    activityPriority:     props.activity.priority ?? props.activity.activityPriority ?? undefined,
+    activityPriority:     isIssue.value ? formPriority.value : undefined,
     activityScheduleFrom: isSchedule.value ? formScheduleFrom.value : undefined,
     activityScheduleTo:   isSchedule.value ? formScheduleTo.value   : undefined,
   })
@@ -199,6 +209,12 @@ function handleSave() {
         </p>
         <BaseTextField v-model="formTitle" placeholder="활동 제목을 입력하세요" />
         <p v-if="errors.title" class="mt-1 text-xs text-red-500">{{ errors.title }}</p>
+      </div>
+
+      <!-- 우선순위 (이슈일 때만) -->
+      <div v-if="isIssue" class="space-y-1.5">
+        <p class="text-sm font-semibold text-slate-700">우선순위</p>
+        <BaseSelect v-model="formPriority" :options="priorityOptions" />
       </div>
 
       <!-- 내용 (일정이 아닐 때) -->

--- a/src/components/domain/activity/ActivityTypeBadge.vue
+++ b/src/components/domain/activity/ActivityTypeBadge.vue
@@ -8,15 +8,22 @@ const props = defineProps({
   },
 })
 
+const labelMap = {
+  meeting: '미팅/협의',
+  issue: '이슈',
+  memo: '메모/노트',
+  schedule: '일정',
+}
+
 const variantMap = {
   '미팅/협의': 'bg-sky-50 text-sky-700 border-sky-200',
   '메모/노트': 'bg-slate-100 text-slate-700 border-slate-200',
   '이슈': 'bg-rose-50 text-rose-700 border-rose-200',
-
   '일정': 'bg-amber-50 text-amber-700 border-amber-200',
 }
 
-const badgeClasses = computed(() => variantMap[props.value] || 'bg-slate-100 text-slate-700 border-slate-200')
+const displayLabel = computed(() => labelMap[props.value] ?? props.value)
+const badgeClasses = computed(() => variantMap[displayLabel.value] || 'bg-slate-100 text-slate-700 border-slate-200')
 </script>
 
 <template>
@@ -24,6 +31,6 @@ const badgeClasses = computed(() => variantMap[props.value] || 'bg-slate-100 tex
     class="inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-semibold"
     :class="badgeClasses"
   >
-    {{ value }}
+    {{ displayLabel }}
   </span>
 </template>

--- a/src/views/activity/ActivityListPage.vue
+++ b/src/views/activity/ActivityListPage.vue
@@ -33,10 +33,10 @@ const filterType = ref('')
 const filterTitle = ref('')
 
 const typeOptions = [
-  { label: '미팅/협의', value: '미팅/협의' },
-  { label: '이슈', value: '이슈' },
-  { label: '메모/노트', value: '메모/노트' },
-  { label: '일정', value: '일정' },
+  { label: '미팅/협의', value: 'meeting' },
+  { label: '이슈', value: 'issue' },
+  { label: '메모/노트', value: 'memo' },
+  { label: '일정', value: 'schedule' },
 ]
 
 const authorOptions = computed(() => {
@@ -156,15 +156,23 @@ function closeEdit() {
   editActivity.value = null
 }
 
+const isSaving = ref(false)
+
 async function handleSave(updated) {
+  if (isSaving.value) return
+  const activityId = editActivity.value?.id
+  if (!activityId) return
+  isSaving.value = true
   try {
-    await updateActivity(updated.id, updated)
-    const idx = activities.value.findIndex((a) => a.id === updated.id)
-    if (idx !== -1) activities.value[idx] = updated
+    await updateActivity(activityId, updated)
+    const idx = activities.value.findIndex((a) => a.id === activityId)
+    if (idx !== -1) activities.value[idx] = { ...activities.value[idx], ...updated }
     closeEdit()
   } catch (e) {
     console.error('기록 수정 실패', e)
     error('기록 수정에 실패했습니다. 다시 시도해주세요.')
+  } finally {
+    isSaving.value = false
   }
 }
 
@@ -182,9 +190,13 @@ function closeDelete() {
   deleteTarget.value = null
 }
 
+const isDeleting = ref(false)
+
 async function handleDelete() {
+  if (isDeleting.value) return
   const targetId = deleteTarget.value?.id
   if (!targetId) return
+  isDeleting.value = true
   try {
     await deleteActivity(targetId)
     activities.value = activities.value.filter((a) => a.id !== targetId)
@@ -192,6 +204,8 @@ async function handleDelete() {
   } catch (e) {
     console.error('기록 삭제 실패', e)
     error('기록 삭제에 실패했습니다. 다시 시도해주세요.')
+  } finally {
+    isDeleting.value = false
   }
 }
 


### PR DESCRIPTION
## 📋 작업 내용

활동기록 CRUD QA FAIL 5건 수정

| FAIL | 수정 내용 |
|------|----------|
| F-9 (Critical) | `handleSave`에서 `updated.id` → `editActivity.value.id` 사용. PUT /api/activities/undefined 해소 |
| F-7 | `ActivityTypeBadge`에 영문→한글 `labelMap` 추가 (meeting→미팅/협의 등). 목록 필터 `typeOptions`도 영문코드로 통일 |
| F-8 | F-7과 동일 (배지 한글화로 상세 모달도 자동 해결) |
| F-10 | `ActivityEditModal`에 이슈 우선순위(`BaseSelect`) 추가 + `formPriority` 초기화/emit 반영 |
| 중복요청 | `handleSave`/`handleDelete`에 `isSaving`/`isDeleting` ref 가드 추가 |

## 🔗 관련 이슈

- closes #377

## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

- F-8 상세 모달에서 일정 기간/이슈 우선순위 표시는 `ActivityDetailModal` 수정이 추가로 필요할 수 있음 (이번 PR은 수정 모달만 대상)
- 영업 role 거래처 조회 0건 이슈는 별도 백엔드 권한 조사 필요 (이번 PR 범위 밖)