### PR TITLE
feat(documents): 초안 직접 삭제 + 결재 요청 취소 버튼

### DIFF
--- a/src/api/documents.js
+++ b/src/api/documents.js
@@ -31,6 +31,14 @@ export const validatePiDeletable = (piId) =>
   api.post(`/proforma-invoices/${piId}/validate-deletable`).then((r) => r.data)
 export const requestPiDeletion = (payload) =>
   api.post('/proforma-invoices/request-deletion', payload).then((r) => r.data)
+// 초안(DRAFT) 상태 PI 를 결재 없이 직접 수정/삭제. 상태 위배 시 409.
+export const updateProformaInvoiceDraft = (piId, payload) =>
+  api.put(`/proforma-invoices/${piId}`, payload).then((r) => r.data)
+export const deleteProformaInvoiceDraft = (piId) =>
+  api.delete(`/proforma-invoices/${piId}`).then((r) => r.data)
+// 결재대기 상태의 PI 결재 요청을 요청자 본인이 취소.
+export const cancelProformaInvoiceApproval = (piId) =>
+  api.post(`/proforma-invoices/${piId}/cancel-approval`).then((r) => r.data)
 
 // ── Purchase Orders ──────────────────────────────────────────
 export async function fetchPurchaseOrdersPaged({ page = 0, size = 20 } = {}) {
@@ -51,6 +59,13 @@ export const validatePoDeletable = (poId) =>
   api.post(`/purchase-orders/${poId}/validate-deletable`).then((r) => r.data)
 export const requestPoDeletion = (payload) =>
   api.post('/purchase-orders/request-deletion', payload).then((r) => r.data)
+// 초안(DRAFT) 상태 PO 를 결재 없이 직접 수정/삭제.
+export const updatePurchaseOrderDraft = (poId, payload) =>
+  api.put(`/purchase-orders/${poId}`, payload).then((r) => r.data)
+export const deletePurchaseOrderDraft = (poId) =>
+  api.delete(`/purchase-orders/${poId}`).then((r) => r.data)
+export const cancelPurchaseOrderApproval = (poId) =>
+  api.post(`/purchase-orders/${poId}/cancel-approval`).then((r) => r.data)
 
 // ── Commercial Invoices ──────────────────────────────────────
 export async function fetchCommercialInvoicesPaged({ page = 0, size = 20 } = {}) {

--- a/src/views/documents/PIDetailPage.vue
+++ b/src/views/documents/PIDetailPage.vue
@@ -12,7 +12,12 @@ import { formatRevisionEntry } from '@/utils/revisionFormat'
 import DocumentPreviewModal from '@/components/domain/document/DocumentPreviewModal.vue'
 import PIDocumentTemplate from '@/components/domain/document/PIDocumentTemplate.vue'
 import PIFormModal from '@/components/domain/document/PIFormModal.vue'
-import { validatePiDeletable, requestPiDeletion } from '@/api/documents'
+import {
+  validatePiDeletable,
+  requestPiDeletion,
+  deleteProformaInvoiceDraft,
+  cancelProformaInvoiceApproval,
+} from '@/api/documents'
 import { fetchBuyers, fetchClients, fetchCountries, fetchCurrencies } from '@/api/master'
 import { useToast } from '@/composables/useToast'
 import { useAuthStore } from '@/stores/auth'
@@ -541,6 +546,21 @@ async function handleDelete() {
     return
   }
 
+  // DRAFT 는 결재 없이 바로 삭제 (백엔드 DELETE /proforma-invoices/{id}).
+  const statusKey = String(sourceRow.value?.status ?? '').trim().toLowerCase()
+  const isDraft = statusKey === 'draft' || statusKey === '초안'
+  if (isDraft) {
+    try {
+      await deleteProformaInvoiceDraft(sourceRow.value.id)
+      await loadPiDocuments()
+      success(`${sourceRow.value.id} 초안 PI가 삭제되었습니다.`)
+      router.back()
+    } catch (e) {
+      error(e.response?.data?.message || '초안 삭제 중 오류가 발생했습니다.')
+    }
+    return
+  }
+
   if (isTeamLeader.value) {
     try {
       const userId = authStore.currentUser?.userId
@@ -727,6 +747,19 @@ async function confirmDeleteApprovalRequest() {
 function cancelDeleteApprovalRequest() {
   deleteApprovalRequestOpen.value = false
 }
+
+// APPROVAL_PENDING 상태에서 요청자 본인이 결재 요청을 취소.
+// 백엔드가 REGISTRATION 은 DRAFT, MODIFICATION/DELETION 은 CONFIRMED 로 상태 복구.
+async function handleCancelApproval() {
+  if (!sourceRow.value) return
+  try {
+    await cancelProformaInvoiceApproval(sourceRow.value.id)
+    await loadPiDocuments()
+    success(`${sourceRow.value.id} 결재 요청이 취소되었습니다.`)
+  } catch (e) {
+    error(e.response?.data?.message || '결재 요청 취소 중 오류가 발생했습니다.')
+  }
+}
 </script>
 
 <template>
@@ -745,6 +778,17 @@ function cancelDeleteApprovalRequest() {
               <i class="fas fa-trash text-xs" aria-hidden="true"></i>
             </template>
             {{ ['확정','confirmed','CONFIRMED'].includes(detail.status) ? '삭제요청' : '삭제' }}
+          </BaseButton>
+          <BaseButton
+            v-if="['결재대기','pending_approval','APPROVAL_PENDING'].includes(detail.status)"
+            variant="secondary"
+            size="sm"
+            @click="handleCancelApproval"
+          >
+            <template #leading>
+              <i class="fas fa-undo text-xs" aria-hidden="true"></i>
+            </template>
+            결재 요청 취소
           </BaseButton>
           <BaseButton variant="secondary" size="sm" @click="openPreview">
             <template #leading>

--- a/src/views/documents/PODetailPage.vue
+++ b/src/views/documents/PODetailPage.vue
@@ -12,7 +12,13 @@ import { formatRevisionEntry } from '@/utils/revisionFormat'
 import DocumentPreviewModal from '@/components/domain/document/DocumentPreviewModal.vue'
 import PODocumentTemplate from '@/components/domain/document/PODocumentTemplate.vue'
 import POFormModal from '@/components/domain/document/POFormModal.vue'
-import { requestPoModification, validatePoDeletable, requestPoDeletion } from '@/api/documents'
+import {
+  requestPoModification,
+  validatePoDeletable,
+  requestPoDeletion,
+  deletePurchaseOrderDraft,
+  cancelPurchaseOrderApproval,
+} from '@/api/documents'
 import { useSearchModalLookups } from '@/composables/useSearchModalLookups'
 import { useToast } from '@/composables/useToast'
 import { useAuthStore } from '@/stores/auth'
@@ -543,6 +549,21 @@ async function handleDelete() {
     return
   }
 
+  // DRAFT 는 결재 없이 바로 삭제 (백엔드 DELETE /purchase-orders/{id}).
+  const statusKey = String(sourceRow.value?.status ?? '').trim().toLowerCase()
+  const isDraft = statusKey === 'draft' || statusKey === '초안'
+  if (isDraft) {
+    try {
+      await deletePurchaseOrderDraft(sourceRow.value.id)
+      await loadPoDocuments()
+      success(`${sourceRow.value.id} 초안 PO가 삭제되었습니다.`)
+      router.back()
+    } catch (e) {
+      error(e.response?.data?.message || '초안 삭제 중 오류가 발생했습니다.')
+    }
+    return
+  }
+
   if (isTeamLeader.value) {
     try {
       const userId = authStore.currentUser?.userId
@@ -849,6 +870,18 @@ async function confirmDeleteApprovalRequest() {
 function cancelDeleteApprovalRequest() {
   deleteApprovalRequestOpen.value = false
 }
+
+// APPROVAL_PENDING 상태에서 요청자 본인이 결재 요청을 취소.
+async function handleCancelApproval() {
+  if (!sourceRow.value) return
+  try {
+    await cancelPurchaseOrderApproval(sourceRow.value.id)
+    await loadPoDocuments()
+    success(`${sourceRow.value.id} 결재 요청이 취소되었습니다.`)
+  } catch (e) {
+    error(e.response?.data?.message || '결재 요청 취소 중 오류가 발생했습니다.')
+  }
+}
 </script>
 
 <template>
@@ -878,6 +911,17 @@ function cancelDeleteApprovalRequest() {
               <i class="fas fa-trash text-xs" aria-hidden="true"></i>
             </template>
             {{ ['확정','confirmed','CONFIRMED'].includes(detail.status) ? '삭제요청' : '삭제' }}
+          </BaseButton>
+          <BaseButton
+            v-if="['결재대기','pending_approval','APPROVAL_PENDING'].includes(detail.status)"
+            variant="secondary"
+            size="sm"
+            @click="handleCancelApproval"
+          >
+            <template #leading>
+              <i class="fas fa-undo text-xs" aria-hidden="true"></i>
+            </template>
+            결재 요청 취소
           </BaseButton>
           <BaseButton variant="secondary" size="sm" @click="openPreview">
             <template #leading>


### PR DESCRIPTION
## 📋 작업 내용

영업팀원 워크플로우 Phase 1 의 프론트 반영. 백엔드는 team2-backend-documents@c7bbecd 에 이미 머지됨.

### 변경 파일

| 파일 | 변경 |
|------|-----|
| \`src/api/documents.js\` | update/delete/cancelApproval 헬퍼 6개 신규 (PI/PO 대칭) |
| \`src/views/documents/PIDetailPage.vue\` | handleDelete 에 DRAFT 분기 추가, handleCancelApproval 추가, 결재대기 상태 버튼 노출 |
| \`src/views/documents/PODetailPage.vue\` | PI 와 동일 대칭 |

### 상태별 버튼 매트릭스

| 상태 | 수정 | 삭제 | 결재 요청 취소 |
|------|-----|------|---------------|
| 초안 (DRAFT) | 수정 (로컬 only, 후속) | **삭제** → DELETE /{id} (신규 직접 호출) | - |
| 결재대기 (APPROVAL_PENDING) | - | - | **결재 요청 취소** → POST /{id}/cancel-approval (신규) |
| 확정 (CONFIRMED) | 수정요청 (기존) | 삭제요청 (기존) | - |

### 백엔드 동작 (참고)
- DELETE /proforma-invoices/{piId} / DELETE /purchase-orders/{poId} — DRAFT 만 허용. soft delete (status=DELETED).
- POST /proforma-invoices/{piId}/cancel-approval / POST /purchase-orders/{poId}/cancel-approval — APPROVAL_PENDING 만 허용. PENDING ApprovalRequest 를 delete 하고 requestType 에 따라 DRAFT (REGISTRATION) 또는 CONFIRMED (MOD/DEL) 로 상태 복구.

## 🔗 관련 이슈
- closes #401

## 📸 스크린샷 (선택)
N/A — 배포 후 스테이징에서 재검증. 재검증 포인트:
- 영업팀원 계정으로 초안 PI/PO 생성 → 상세에서 '삭제' → 즉시 삭제되는지 (Network: DELETE 200)
- 영업팀원 계정으로 등록 결재 요청 후 결재대기 상태에서 '결재 요청 취소' 클릭 → 초안으로 복구되는지 (Network: POST /cancel-approval 200, 상태 DRAFT)

## ✅ 체크리스트
- [x] 정상 동작 확인 (코드 레벨)
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게
- **초안 수정 저장 API 연동 은 범위 외**입니다. PIFormModal 의 @save payload 를 백엔드 ProformaInvoiceCreateRequest DTO 로 변환하는 buildUpdatePayload 유틸이 필요하고, PIPage.vue 의 기존 buildCreatePayload 를 공통 util 로 빼는 작업이 따라옵니다. 별도 이슈로 분리하는 게 안전하다고 판단.
- 결재 요청 취소는 요청자 본인만 가능 (백엔드 가드). 팀장 즉시 확정/삭제 는 요청자 본인이 아닐 수 있으므로 이 버튼이 의미 없을 수도 있지만, 현재로는 버튼만 눌러도 409 로 안전하게 실패.

🤖 Generated with [Claude Code](https://claude.com/claude-code)