### PR TITLE
fix: PI 수정 결재 요청 API 연동 + 로그아웃 시 document store 캐시 초기화

### DIFF
--- a/src/api/documents.js
+++ b/src/api/documents.js
@@ -39,6 +39,9 @@ export const deleteProformaInvoiceDraft = (piId) =>
 // 결재대기 상태의 PI 결재 요청을 요청자 본인이 취소.
 export const cancelProformaInvoiceApproval = (piId) =>
   api.post(`/proforma-invoices/${piId}/cancel-approval`).then((r) => r.data)
+// 확정 PI 수정 결재 요청 (PO 의 requestPoModification 과 대칭).
+export const requestPiModification = (payload) =>
+  api.post('/proforma-invoices/request-modification', payload).then((r) => r.data)
 
 // ── Purchase Orders ──────────────────────────────────────────
 export async function fetchPurchaseOrdersPaged({ page = 0, size = 20 } = {}) {

--- a/src/stores/auth.js
+++ b/src/stores/auth.js
@@ -50,6 +50,19 @@ export const useAuthStore = defineStore('auth', () => {
     }
     accessToken.value = null
     user.value = null
+
+    // 재로그인 시 이전 계정 캐시 노출 방지. document/status store 전체 초기화.
+    // 동적 import 로 circular dependency 회피 (각 store 는 auth store 를 use).
+    await Promise.all([
+      import('./piDocuments').then((m) => m.clearPiDocuments()),
+      import('./poDocuments').then((m) => m.clearPoDocuments()),
+      import('./ciDocuments').then((m) => m.clearCiDocuments()),
+      import('./plDocuments').then((m) => m.clearPlDocuments()),
+      import('./productionOrderDocuments').then((m) => m.clearProductionOrderDocuments()),
+      import('./shipmentOrderDocuments').then((m) => m.clearShipmentOrderDocuments()),
+      import('./shipmentStatusDocuments').then((m) => m.clearShipmentStatusDocuments()),
+      import('./salesCollectionDocuments').then((m) => m.clearSalesCollectionDocuments()),
+    ]).catch((e) => console.error('document store reset 중 오류', e))
   }
 
   /**

--- a/src/stores/ciDocuments.js
+++ b/src/stores/ciDocuments.js
@@ -94,3 +94,9 @@ export function useCiDocuments() {
 export function useCiPageInfo() {
   return ciPageInfo
 }
+
+export function clearCiDocuments() {
+  ciDocuments.value = []
+  ciPageInfo.value = { size: 1000, number: 0, totalElements: 0, totalPages: 0 }
+  loading = null
+}

--- a/src/stores/piDocuments.js
+++ b/src/stores/piDocuments.js
@@ -97,3 +97,10 @@ export function usePiDocuments() {
 export function usePiPageInfo() {
   return piPageInfo
 }
+
+/** 로그아웃 시 호출 — loading 플래그와 캐시를 초기화하여 재로그인 시 이전 세션 데이터 노출 방지. */
+export function clearPiDocuments() {
+  piDocuments.value = []
+  piPageInfo.value = { size: 1000, number: 0, totalElements: 0, totalPages: 0 }
+  loading = null
+}

--- a/src/stores/plDocuments.js
+++ b/src/stores/plDocuments.js
@@ -94,3 +94,9 @@ export function usePlDocuments() {
 export function usePlPageInfo() {
   return plPageInfo
 }
+
+export function clearPlDocuments() {
+  plDocuments.value = []
+  plPageInfo.value = { size: 1000, number: 0, totalElements: 0, totalPages: 0 }
+  loading = null
+}

--- a/src/stores/poDocuments.js
+++ b/src/stores/poDocuments.js
@@ -108,3 +108,9 @@ export function usePoDocuments() {
 export function usePoPageInfo() {
   return poPageInfo
 }
+
+export function clearPoDocuments() {
+  poDocuments.value = []
+  poPageInfo.value = { size: 1000, number: 0, totalElements: 0, totalPages: 0 }
+  loading = null
+}

--- a/src/stores/productionOrderDocuments.js
+++ b/src/stores/productionOrderDocuments.js
@@ -68,6 +68,12 @@ export function useProductionOrderPageInfo() {
   return productionOrderPageInfo
 }
 
+export function clearProductionOrderDocuments() {
+  productionOrderDocuments.value = []
+  productionOrderPageInfo.value = { size: 1000, number: 0, totalElements: 0, totalPages: 0 }
+  loading = null
+}
+
 export function useProductionOrderDocuments() {
   const auth = useAuthStore()
   const role = auth.currentUser?.role

--- a/src/stores/salesCollectionDocuments.js
+++ b/src/stores/salesCollectionDocuments.js
@@ -35,6 +35,12 @@ export function useSalesCollectionDocuments() {
   return salesCollectionDocuments
 }
 
+export function clearSalesCollectionDocuments() {
+  salesCollectionDocuments.value = []
+  salesCollectionPageInfo.value = { size: 1000, number: 0, totalElements: 0, totalPages: 0 }
+  loading = null
+}
+
 export function useSalesCollectionPageInfo() {
   return salesCollectionPageInfo
 }

--- a/src/stores/shipmentOrderDocuments.js
+++ b/src/stores/shipmentOrderDocuments.js
@@ -68,6 +68,12 @@ export function useShipmentOrderDocuments() {
   return shipmentOrderDocuments
 }
 
+export function clearShipmentOrderDocuments() {
+  shipmentOrderDocuments.value = []
+  shipmentOrderPageInfo.value = { size: 1000, number: 0, totalElements: 0, totalPages: 0 }
+  loading = null
+}
+
 export function useShipmentOrderPageInfo() {
   return shipmentOrderPageInfo
 }

--- a/src/stores/shipmentStatusDocuments.js
+++ b/src/stores/shipmentStatusDocuments.js
@@ -42,6 +42,12 @@ export function useShipmentStatusPageInfo() {
   return shipmentStatusPageInfo
 }
 
+export function clearShipmentStatusDocuments() {
+  shipmentStatusDocuments.value = []
+  shipmentStatusPageInfo.value = { size: 1000, number: 0, totalElements: 0, totalPages: 0 }
+  loading = null
+}
+
 export function useShipmentStatusDocuments() {
   const auth = useAuthStore()
   const role = auth.currentUser?.role

--- a/src/views/documents/PIDetailPage.vue
+++ b/src/views/documents/PIDetailPage.vue
@@ -15,6 +15,7 @@ import PIFormModal from '@/components/domain/document/PIFormModal.vue'
 import {
   validatePiDeletable,
   requestPiDeletion,
+  requestPiModification,
   deleteProformaInvoiceDraft,
   cancelProformaInvoiceApproval,
 } from '@/api/documents'
@@ -677,47 +678,20 @@ function cancelEditRequestIntent() {
   pendingEditRequest.value = null
 }
 
-// TODO: PI 수정 결재 API (request-modification) 가 백엔드에 추가되면
-//       PO 와 동일하게 requestPiModification 연동으로 교체한다.
-//       현재는 로컬-only 로 스냅샷 비교만 수행 → 새로고침 시 소실됨.
-function confirmEditApprovalRequest() {
+async function confirmEditApprovalRequest() {
   if (!pendingEditRequest.value) return
+  try {
+    const userId = authStore.currentUser?.userId
+    await requestPiModification({ piId: pendingEditRequest.value.id, userId })
+    await loadPiDocuments()
 
-  const requesterName = getCurrentRequesterName()
-  const requestedAt = getRequestedAt()
-  const approvalReview = createApprovalReviewSnapshot({
-    title: 'PI 수정 결재 검토',
-    message: '요청된 변경 사항과 변경 후 문서 정보를 검토한 뒤 승인 또는 반려를 결정합니다.',
-    requestRows: editApprovalRequestRows.value,
-    documentRows: editApprovalDocumentRows.value,
-    changeRows: pendingEditRequest.value.changeRows ?? [],
-    itemRows: editApprovalItemRows.value,
-    itemSummaryRows: editApprovalItemSummaryRows.value,
-    documentSectionTitle: '수정 대상 PI 정보',
-    changeSectionTitle: '변경 사항 비교',
-    itemSectionTitle: '변경 후 PI 품목 정보',
-    helperText: '수정 요청은 승인 전까지 확정되지 않으며, 반려 시 요청 상태만 반영됩니다.',
-  })
-
-  piDocuments.value = piDocuments.value.map((row) => (
-    row.id === pendingEditRequest.value.id
-      ? {
-        ...row,
-        ...pendingEditRequest.value.nextRow,
-        approvalReview,
-        ...createEditApprovalMeta({
-          approver: pendingEditRequest.value.approver,
-          requesterName,
-          requestedAt,
-        }),
-      }
-      : row
-  ))
-
-  editApprovalRequestOpen.value = false
-  pendingEditRequest.value = null
-  formOpen.value = false
-  success(`${sourceRow.value?.id} 수정 결재 요청이 전송되었습니다.`)
+    editApprovalRequestOpen.value = false
+    pendingEditRequest.value = null
+    formOpen.value = false
+    success(`${sourceRow.value?.id} 수정 결재 요청이 전송되었습니다.`)
+  } catch (e) {
+    error(e.response?.data?.message || '수정 결재 요청 중 오류가 발생했습니다.')
+  }
 }
 
 function cancelEditApprovalRequest() {

--- a/src/views/documents/PIPage.vue
+++ b/src/views/documents/PIPage.vue
@@ -20,6 +20,7 @@ import PIFormModal from '@/components/domain/document/PIFormModal.vue'
 import {
   createProformaInvoice,
   requestPiRegistration,
+  requestPiModification,
   validatePiDeletable,
   requestPiDeletion,
 } from '@/api/documents'
@@ -815,45 +816,21 @@ function cancelCreateApprovalRequest() {
   createApprovalRequestOpen.value = false
 }
 
-function confirmEditApprovalRequest() {
+async function confirmEditApprovalRequest() {
   if (!pendingEditRequest.value) return
+  try {
+    const userId = authStore.currentUser?.userId
+    await requestPiModification({ piId: pendingEditRequest.value.id, userId })
+    await loadPiDocuments()
 
-  const requesterName = getCurrentRequesterName()
-  const requestedAt = getRequestedAt()
-  const approvalReview = createApprovalReviewSnapshot({
-    title: 'PI 수정 결재 검토',
-    message: '요청된 변경 사항과 변경 후 문서 정보를 검토한 뒤 승인 또는 반려를 결정합니다.',
-    requestRows: editApprovalRequestRows.value,
-    documentRows: editApprovalDocumentRows.value,
-    changeRows: pendingEditRequest.value.changeRows ?? [],
-    itemRows: editApprovalItemRows.value,
-    itemSummaryRows: editApprovalItemSummaryRows.value,
-    documentSectionTitle: '수정 대상 PI 정보',
-    changeSectionTitle: '변경 사항 비교',
-    itemSectionTitle: '변경 후 PI 품목 정보',
-    helperText: '수정 요청은 승인 전까지 확정되지 않으며, 반려 시 요청 상태만 반영됩니다.',
-  })
-
-  rowsData.value = rowsData.value.map((row) => (
-    row.id === pendingEditRequest.value.id
-      ? {
-        ...row,
-        ...pendingEditRequest.value.nextRow,
-        approvalReview,
-        ...createEditApprovalMeta({
-          approver: pendingEditRequest.value.approver || row.approver || '',
-          requesterName,
-          requestedAt,
-        }),
-      }
-      : row
-  ))
-
-  editApprovalRequestOpen.value = false
-  pendingEditRequest.value = null
-  formOpen.value = false
-  selectedClient.value = null
-  success('PI 수정 결재 요청이 전송되었습니다.')
+    editApprovalRequestOpen.value = false
+    pendingEditRequest.value = null
+    formOpen.value = false
+    selectedClient.value = null
+    success('PI 수정 결재 요청이 전송되었습니다.')
+  } catch (e) {
+    error(e.response?.data?.message || 'PI 수정 결재 요청 중 오류가 발생했습니다.')
+  }
 }
 
 function cancelEditApprovalRequest() {


### PR DESCRIPTION
## 📋 작업 내용

Step1 ultrareview Critical 2 건 처리. 백엔드는 team2-backend-documents@05a1446 에 PI modification 엔드포인트 먼저 머지 완료.

### ① PI 수정 결재 요청 API 연동
- PIPage.vue / PIDetailPage.vue 의 \`confirmEditApprovalRequest\` 가 기존에 \`rowsData.value\` 로컬 뮤테이션만 수행 → 새로고침 시 변경 사라지고 결재자에게 도달 안 함. (TODO 주석 상태로 프로덕션 배포됨)
- PO 의 \`requestPoModification\` 대칭 패턴으로 수정. \`api/documents.js\` 에 \`requestPiModification\` 추가 + 두 페이지의 함수가 실제 \`POST /api/proforma-invoices/request-modification\` 호출 후 \`loadPiDocuments()\` refetch.

### ② 로그아웃 후 재로그인 시 이전 계정 데이터 노출
- 8 개 document/status store(\`piDocuments\`, \`poDocuments\`, \`ciDocuments\`, \`plDocuments\`, \`productionOrderDocuments\`, \`shipmentOrderDocuments\`, \`shipmentStatusDocuments\`, \`salesCollectionDocuments\`)가 모듈 레벨 \`let loading = null\` 을 써 logout 때 리셋되지 않음.
- admin 로그인 → 전체 데이터 캐시 → 로그아웃 → 영업팀원 재로그인 → admin 의 전체 데이터가 순간 노출 가능.
- 각 store 에 \`clear{Xxx}Documents()\` export 추가. \`auth.js\` logout 에서 dynamic import 로 8 개 clear 동시 호출 (circular dependency 회피).

## 🔗 관련 이슈
- closes #405

## 📸 스크린샷 (선택)
N/A — 배포 후 스테이징 재검증.
- 영업팀원으로 확정 PI 에서 '수정요청' → 결재자에게 도달 확인 (이전: 로컬만 변경)
- admin 로그인 → PI 목록 확인 → 로그아웃 → 영업팀원 재로그인 → PI 목록에 영업팀 스코프만 남는지 확인 (이전: admin 캐시 잔존)

## ✅ 체크리스트
- [x] 정상 동작 확인 (코드 레벨)
- [x] 불필요한 TODO/로컬 뮤테이션 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게
- 8 개 store 의 clear 함수는 단순 반복이지만 모듈 레벨 \`loading\` 변수를 리셋해야 하므로 store 내부에서 export 하는 방식이 필요. store 를 Pinia 로 마이그레이션하는 건 범위 외.
- PO 쪽 \`confirmEditApprovalRequest\` 는 이미 동일 패턴이라 건드리지 않음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)