### PR TITLE
fix: D-03 PI 필터 PO 재호출 제거 + G-01 거래처 에러 격리

### DIFF
--- a/src/views/documents/POPage.vue
+++ b/src/views/documents/POPage.vue
@@ -1174,7 +1174,7 @@ function handleProductSelect(product) {
       :document="selectedRow"
       :selected-pi="selectedPi"
       :selected-client="selectedClient"
-      @open-pi-search="loadPoDocuments().then(() => { piSearchOpen = true })"
+      @open-pi-search="piSearchOpen = true"
       @open-client-search="openClientSearch('form')"
       @close="closeForm"
       @save="handleSave"

--- a/src/views/master/ClientListPage.vue
+++ b/src/views/master/ClientListPage.vue
@@ -180,12 +180,12 @@ async function loadData() {
   loading.value = true
   try {
     const [clientsData, , deptsData, teamsData] = await Promise.all([
-      fetchClients(),
-      loadReferenceData(),
-      fetchDepartments(),
-      fetchTeams(),
+      fetchClients().catch((e) => { console.error('거래처 로드 실패', e); return [] }),
+      loadReferenceData().catch(() => {}),
+      fetchDepartments().catch((e) => { console.error('부서 로드 실패', e); return [] }),
+      fetchTeams().catch((e) => { console.error('팀 로드 실패', e); return [] }),
     ])
-    clients.value = clientsData
+    clients.value = clientsData ?? []
     departments.value = deptsData ?? []
     teams.value = teamsData ?? []
   } catch {


### PR DESCRIPTION
## 📋 작업 내용

| FAIL | 원인 | 수정 |
|------|------|------|
| D-03 | PI 검색 시 `loadPoDocuments()` 재호출 → PO 데이터가 빈 배열로 덮어씀 → 필터 무력화 | 재호출 제거. 페이지 로드 시 이미 로드된 PO 데이터 사용 |
| G-01/G-02 | `ClientListPage`의 `Promise.all`에서 `fetchDepartments()`/`fetchTeams()` 실패 시 전체 catch → 거래처도 0건 | 개별 `.catch()`로 에러 격리 |

### D-03 근본 원인
콘솔: `[PI필터] PO 데이터 0건 — 모든 PI가 선택 가능 상태로 표시됩니다`
→ `loadPoDocuments()` 재호출 시 API 응답이 빈 배열 → `poDocuments.value = []` → 필터가 모든 PI 허용

### G-01 근본 원인
백엔드 API (`curl` 테스트)는 김영업 토큰으로 거래처 정상 반환 확인됨.
프론트에서 `fetchDepartments()`가 실패 → `Promise.all` 전체 catch → `clients.value` 미할당 → 0건.

## 🔗 관련 이슈
- closes #391

## ✅ 체크리스트
- [x] 정상 동작 확인
- [x] 충돌(conflict) 해결 완료