### PR TITLE
fix(qa): 품목 상태 저장 회귀 + 팀장 PI/PO 모달 안내 정정

### DIFF
--- a/src/views/documents/PIPage.vue
+++ b/src/views/documents/PIPage.vue
@@ -123,6 +123,14 @@ const { currentPage, totalPages, paginatedRows } = usePagination(filteredRows)
 
 const isTeamLeader = computed(() => Number(authStore.currentUser?.positionId) === 1)
 
+// 팀장(MANAGER) 은 백엔드 requestRegistration 에서 즉시 CONFIRMED 처리되므로
+// 결재대기 문구가 오해를 준다. 실제 동작에 맞춘 안내로 분기.
+const createHelperText = computed(() => (
+  isTeamLeader.value
+    ? '팀장 권한이므로 저장 시 PI 가 즉시 확정 처리됩니다.'
+    : '요청 후 PI는 결재대기 상태로 등록되며, 승인 전까지 확정 처리되지 않습니다.'
+))
+
 const managerOptions = computed(() => buildSelectOptionsFromRows(rowsData.value, 'manager'))
 const countryOptions = computed(() => buildSelectOptionsFromRows(rowsData.value, 'country'))
 const statusOptions = computed(() => buildSelectOptionsFromRows(rowsData.value, 'status'))
@@ -1186,7 +1194,7 @@ function handleProductSelect(product) {
       :item-summary-rows="createApprovalItemSummaryRows"
       document-section-title="PI 문서 정보"
       item-section-title="PI 품목 정보"
-      helper-text="요청 후 PI는 결재대기 상태로 등록되며, 승인 전까지 확정 처리되지 않습니다."
+      :helper-text="createHelperText"
       width="max-w-6xl"
       confirm-label="결재 요청"
       @confirm="confirmCreateApprovalRequest"

--- a/src/views/documents/POPage.vue
+++ b/src/views/documents/POPage.vue
@@ -162,6 +162,14 @@ const { currentPage, totalPages, paginatedRows } = usePagination(filteredRows)
 
 const isTeamLeader = computed(() => Number(authStore.currentUser?.positionId) === 1)
 
+// 팀장(MANAGER) 은 백엔드 requestRegistration 에서 즉시 CONFIRMED 처리되므로
+// 결재대기 문구가 오해를 준다. 실제 동작에 맞춘 안내로 분기.
+const createHelperText = computed(() => (
+  isTeamLeader.value
+    ? '팀장 권한이므로 저장 시 PO 가 즉시 확정 처리됩니다.'
+    : '요청 후 PO는 결재대기 상태로 등록되며, 승인 전까지 확정 처리되지 않습니다.'
+))
+
 const managerOptions = computed(() => buildSelectOptionsFromRows(rowsData.value, 'manager'))
 const countryOptions = computed(() => buildSelectOptionsFromRows(rowsData.value, 'country'))
 const statusOptions = computed(() => buildSelectOptionsFromRows(rowsData.value, 'status'))
@@ -1194,7 +1202,7 @@ function handleProductSelect(product) {
       document-section-title="PO 문서 정보"
       item-section-title="연결 PI 기준 품목"
       reference-section-title="연결 PI 정보"
-      helper-text="요청 후 PO는 결재대기 상태로 등록되며, 승인 전까지 확정 처리되지 않습니다."
+      :helper-text="createHelperText"
       width="max-w-6xl"
       confirm-label="결재 요청"
       @confirm="confirmCreateApprovalRequest"

--- a/src/views/master/ItemListPage.vue
+++ b/src/views/master/ItemListPage.vue
@@ -201,11 +201,14 @@ async function handleSave(formData) {
       await createItem({ ...formData, itemRegDate: new Date().toISOString().slice(0, 10) })
       success('품목이 등록되었습니다.')
     } else {
+      // 백엔드는 상태 변경을 PATCH /api/items/{id}/status 로 분리해 둠.
+      // PUT 의 UpdateItemRequest DTO 에는 itemStatus 필드가 없어 포함시켜도 무시된다.
+      // 따라서 상태가 변경된 경우에는 PATCH 를 별도로 호출해야 실제 반영됨.
+      const statusChanged = formData.itemStatus !== selectedItem.value.itemStatus
       await updateItem(selectedItem.value.id, formData)
-      // HTTP 캐시가 개입해 loadData() 가 이전 스냅샷을 돌려줄 수 있어, 전송한 값으로
-      // 로컬 items 를 선반영한다. 이후 loadData() 가 정상 응답하면 덮어써진다.
-      const idx = items.value.findIndex((i) => i.id === selectedItem.value.id)
-      if (idx !== -1) items.value[idx] = { ...items.value[idx], ...formData }
+      if (statusChanged) {
+        await changeItemStatus(selectedItem.value.id, formData.itemStatus)
+      }
       success('품목 정보가 수정되었습니다.')
     }
     showFormModal.value = false


### PR DESCRIPTION
## 📋 작업 내용

재검증(#393 후속)에서 발견된 2건 처리.

### ① 품목 상태 저장 회귀 (Critical)
- 원인: 백엔드 `UpdateItemRequest` DTO 에 `itemStatus` 가 없어 PUT 요청 시 무시됨. 상태 변경은 `PATCH /api/items/{id}/status` 로 분리 설계.
- 수정: `ItemListPage.handleSave` 에서 수정 모드 + 상태 변경 시 `changeItemStatus` 별도 호출.
- 철회: PR #394 에서 추가한 '로컬 items merge 선반영' 은 저장 실패를 UI 상 가리는 역효과라 제거.

### ② 팀장 등록 모달 안내 정정 (UX)
- 팀장(positionId=1) 은 백엔드 `requestRegistration` 에서 즉시 `CONFIRMED` 처리되는데, 모달 helper-text 가 \"결재대기 상태로 등록됩니다\" 라고 오안내.
- `isTeamLeader` 기반 computed 로 helper-text 분기. 수정 파일: `PIPage.vue`, `POPage.vue` 등록 결재 요청 모달.
- 수정/삭제 모달은 동작 확인이 필요해 이번 PR 에선 손대지 않음.

## 🔗 관련 이슈
- closes #395

## 📸 스크린샷 (선택)
N/A — 스테이징 배포 후 재검증 필요.

## ✅ 체크리스트
- [x] 정상 동작 확인 (코드 레벨)
- [x] 불필요한 코드/주석 제거 (로컬 merge 선반영 철회)
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게
- 품목 쪽 수정은 **백엔드 설계(별도 PATCH) 존중** 방향으로 잡았습니다. 만약 UpdateItemRequest DTO 에 itemStatus 를 추가하는 편이 API 스펙상 낫다고 판단되면 그쪽이 더 좋은 해결책이 될 수 있습니다.
- 팀장 문구는 '등록'에만 적용했습니다. 수정/삭제 플로우도 팀장이 즉시 처리되는지는 별도 동작 확인이 필요해 보류.

🤖 Generated with [Claude Code](https://claude.com/claude-code)