### PR TITLE
fix: 일정 수정 기간 pre-fill + PL TOTAL EA 중복 제거

### DIFF
--- a/src/components/domain/activity/ActivityEditModal.vue
+++ b/src/components/domain/activity/ActivityEditModal.vue
@@ -127,8 +127,8 @@ function initForm(val) {
   formTitle.value        = val?.title        ?? ''
   formContent.value      = val?.content      ?? ''
   formPriority.value     = val?.priority     ?? val?.activityPriority ?? 'medium'
-  formScheduleFrom.value = (val?.scheduleFrom ?? '').replaceAll('/', '-')
-  formScheduleTo.value   = (val?.scheduleTo   ?? '').replaceAll('/', '-')
+  formScheduleFrom.value = (val?.scheduleFrom ?? val?.activityScheduleFrom ?? '').replaceAll('/', '-')
+  formScheduleTo.value   = (val?.scheduleTo   ?? val?.activityScheduleTo   ?? '').replaceAll('/', '-')
   errors.value           = {}
   // 달력 월 동기화
   if (val?.scheduleFrom) {

--- a/src/stores/plDocuments.js
+++ b/src/stores/plDocuments.js
@@ -60,7 +60,7 @@ function mapPlResponse(row) {
     poId: row.poId ?? '',
     shipmentOrderId: row.shipmentOrderId ?? '',
     remarks: row.remarks ?? '-',
-    totalQuantity: `${totalQuantity} EA`,
+    totalQuantity,
     totalNetWeight: formatNumber(totalNetWeight, 2),
     totalGrossWeight: formatNumber(totalGrossWeight, 2),
     totalMeasurement: formatNumber(totalMeasurement, 2),


### PR DESCRIPTION
## 📋 작업 내용

| FAIL | 원인 | 수정 |
|------|------|------|
| H-10 | `initForm`이 `scheduleFrom`만 읽고 API 응답 키 `activityScheduleFrom` 미대응 | fallback `val?.activityScheduleFrom` 추가 |
| E-04 | PL store에서 `totalQuantity: "3 EA"` + 템플릿에서 `${totalQuantity} EA` → "3 EA EA" | store에서 suffix 제거 (숫자만), 템플릿에서만 EA 붙임 |

## 🔗 관련 이슈
- closes #387

## ✅ 체크리스트
- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료