### PR TITLE
fix(common): BaseModal 드래그-세이프 백드롭 닫기

### DIFF
--- a/src/components/common/BaseModal.vue
+++ b/src/components/common/BaseModal.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { onMounted, onUnmounted, watch } from 'vue'
+import { onUnmounted, ref, watch } from 'vue'
 
 const props = defineProps({
   open: {
@@ -30,14 +30,28 @@ const props = defineProps({
 
 const emit = defineEmits(['close'])
 
+// 드래그-세이프 백드롭 닫기:
+// 브라우저는 mousedown 과 mouseup 의 공통 조상에서 click 을 디스패치한다.
+// 입력 필드에서 텍스트를 드래그 선택하다가 백드롭 위에서 마우스를 떼면
+// click 타겟이 백드롭이 되어버려 사용자가 의도하지 않은 닫기가 일어난다.
+// mousedown 도 백드롭에서 시작됐을 때에만 닫도록 게이트.
+const backdropMousedown = ref(false)
+
 function closeModal() {
   emit('close')
 }
 
-function handleBackdropClick() {
-  if (props.closeOnBackdrop) {
-    closeModal()
-  }
+function handleBackdropMousedown(e) {
+  backdropMousedown.value = e.target === e.currentTarget
+}
+
+function handleBackdropClick(e) {
+  // mousedown 이 모달 내부에서 시작됐다면 (드래그 후 백드롭에서 떼진 경우) 무시
+  if (!backdropMousedown.value) return
+  backdropMousedown.value = false
+  if (!props.closeOnBackdrop) return
+  if (e.target !== e.currentTarget) return
+  closeModal()
 }
 
 function handleKeydown(e) {
@@ -65,7 +79,8 @@ onUnmounted(() => {
       v-if="open"
       class="fixed inset-0 flex items-center justify-center bg-slate-900/50 px-4 py-8"
       :style="{ zIndex: props.zIndex }"
-      @click.self="handleBackdropClick"
+      @mousedown="handleBackdropMousedown"
+      @click="handleBackdropClick"
     >
       <div
         class="flex max-h-[90vh] w-full flex-col overflow-hidden rounded-lg bg-white shadow-2xl"


### PR DESCRIPTION
## 📋 작업 내용

모든 모달이 공통적으로 겪는 UX 버그 수정.

### 증상
입력 필드에서 텍스트를 드래그 선택하다가 마우스를 모달 **바깥(백드롭)** 여백에서 떼면 모달이 실수로 닫힘. 다시 열면 입력값이 전부 날아가 재입력 필요.

### 원인
브라우저 \`click\` 이벤트는 \`mousedown\` 과 \`mouseup\` 의 **공통 조상** 요소에서 발화한다.
- mousedown = input (모달 내부)
- mouseup = backdrop
- 공통 조상 = backdrop (input 이 그 하위)

따라서 기존 \`@click.self\` 조건을 통과해 \`handleBackdropClick\` 이 호출됨.

### 수정
\`mousedown\` 도 백드롭에서 시작됐을 때에만 닫기를 허용. mousedown 을 ref 로 추적 후 click 핸들러에서 게이트.

```js
function handleBackdropMousedown(e) {
  backdropMousedown.value = e.target === e.currentTarget
}
function handleBackdropClick(e) {
  if (!backdropMousedown.value) return   // 드래그 밖으로 뺀 케이스 차단
  backdropMousedown.value = false
  if (!props.closeOnBackdrop) return
  if (e.target !== e.currentTarget) return
  closeModal()
}
```

영향 없는 동작 (그대로 유지):
- X 버튼 클릭 → 닫힘
- ESC 키 → 닫힘
- 백드롭 직접 클릭 (모달 바깥 빈 공간 클릭) → 닫힘

## 🔗 관련 이슈
- closes #399

## 📸 스크린샷 (선택)
N/A — 재검증 항목: 아무 등록/수정 모달 오픈 → 텍스트 입력 → 값 일부 드래그 선택 후 백드롭에서 떼기 → 닫히지 않아야 함.

## ✅ 체크리스트
- [x] 정상 동작 확인 (코드 레벨)
- [x] 불필요한 코드/주석 제거 (사용하지 않던 \`onMounted\` import 제거)
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게
- 본 PR 은 BaseModal 공통 컴포넌트 한 파일만 건드립니다. 프로젝트 내 모든 모달(BaseModal 을 래핑하는 ConfirmModal/ApprovalRequestModal/각종 FormModal 등)이 자동으로 혜택 받음.
- 추가로 \"모달 닫혔을 때 폼 값 보존(캐싱)\" 같은 요구사항은 별도 UX 설계가 필요하므로 이번 PR 범위 외. 실수 닫힘 자체가 사라지면 체감상 대부분 해소될 것으로 예상.

🤖 Generated with [Claude Code](https://claude.com/claude-code)