### PR TITLE
fix(qa): Minor 3건 수금액 undefined / PO 참조 PI stale / 거래처 빈 문구

### DIFF
--- a/src/views/documents/CollectionsPage.vue
+++ b/src/views/documents/CollectionsPage.vue
@@ -188,6 +188,8 @@ const currencySymbols = {
 }
 
 function formatAmount(value, currency) {
+  // 백엔드 응답 필드 누락/null 로 인한 'undefined' 문자열 렌더 방지.
+  if (value == null || (typeof value === 'number' && Number.isNaN(value))) return '-'
   const symbol = currencySymbols[currency] || ''
   if (typeof value === 'number') {
     return `${symbol}${value.toLocaleString()}`

--- a/src/views/documents/PODetailPage.vue
+++ b/src/views/documents/PODetailPage.vue
@@ -145,12 +145,18 @@ function buildLinkedDocuments(row) {
   const linkedPi = piDocuments.value.find((pi) => pi.id === (row.piId || row.linkedPiId))
   const linkedProductionOrder = productionOrderDocuments.value.find((production) => production.poId === row.id)
 
-  if (linkedPi && !currentLinks.some((document) => document.id === linkedPi.id)) {
-    currentLinks.unshift({ id: linkedPi.id, status: linkedPi.status })
+  // 스냅샷 status 는 PO 생성 시점 기준이라 PI 가 이후 확정돼도 stale 유지.
+  // live store 에서 찾은 문서가 이미 링크에 있으면 최신 status 로 덮어쓴다.
+  if (linkedPi) {
+    const idx = currentLinks.findIndex((document) => document.id === linkedPi.id)
+    if (idx === -1) currentLinks.unshift({ id: linkedPi.id, status: linkedPi.status })
+    else currentLinks[idx] = { ...currentLinks[idx], status: linkedPi.status }
   }
 
-  if (linkedProductionOrder && !currentLinks.some((document) => document.id === linkedProductionOrder.id)) {
-    currentLinks.push({ id: linkedProductionOrder.id, status: linkedProductionOrder.status })
+  if (linkedProductionOrder) {
+    const idx = currentLinks.findIndex((document) => document.id === linkedProductionOrder.id)
+    if (idx === -1) currentLinks.push({ id: linkedProductionOrder.id, status: linkedProductionOrder.status })
+    else currentLinks[idx] = { ...currentLinks[idx], status: linkedProductionOrder.status }
   }
 
   return currentLinks

--- a/src/views/master/ClientListPage.vue
+++ b/src/views/master/ClientListPage.vue
@@ -332,7 +332,7 @@ function goToDetail(row) {
     </div>
 
     <BaseTable v-else :columns="columns" :rows="paginatedClients" row-key="id"
-      :empty-text="appliedFilters.keyword || appliedFilters.code || appliedFilters.name || appliedFilters.country || appliedFilters.manager || appliedFilters.status ? '검색 결과가 없습니다.' : '등록된 거래처가 없습니다.'"
+      :empty-text="appliedFilters.keyword || appliedFilters.code || appliedFilters.name || appliedFilters.country || appliedFilters.manager || appliedFilters.status ? '검색 결과가 없습니다.' : '데이터가 없습니다.'"
       :footer-text="`총 ${filteredClients.length}건`"
       clickable-rows
       @row-click="goToDetail"


### PR DESCRIPTION
## 📋 작업 내용

재검증 전수 QA(#395 후속)에서 새로 발견된 Minor 3건.

| # | 파일 | 변경 |
|---|------|-----|
| 1 | `src/views/documents/CollectionsPage.vue` | \`formatAmount\` 에 null/NaN 가드 추가 → 'undefined' 문자열 렌더 방지 |
| 2 | `src/views/documents/PODetailPage.vue` | \`buildLinkedDocuments\` 가 live store 의 최신 status 로 stale 스냅샷을 덮어쓰도록 변경. PI/생산지시서 둘 다 적용 |
| 3 | `src/views/master/ClientListPage.vue` | 빈 상태 문구 '등록된 거래처가 없습니다.' → '데이터가 없습니다.' 공통 규격으로 통일 |

## 🔗 관련 이슈
- closes #397

## 📸 스크린샷 (선택)
N/A — 배포 후 스테이징에서 재검증.

## ✅ 체크리스트
- [x] 정상 동작 확인 (코드 레벨)
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게
- (1) 수금액 undefined 의 **근본 원인**(백엔드 응답 필드 누락/오매핑) 은 스테이징 Network 응답 직접 검사 후 별도 이슈로 추적 추천. 이 PR 은 UI 방어만 처리.
- (2) PO 뿐만 아니라 PI 상세의 참조 문서에도 같은 stale 패턴이 있을 가능성 — 이번엔 범위 제한, 재검증에서 발견되면 대칭 적용.

🤖 Generated with [Claude Code](https://claude.com/claude-code)