### PR TITLE
fix(qa): 2026-04-18 전수 검증 수정 패키지

### DIFF
--- a/src/views/activity/ActivityListPage.vue
+++ b/src/views/activity/ActivityListPage.vue
@@ -237,13 +237,15 @@ const columns = [
       </template>
     </DocumentPageHeader>
 
-    <!-- 키워드 검색 + 상세검색 토글 -->
-    <FilterToolbarCard
-      v-model="filterTitle"
-      placeholder="제목 검색..."
-      :advanced-open="isFilterOpen"
-      @toggle-advanced="isFilterOpen = !isFilterOpen"
-    />
+    <!-- 키워드 검색 + 상세검색 토글. Enter 로 검색 적용 (ItemListPage 와 동일 패턴) -->
+    <div @keyup.enter="applySearch">
+      <FilterToolbarCard
+        v-model="filterTitle"
+        placeholder="제목 검색..."
+        :advanced-open="isFilterOpen"
+        @toggle-advanced="isFilterOpen = !isFilterOpen"
+      />
+    </div>
 
     <!-- 상세검색 패널 -->
     <CollapsibleFilterCard :open="isFilterOpen" @toggle="isFilterOpen = !isFilterOpen">

--- a/src/views/documents/PIDetailPage.vue
+++ b/src/views/documents/PIDetailPage.vue
@@ -39,6 +39,7 @@ import {
 import { formatReferenceDocumentStatus } from '@/utils/referenceDocumentStatus'
 import { formatIncotermsLabel, resolveIncotermState } from '@/utils/incoterms'
 import { clientSearchColumns } from '@/utils/searchModalColumns'
+import { label, PI_PO_STATUS_LABEL } from '@/utils/enumLabels'
 
 const route = useRoute()
 const router = useRouter()
@@ -449,7 +450,7 @@ const deleteApprovalDocumentRows = computed(() => {
 
   return [
     { label: '대상 PI 번호', value: sourceRow.value.id || '-' },
-    { label: '현재 상태', value: sourceRow.value.status || '-' },
+    { label: '현재 상태', value: sourceRow.value.status ? label(PI_PO_STATUS_LABEL, sourceRow.value.status) : '-' },
     { label: '거래처', value: snapshot.clientName || '-' },
     { label: '영문주소', value: snapshot.clientAddress || '-', fullWidth: true },
     { label: '바이어', value: snapshot.buyerName || '-' },

--- a/src/views/documents/PIPage.vue
+++ b/src/views/documents/PIPage.vue
@@ -498,7 +498,8 @@ function getRequestedAt() {
 }
 
 function buildNextPiId() {
-  return `PI26${String(rowsData.value.length + 1).padStart(3, '0')}`
+  // 실제 DB 포맷: PI + 2자리년도 + 4자리 시퀀스 (예: PI260011). 미리보기도 동일 자리수 유지.
+  return `PI26${String(rowsData.value.length + 1).padStart(4, '0')}`
 }
 
 function toIsoDate(value) {

--- a/src/views/master/ItemListPage.vue
+++ b/src/views/master/ItemListPage.vue
@@ -202,6 +202,10 @@ async function handleSave(formData) {
       success('품목이 등록되었습니다.')
     } else {
       await updateItem(selectedItem.value.id, formData)
+      // HTTP 캐시가 개입해 loadData() 가 이전 스냅샷을 돌려줄 수 있어, 전송한 값으로
+      // 로컬 items 를 선반영한다. 이후 loadData() 가 정상 응답하면 덮어써진다.
+      const idx = items.value.findIndex((i) => i.id === selectedItem.value.id)
+      if (idx !== -1) items.value[idx] = { ...items.value[idx], ...formData }
       success('품목 정보가 수정되었습니다.')
     }
     showFormModal.value = false


### PR DESCRIPTION
## 📋 작업 내용

2026-04-18 전수 QA 검증에서 발견된 프론트 버그 4건을 한 번에 처리.

| # | 파일 | 변경 |
|---|------|-----|
| 1 | `src/views/documents/PIDetailPage.vue` | 삭제 결재 요청 모달 '현재 상태' → `PI_PO_STATUS_LABEL` 한글 매핑 |
| 2 | `src/views/activity/ActivityListPage.vue` | 검색 인풋 Enter 트리거 누락 → `@keyup.enter="applySearch"` 래핑 (ItemListPage 동일 패턴) |
| 3 | `src/views/master/ItemListPage.vue` | `updateItem` 성공 후 HTTP 캐시 대응으로 로컬 `items` 선반영 |
| 4 | `src/views/documents/PIPage.vue` | `buildNextPiId` 의 `padStart(3)` → `padStart(4)` — 실제 DB 포맷(`PI260001`) 6자리 일치 |

백엔드 쪽 Critical 이슈(팀장 PI/PO 즉시 확정 401)는 별도 커밋으로 main 직푸시 완료:
- `team2-backend-auth@7acd14b` — `/api/users/internal/{id}` 엔드포인트 추가
- `team2-backend-documents@728a6af` — AuthFeignClient 를 internal 경로로 전환

## 🔗 관련 이슈
- closes #393

## 📸 스크린샷 (선택)
N/A — 로컬 수정 확인만 진행. 스테이징 배포 후 QA 재검증 필요.

## ✅ 체크리스트
- [x] 정상 동작 확인 (로컬 코드 레벨, 런타임 재검증 예정)
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게
- 품목 리스트 캐시 이슈(③)는 **브라우저/axios 레이어 캐시 가설** 기반의 우회 수정이라, 재현 안 되면 원인이 다른 곳일 수 있음. 실제 스테이징에서 재확인 부탁.
- PI 예정번호(④)는 어디까지나 **프리뷰 라벨**이고 실제 번호는 백엔드가 발급하므로, rowsData 길이 기반 추정이 틀릴 수 있음. 자리수만 맞춘 최소 수정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)