### PR TITLE
fix: 팀장 즉시 처리 프론트 분기 제거 — 결재 플로우 통일

### DIFF
--- a/src/views/documents/PIDetailPage.vue
+++ b/src/views/documents/PIDetailPage.vue
@@ -540,18 +540,6 @@ async function handleDelete() {
     return
   }
 
-  if (isTeamLeader.value) {
-    try {
-      const userId = authStore.currentUser?.userId
-      await requestPiDeletion({ piId: sourceRow.value.id, userId })
-      await loadPiDocuments()
-      success(`${sourceRow.value.id} PI가 삭제되었습니다.`)
-    } catch (e) {
-      error(e.response?.data?.message || '삭제 처리 중 오류가 발생했습니다.')
-    }
-    return
-  }
-
   deleteApprovalRequestOpen.value = true
 }
 

--- a/src/views/documents/PIPage.vue
+++ b/src/views/documents/PIPage.vue
@@ -870,22 +870,6 @@ async function handleSave(formValue) {
       return
     }
 
-    if (isTeamLeader.value) {
-      // 팀장 셀프 등록: 백엔드가 MANAGER 권한 기준으로 즉시 확정 처리
-      try {
-        const payload = buildCreatePayload(formValue)
-        const { piId } = await createProformaInvoice(payload)
-        const userId = authStore.currentUser?.userId
-        await requestPiRegistration({ piId, userId })
-        await loadPiDocuments()
-        formOpen.value = false
-        selectedClient.value = null
-        success('PI가 등록되었습니다.')
-      } catch (e) {
-        error(e.response?.data?.message || 'PI 등록 중 오류가 발생했습니다.')
-      }
-      return
-    }
     pendingCreateFormValue.value = {
       ...formValue,
       items: (formValue.items ?? []).map((item) => ({ ...item })),
@@ -898,16 +882,6 @@ async function handleSave(formValue) {
   //       PO 와 동일하게 requestPiModification 연동으로 교체한다.
   //       현재는 로컬-only 로 스냅샷 비교만 수행.
   const { nextRow } = buildRowPayload(formValue)
-
-  if (isTeamLeader.value) {
-    rowsData.value = rowsData.value.map((r) =>
-      r.id === selectedRow.value?.id ? { ...r, ...nextRow } : r
-    )
-    formOpen.value = false
-    selectedClient.value = null
-    success('PI가 수정되었습니다.')
-    return
-  }
 
   const originalSnapshot = createComparableSnapshot(selectedRow.value ?? {})
   const revisedSnapshot = createComparableSnapshot({
@@ -943,18 +917,6 @@ async function openDeleteApprovalRequest(row) {
     await validatePiDeletable(row.id)
   } catch (e) {
     error(e.response?.data?.message || e.response?.data || '후속 문서가 존재하여 삭제할 수 없습니다.')
-    return
-  }
-
-  if (isTeamLeader.value) {
-    try {
-      const userId = authStore.currentUser?.userId
-      await requestPiDeletion({ piId: row.id, userId })
-      await loadPiDocuments()
-      success(`${row.id} PI가 삭제되었습니다.`)
-    } catch (e) {
-      error(e.response?.data?.message || '삭제 처리 중 오류가 발생했습니다.')
-    }
     return
   }
 

--- a/src/views/documents/PODetailPage.vue
+++ b/src/views/documents/PODetailPage.vue
@@ -537,18 +537,6 @@ async function handleDelete() {
     return
   }
 
-  if (isTeamLeader.value) {
-    try {
-      const userId = authStore.currentUser?.userId
-      await requestPoDeletion({ poId: sourceRow.value.id, userId })
-      await loadPoDocuments()
-      success(`${sourceRow.value.id} PO가 삭제되었습니다.`)
-    } catch (e) {
-      error(e.response?.data?.message || '삭제 처리 중 오류가 발생했습니다.')
-    }
-    return
-  }
-
   deleteApprovalRequestOpen.value = true
 }
 

--- a/src/views/documents/POPage.vue
+++ b/src/views/documents/POPage.vue
@@ -844,24 +844,6 @@ async function handleSave(formValue) {
   }
 
   if (formMode.value === 'create') {
-    if (isTeamLeader.value) {
-      // 팀장 셀프 등록: 백엔드 MANAGER 권한 기준 즉시 확정.
-      try {
-        const payload = buildCreatePayload(formValue)
-        const { poId } = await createPurchaseOrder(payload)
-        const userId = authStore.currentUser?.userId
-        await requestPoRegistration({ poId, userId })
-        await loadPoDocuments()
-        formOpen.value = false
-        selectedPi.value = null
-        selectedClient.value = null
-        success('PO가 등록되었습니다.')
-      } catch (e) {
-        error(e.response?.data?.message || 'PO 등록 중 오류가 발생했습니다.')
-      }
-      return
-    }
-
     pendingCreateFormValue.value = { ...formValue }
     createApprovalRequestOpen.value = true
     return
@@ -881,22 +863,6 @@ async function handleSave(formValue) {
 
   if (!changeRows.length) {
     warning('변경된 내용이 없습니다.')
-    return
-  }
-
-  if (isTeamLeader.value) {
-    // 팀장 셀프 수정: 백엔드에 수정 결재 요청을 보내고 즉시 반영을 기대한다.
-    try {
-      const userId = authStore.currentUser?.userId
-      await requestPoModification({ poId: selectedRow.value?.id, userId })
-      await loadPoDocuments()
-      formOpen.value = false
-      selectedPi.value = null
-      selectedClient.value = null
-      success('PO가 수정되었습니다.')
-    } catch (e) {
-      error(e.response?.data?.message || 'PO 수정 중 오류가 발생했습니다.')
-    }
     return
   }
 
@@ -921,18 +887,6 @@ async function openDeleteApprovalRequest(row) {
     await validatePoDeletable(row.id)
   } catch (e) {
     error(e.response?.data?.message || e.response?.data || '후속 문서가 존재하여 삭제할 수 없습니다.')
-    return
-  }
-
-  if (isTeamLeader.value) {
-    try {
-      const userId = authStore.currentUser?.userId
-      await requestPoDeletion({ poId: row.id, userId })
-      await loadPoDocuments()
-      success(`${row.id} PO가 삭제되었습니다.`)
-    } catch (e) {
-      error(e.response?.data?.message || '삭제 처리 중 오류가 발생했습니다.')
-    }
     return
   }
 


### PR DESCRIPTION
## 📋 작업 내용

백엔드에서 팀장 즉시 처리 로직 제거(team2-backend-documents 33b73bc)에 맞춰
프론트엔드의 `isTeamLeader` 분기도 제거.

**변경 전**: 팀장이면 결재 모달 스킵 → 직접 확정/수정/삭제
**변경 후**: 모든 사용자가 결재 모달을 통해 요청 → 팀장이 결재 승인

| 파일 | 제거된 분기 |
|------|-----------|
| PIDetailPage | handleDelete 팀장 즉시 삭제 |
| PODetailPage | handleDelete 팀장 즉시 삭제 |
| PIPage | 등록/수정/삭제 3곳 팀장 즉시 처리 |
| POPage | 등록/수정/삭제 3곳 팀장 즉시 처리 |

## 🔗 관련 이슈

- closes #379

## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료