### PR TITLE
fix: PI/PO 상태 비교 영문코드 대응 + 사용자 목록 size

### DIFF
--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -17,7 +17,7 @@ export async function logoutApi(userId) {
 }
 
 export async function fetchUsers() {
-  const { data } = await api.get('/users')
+  const { data } = await api.get('/users', { params: { size: 1000 } })
   return unwrapCollection(data)
 }
 

--- a/src/views/documents/PIDetailPage.vue
+++ b/src/views/documents/PIDetailPage.vue
@@ -733,17 +733,17 @@ function cancelDeleteApprovalRequest() {
     <div class="mb-6">
       <DetailPageHeader :title="detail.id" :status="detail.status" @back="goBack">
         <template #actions>
-          <BaseButton v-if="!shipmentLockInfo.locked && detail.status !== '결재대기'" size="sm" @click="handleEdit">
+          <BaseButton v-if="!shipmentLockInfo.locked && !['결재대기','pending_approval','APPROVAL_PENDING'].includes(detail.status)" size="sm" @click="handleEdit">
             <template #leading>
               <i class="fas fa-edit text-xs" aria-hidden="true"></i>
             </template>
-            {{ detail.status === '확정' ? '수정요청' : '수정' }}
+            {{ ['확정','confirmed','CONFIRMED'].includes(detail.status) ? '수정요청' : '수정' }}
           </BaseButton>
-          <BaseButton v-if="!shipmentLockInfo.locked && detail.status !== '결재대기'" variant="secondary" size="sm" @click="handleDelete">
+          <BaseButton v-if="!shipmentLockInfo.locked && !['결재대기','pending_approval','APPROVAL_PENDING'].includes(detail.status)" variant="secondary" size="sm" @click="handleDelete">
             <template #leading>
               <i class="fas fa-trash text-xs" aria-hidden="true"></i>
             </template>
-            {{ detail.status === '확정' ? '삭제요청' : '삭제' }}
+            {{ ['확정','confirmed','CONFIRMED'].includes(detail.status) ? '삭제요청' : '삭제' }}
           </BaseButton>
           <BaseButton variant="secondary" size="sm" @click="openPreview">
             <template #leading>

--- a/src/views/documents/PODetailPage.vue
+++ b/src/views/documents/PODetailPage.vue
@@ -851,7 +851,7 @@ function cancelDeleteApprovalRequest() {
       <DetailPageHeader :title="detail.id" :status="detail.status" @back="goBack">
         <template #actions>
           <BaseButton
-            v-if="canIssueProductionOrder && detail.status !== '결재대기'"
+            v-if="canIssueProductionOrder && !['결재대기','pending_approval','APPROVAL_PENDING'].includes(detail.status)"
             variant="secondary"
             size="sm"
             @click="openProductionIssueConfirm"
@@ -861,17 +861,17 @@ function cancelDeleteApprovalRequest() {
             </template>
             생산지시서 발행
           </BaseButton>
-          <BaseButton v-if="!shipmentLockInfo.locked && detail.status !== '결재대기'" size="sm" @click="handleEdit">
+          <BaseButton v-if="!shipmentLockInfo.locked && !['결재대기','pending_approval','APPROVAL_PENDING'].includes(detail.status)" size="sm" @click="handleEdit">
             <template #leading>
               <i class="fas fa-edit text-xs" aria-hidden="true"></i>
             </template>
-            {{ detail.status === '확정' ? '수정요청' : '수정' }}
+            {{ ['확정','confirmed','CONFIRMED'].includes(detail.status) ? '수정요청' : '수정' }}
           </BaseButton>
-          <BaseButton v-if="!shipmentLockInfo.locked && detail.status !== '결재대기'" variant="secondary" size="sm" @click="handleDelete">
+          <BaseButton v-if="!shipmentLockInfo.locked && !['결재대기','pending_approval','APPROVAL_PENDING'].includes(detail.status)" variant="secondary" size="sm" @click="handleDelete">
             <template #leading>
               <i class="fas fa-trash text-xs" aria-hidden="true"></i>
             </template>
-            {{ detail.status === '확정' ? '삭제요청' : '삭제' }}
+            {{ ['확정','confirmed','CONFIRMED'].includes(detail.status) ? '삭제요청' : '삭제' }}
           </BaseButton>
           <BaseButton variant="secondary" size="sm" @click="openPreview">
             <template #leading>


### PR DESCRIPTION
## 📋 작업 내용

| FAIL | 수정 |
|------|------|
| C-04 | 확정 PI 버튼 라벨: `confirmed` 영문코드도 대응 → "수정요청"/"삭제요청" 정상 |
| D-05 | 결재대기 PO 버튼 숨김: `pending_approval`/`APPROVAL_PENDING` 영문코드 대응 |
| A-05 | `fetchUsers()` size 파라미터 없어 기본 10건 → `size=1000` 추가 |

## 🔗 관련 이슈
- closes #383

## ✅ 체크리스트
- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료