### PR TITLE
feat(documents): 생산지시서 발행 담당자 선택 + 완료 권한 담당자 본인 제한

### DIFF
--- a/src/api/documents.js
+++ b/src/api/documents.js
@@ -98,6 +98,12 @@ export const fetchProductionOrder = (id) =>
   api.get(`/production-orders/${id}`).then((r) => r.data)
 export const completeProductionOrder = (productionOrderId) =>
   api.put(`/production-orders/${productionOrderId}/complete`).then((r) => r.data)
+// 생산지시서 발행 (담당자 지정 가능). payload: { assigneeUserId, assigneeName } | null
+export const generateProductionOrder = (poId, payload) =>
+  api.post(`/purchase-orders/${poId}/generate-production-order`, payload ?? {}).then((r) => r.data)
+// 담당자 후보 조회: role=production|shipping. Documents 가 Auth Feign 으로 프록시.
+export const fetchAssignableUsers = (role) =>
+  api.get('/assignable-users', { params: { role } }).then((r) => r.data)
 
 // ── Shipment Orders ──────────────────────────────────────────
 export async function fetchShipmentOrdersPaged({ page = 0, size = 20 } = {}) {

--- a/src/components/domain/document/ProductionOrderIssueModal.vue
+++ b/src/components/domain/document/ProductionOrderIssueModal.vue
@@ -1,0 +1,105 @@
+<script setup>
+import { computed, ref, watch } from 'vue'
+import BaseButton from '@/components/common/BaseButton.vue'
+import BaseModal from '@/components/common/BaseModal.vue'
+import BaseSelect from '@/components/common/BaseSelect.vue'
+import FormField from '@/components/common/FormField.vue'
+import { fetchAssignableUsers } from '@/api/documents'
+
+const props = defineProps({
+  open: { type: Boolean, default: false },
+  po: { type: Object, default: () => null },
+  saving: { type: Boolean, default: false },
+})
+
+const emit = defineEmits(['confirm', 'cancel'])
+
+// 생산담당자 후보 (role=production, active). 모달 오픈 시점에 로드.
+const candidates = ref([])
+const loading = ref(false)
+const loadError = ref('')
+const selectedUserId = ref(null)
+
+const options = computed(() => candidates.value.map((u) => ({
+  label: `${u.userName ?? ''}${u.departmentName ? ` (${u.departmentName})` : ''}`,
+  value: u.userId,
+})))
+
+const selectedCandidate = computed(() => candidates.value.find((u) => u.userId === selectedUserId.value))
+
+const detailRows = computed(() => {
+  if (!props.po) return []
+  return [
+    { label: '원천 PO', value: props.po.id ?? '-' },
+    { label: '거래처', value: props.po.clientName ?? '-' },
+    { label: '국가', value: props.po.country ?? '-' },
+    { label: '납기일', value: props.po.deliveryDate ?? '-' },
+  ]
+})
+
+async function loadCandidates() {
+  loading.value = true
+  loadError.value = ''
+  try {
+    const data = await fetchAssignableUsers('production')
+    candidates.value = Array.isArray(data) ? data : []
+  } catch (e) {
+    console.error('생산담당자 후보 조회 실패', e)
+    loadError.value = '생산담당자 후보를 불러오지 못했습니다. 미지정으로 발행 시 PO 영업담당자가 자동 할당됩니다.'
+    candidates.value = []
+  } finally {
+    loading.value = false
+  }
+}
+
+watch(() => props.open, (isOpen) => {
+  if (isOpen) {
+    selectedUserId.value = null
+    loadCandidates()
+  }
+})
+
+function handleConfirm() {
+  // 드롭다운 미선택 시 null 전달 → 백엔드가 PO 영업담당자 승계.
+  emit('confirm', {
+    assigneeUserId: selectedUserId.value ?? null,
+    assigneeName: selectedCandidate.value?.userName ?? null,
+  })
+}
+</script>
+
+<template>
+  <BaseModal :open="open" title="생산지시서 발행" width="max-w-xl" @close="emit('cancel')">
+    <div class="space-y-4 text-sm">
+      <div class="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 leading-6 text-slate-700">
+        선택한 PO 기준으로 생산지시서를 발행합니다. 발행 시 지정한 담당자만 생산완료 처리가 가능합니다.
+      </div>
+
+      <dl class="grid grid-cols-1 gap-2 md:grid-cols-2">
+        <div
+          v-for="row in detailRows"
+          :key="row.label"
+          class="rounded-md border border-slate-200 bg-white px-4 py-3"
+        >
+          <dt class="text-xs font-medium text-slate-500">{{ row.label }}</dt>
+          <dd class="mt-1 text-sm font-medium text-slate-800">{{ row.value }}</dd>
+        </div>
+      </dl>
+
+      <FormField label="생산담당자" hint="미선택 시 PO 영업담당자가 자동 할당됩니다.">
+        <BaseSelect
+          v-model="selectedUserId"
+          :options="options"
+          :placeholder="loading ? '불러오는 중...' : (candidates.length ? '생산담당자 선택' : '등록된 생산담당자 없음')"
+          :disabled="loading || !candidates.length"
+        />
+        <p v-if="loadError" class="mt-1 text-xs text-amber-600">{{ loadError }}</p>
+      </FormField>
+    </div>
+
+    <template #footer>
+      <BaseButton variant="secondary" @click="emit('cancel')">취소</BaseButton>
+      <BaseButton :disabled="saving" @click="handleConfirm">{{ saving ? '발행 중...' : '발행' }}</BaseButton>
+    </template>
+  </BaseModal>
+</template>

--- a/src/stores/productionOrderDocuments.js
+++ b/src/stores/productionOrderDocuments.js
@@ -38,6 +38,7 @@ function mapProductionOrderResponse(row) {
     clientAddress: row.clientAddress ?? '-',
     itemName: row.itemName ?? items[0]?.name ?? '-',
     manager: row.managerName ?? '-',
+    managerId: row.managerId ?? null,
     dueDate: formatDate(row.dueDate),
     department: row.department ?? '-',
     productionSite: row.productionSite ?? '-',

--- a/src/views/documents/PODetailPage.vue
+++ b/src/views/documents/PODetailPage.vue
@@ -12,12 +12,14 @@ import { formatRevisionEntry } from '@/utils/revisionFormat'
 import DocumentPreviewModal from '@/components/domain/document/DocumentPreviewModal.vue'
 import PODocumentTemplate from '@/components/domain/document/PODocumentTemplate.vue'
 import POFormModal from '@/components/domain/document/POFormModal.vue'
+import ProductionOrderIssueModal from '@/components/domain/document/ProductionOrderIssueModal.vue'
 import {
   requestPoModification,
   validatePoDeletable,
   requestPoDeletion,
   deletePurchaseOrderDraft,
   cancelPurchaseOrderApproval,
+  generateProductionOrder,
 } from '@/api/documents'
 import { useSearchModalLookups } from '@/composables/useSearchModalLookups'
 import { useToast } from '@/composables/useToast'
@@ -26,7 +28,7 @@ import { useCiDocuments } from '@/stores/ciDocuments'
 import { usePiDocuments } from '@/stores/piDocuments'
 import { usePlDocuments } from '@/stores/plDocuments'
 import { loadPoDocuments, usePoDocuments } from '@/stores/poDocuments'
-import { useProductionOrderDocuments } from '@/stores/productionOrderDocuments'
+import { loadProductionOrderDocuments, useProductionOrderDocuments } from '@/stores/productionOrderDocuments'
 import { useShipmentOrderDocuments } from '@/stores/shipmentOrderDocuments'
 import { useShipmentStatusDocuments } from '@/stores/shipmentStatusDocuments'
 import {
@@ -741,79 +743,50 @@ function createNextProductionOrderId() {
   return `MO${String(maxNumber + 1)}`
 }
 
-async function confirmIssueProductionOrder() {
+// 발행 모달 확인 시 호출 — payload: { assigneeUserId, assigneeName } | null.
+// 백엔드가 실제 DB 레코드를 생성하므로 저장 후 store refetch.
+const productionIssueSaving = ref(false)
+async function confirmIssueProductionOrder(payload) {
   if (!sourceRow.value || !canIssueProductionOrder.value) return
+  if (productionIssueSaving.value) return
 
-  const productionOrderId = createNextProductionOrderId()
-  const currency = sourceRow.value.currency || 'USD'
-  const items = (sourceRow.value.items ?? []).map((item) => {
-    const quantity = String(item.qty ?? item.quantity ?? '')
-    const unit = item.unit ?? 'EA'
-    const unitPriceValue = parseNumericValue(item.unitPrice)
-    const amountValue = parseNumericValue(item.amount)
-
-    return {
-      name: item.name ?? '',
-      quantity,
-      unit,
-      unitPrice: formatCurrencyValue(currency, unitPriceValue),
-      amount: formatCurrencyValue(currency, amountValue),
-      remark: item.remark ?? '',
-    }
-  })
-
-  const nextProductionOrder = {
-    id: productionOrderId,
-    status: '진행중',
-    issueDate: formatTodaySlashDate(),
-    poId: sourceRow.value.id,
-    country: sourceRow.value.country || '-',
-    clientName: sourceRow.value.clientName,
-    clientAddress: sourceRow.value.clientAddress || '',
-    itemName: sourceRow.value.itemName || items[0]?.name || '-',
-    manager: sourceRow.value.manager || authStore.currentUser?.name || '-',
-    dueDate: sourceRow.value.deliveryDate || '-',
-    department: '영업부',
-    productionSite: '-',
-    requestedBy: authStore.currentUser?.name || sourceRow.value.manager || '-',
-    completionTarget: sourceRow.value.deliveryDate || '-',
-    remarks: 'PO 기준으로 생산지시서가 발행되었습니다.',
-    linkedDocuments: [{ id: sourceRow.value.id, status: sourceRow.value.status }],
-    items,
+  const poId = sourceRow.value.id
+  productionIssueSaving.value = true
+  try {
+    await generateProductionOrder(poId, payload ?? null)
+  } catch (e) {
+    productionIssueSaving.value = false
+    error(e.response?.data?.message || '생산지시서 발행 중 오류가 발생했습니다.')
+    return
   }
 
-  productionOrderDocuments.value = [nextProductionOrder, ...productionOrderDocuments.value]
-  poDocuments.value = poDocuments.value.map((row) => {
-    if (row.id !== sourceRow.value.id) return row
-
-    const currentLinks = row.linkedDocuments ?? []
-    const hasProductionLink = currentLinks.some((document) => document.id === productionOrderId)
-
-    return {
-      ...row,
-      linkedDocuments: hasProductionLink
-        ? currentLinks
-        : [...currentLinks, { id: productionOrderId, status: nextProductionOrder.status }],
-    }
-  })
-
+  await loadProductionOrderDocuments()
+  productionIssueSaving.value = false
   productionIssueConfirmOpen.value = false
+
+  // 메일 이력은 best-effort (백엔드가 자동 발송하지만 활동 로그는 이 경로 유지).
   try {
     await recordDocumentEmailActivities({
-      clientName: nextProductionOrder.clientName,
-      poId: nextProductionOrder.poId,
-      sender: authStore.currentUser?.name || nextProductionOrder.requestedBy,
-      title: `[SalesBoost] ${nextProductionOrder.id} 생산지시서 발송`,
+      clientName: sourceRow.value.clientName,
+      poId,
+      sender: authStore.currentUser?.userName || authStore.currentUser?.name || '-',
+      title: `[SalesBoost] ${poId} 생산지시서 발송`,
       types: ['생산지시서'],
-      attachments: [`${nextProductionOrder.id}.pdf`],
+      attachments: [],
     })
   } catch (emailError) {
     console.error('생산지시서 메일 발송 이력 기록 실패', emailError)
-    warning('생산지시서는 발행되었지만 메일 발송 이력 기록에는 실패했습니다.')
   }
-  success(`${productionOrderId} 생산지시서가 발행되었습니다.`)
-  await nextTick()
-  router.push({ name: 'production-detail', params: { id: productionOrderId } })
+
+  // 방금 발행된 지시서 상세로 이동 (poId 매칭 + 생성일 최신).
+  const latest = productionOrderDocuments.value
+      .filter((p) => p.poId === poId)
+      .sort((a, b) => String(b.id).localeCompare(String(a.id)))[0]
+  success(`${latest?.id ?? ''} 생산지시서가 발행되었습니다.`.trim())
+  if (latest?.id) {
+    await nextTick()
+    router.push({ name: 'production-detail', params: { id: latest.id } })
+  }
 }
 
 function confirmEditRequestIntent() {
@@ -1222,15 +1195,10 @@ async function handleCancelApproval() {
       @cancel="cancelDeleteApprovalRequest"
     />
 
-    <ConfirmModal
+    <ProductionOrderIssueModal
       :open="productionIssueConfirmOpen"
-      title="생산지시서 발행"
-      message="선택한 PO를 기준으로 생산지시서를 발행하시겠습니까?"
-      :detail-rows="productionIssueConfirmRows"
-      confirm-label="발행"
-      cancel-label="취소"
-      helper-text="생산지시서는 선택 분기 문서이며, 발행 후 참조 문서에 자동 연결됩니다."
-      width="max-w-2xl"
+      :po="sourceRow"
+      :saving="productionIssueSaving"
       @confirm="confirmIssueProductionOrder"
       @cancel="closeProductionIssueConfirm"
     />

--- a/src/views/documents/ProductionOrderDetailPage.vue
+++ b/src/views/documents/ProductionOrderDetailPage.vue
@@ -48,8 +48,18 @@ const detail = computed(() => {
 const displayItems = computed(() => enrichDocumentItems(detail.value?.items ?? []))
 const isProductionUser = computed(() => authStore.currentUser?.role === 'production')
 const isAdminUser = computed(() => authStore.currentUser?.role === 'admin')
+// 담당자 본인만 완료 처리 가능 (admin 면제). managerId 가 지정되지 않은 레거시 데이터는 role 체크로 통과.
+const isAssignee = computed(() => {
+  if (detail.value?.managerId == null) return true
+  const uid = authStore.currentUser?.userId
+  return uid != null && Number(detail.value.managerId) === Number(uid)
+})
 const canShowCompleteButton = computed(() => isProductionUser.value || isAdminUser.value)
-const canCompleteProduction = computed(() => canShowCompleteButton.value && detail.value?.status === '진행중')
+const canCompleteProduction = computed(() => (
+  canShowCompleteButton.value
+  && detail.value?.status === '진행중'
+  && (isAdminUser.value || isAssignee.value)
+))
 const totalQuantity = computed(() => (
   displayItems.value.reduce((sum, item) => sum + Number.parseInt(item.quantity, 10), 0)
 ))
@@ -130,6 +140,8 @@ async function confirmCompleteProduction() {
   } catch (e) {
     if (e.response?.status === 403) {
       toast.error('생산완료 처리 권한이 없습니다.')
+    } else if (e.response?.status === 409 || /담당자/.test(e.response?.data?.message ?? '')) {
+      toast.error('지정된 담당자만 생산완료 처리할 수 있습니다.')
     } else {
       toast.error('생산완료 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.')
     }


### PR DESCRIPTION
## 📋 작업 내용

Phase 2-A. 백엔드는 team2-backend-documents@d8e4463 에 이미 머지됨.

### 변경 파일
| 파일 | 변경 |
|------|-----|
| \`src/components/domain/document/ProductionOrderIssueModal.vue\` | 신규 — 담당자 드롭다운 + 발행 확인 모달 |
| \`src/api/documents.js\` | \`generateProductionOrder\`, \`fetchAssignableUsers\` 추가 |
| \`src/views/documents/PODetailPage.vue\` | 기존 ConfirmModal → IssueModal 교체, confirmIssue 가 실제 API 호출 + store refetch |
| \`src/views/documents/ProductionOrderDetailPage.vue\` | 완료 버튼 조건 강화 (담당자 본인) + 409 에러 메시지 |
| \`src/stores/productionOrderDocuments.js\` | mapper 에 \`managerId\` 추가 |

### 흐름
1. PO 확정 상태에서 '생산지시서 발행' 버튼 → IssueModal 오픈 → \`GET /api/assignable-users?role=production\` 으로 생산 role 활성 유저 로드.
2. 담당자 선택 후 '발행' → \`POST /api/purchase-orders/{poId}/generate-production-order\` with body \`{ assigneeUserId, assigneeName }\`.
3. 성공 시 \`loadProductionOrderDocuments()\` refetch → 최신 지시서 상세로 이동.
4. 생산담당자 본인(또는 admin)만 상세에서 '생산완료 처리' 버튼 활성화.

### 설계 결정
- **담당자 미선택 시 null 허용**: 백엔드가 PO 영업담당자 승계 (기존 동작). 생산 role 유저가 아직 없을 때 등 fallback.
- **레거시 데이터**: \`managerId\` null 이면 role 체크만으로 완료 허용 (역호환).

## 🔗 관련 이슈
- closes #403

## 📸 스크린샷 (선택)
N/A — 배포 후 스테이징 재검증.
- admin 으로 PO260001 상세에서 '생산지시서 발행' → 모달에 생산 role 사용자 목록 노출 확인
- 박생산(생산 role)으로 지정하여 발행 → 생산지시서 발행 확인
- 박생산 로그인 → 생산지시서 상세 → '생산완료 처리' 버튼 활성화 확인
- 다른 생산 role 유저(있다면)로 로그인 → 같은 지시서 '완료 처리' 비활성 또는 409

## ✅ 체크리스트
- [x] 정상 동작 확인 (코드 레벨)
- [x] 불필요한 mock 로직 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게
- Phase 2-B (출하지시서 담당자 선택, 재할당, 출하 완료 권한) 는 별도 이슈로 후속.
- 생산지시서 Query 응답에 \`managerId\` 필드가 포함되어야 프론트 완료 버튼 조건이 본인 체크로 동작합니다. 없으면 role 체크로 통과(역호환). 필요시 QueryDTO 확인 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)