### PR TITLE
fix: Step1 Major 잔여 4건 — activity API 2건 + 상태 한영 통일 + 대시보드 출하카드 권한

### DIFF
--- a/src/api/activity.js
+++ b/src/api/activity.js
@@ -2,9 +2,11 @@ import { api } from '@/lib/api'
 import { unwrapCollection } from '@/utils/apiResponse'
 
 // ── 거래처 ─────────────────────────────────────────────────
+// master 의 /api/clients/all 은 HATEOAS PagedModel 로 응답한다. unwrapCollection 으로
+// 배열만 꺼내야 호출자(활동기록 드롭다운 등)의 .map 이 정상 동작.
 export async function fetchActivityClients() {
-  const { data } = await api.get('/clients/all')
-  return data
+  const { data } = await api.get('/clients/all', { params: { size: 1000 } })
+  return unwrapCollection(data)
 }
 
 // ── 활동기록 ───────────────────────────────────────────────
@@ -28,9 +30,13 @@ export async function deleteActivity(id) {
 }
 
 // ── PO 검색 ────────────────────────────────────────────────
+// documents 의 /api/purchase-orders 는 clientId 쿼리 파라미터를 지원하지 않는다.
+// 전체 목록을 가져와 클라이언트 사이드에서 필터. 활동기록은 소량 PO 대상이라 허용.
 export async function fetchPOsByClient(clientId) {
-  const { data } = await api.get('/purchase-orders', { params: { clientId: Number(clientId) } })
-  return unwrapCollection(data)
+  const pos = await fetchAllActivityPOs()
+  const target = Number(clientId)
+  if (!Number.isFinite(target)) return pos
+  return (pos ?? []).filter((po) => Number(po.clientId) === target)
 }
 
 export async function fetchAllActivityPOs() {

--- a/src/utils/documentApproval.js
+++ b/src/utils/documentApproval.js
@@ -67,19 +67,24 @@ export function buildApprovalRequestRows({
   ]
 }
 
-// 문서 상태 + 요청 상태 + 결재 상태를 단일 라벨로 합산
+// 문서 상태 + 요청 상태 + 결재 상태를 단일 라벨로 합산.
+// 백엔드가 영문 code('pending_approval','pending','approved','rejected')를 내려줄 때와
+// 프론트 로컬 뮤테이션으로 한글('결재대기','대기','승인','반려')을 박아 둔 상태를 둘 다 수용.
 function resolveCompositeStatus(document) {
-  const status = document.status || ''
+  const normalize = (v) => String(v ?? '').trim().toLowerCase()
+  const statusNorm = normalize(document.status)
+  const approvalNorm = normalize(document.approvalStatus)
   const request = document.requestStatus || ''
-  const approval = document.approvalStatus || ''
 
-  if (status === '결재대기' && request) {
-    if (approval === '대기') return `${request} 결재대기`
-    if (approval === '승인') return `${request} 승인`
-    if (approval === '반려') return `${request} 반려`
+  const isPendingApproval =
+      statusNorm === '결재대기' || statusNorm === 'approval_pending' || statusNorm === 'pending_approval'
+  if (isPendingApproval && request) {
+    if (approvalNorm === '대기' || approvalNorm === 'pending') return `${request} 결재대기`
+    if (approvalNorm === '승인' || approvalNorm === 'approved') return `${request} 승인`
+    if (approvalNorm === '반려' || approvalNorm === 'rejected') return `${request} 반려`
     return `${request} 결재대기`
   }
-  return status || '-'
+  return document.status || '-'
 }
 
 export function buildApprovalInfoRows(document) {

--- a/src/views/DashboardPage.vue
+++ b/src/views/DashboardPage.vue
@@ -684,7 +684,7 @@ async function confirmPackageDelete() {
         </div>
       </BaseCard>
 
-      <BaseCard>
+      <BaseCard v-if="!isProductionUser">
         <template #title>
           <h3 class="font-bold text-slate-800">출하 현황</h3>
         </template>


### PR DESCRIPTION
## 📋 작업 내용
Step 1 ultrareview 에서 확인된 프론트 Major 잔여 4건 일괄 정리.

| 파일 | 변경 |
|------|-----|
| \`src/api/activity.js\` | \`fetchActivityClients\` — PagedModel 응답을 \`unwrapCollection\` 으로 배열 추출 |
| \`src/api/activity.js\` | \`fetchPOsByClient\` — documents 는 clientId 쿼리 미지원 → 전체 받아 클라 사이드 필터 |
| \`src/utils/documentApproval.js\` | \`resolveCompositeStatus\` — 영문 code / 한글 라벨 모두 수용 |
| \`src/views/DashboardPage.vue\` | 출하 현황 카드 \`v-if=\"!isProductionUser\"\` — 생산 role 에서 숨김 |

## 🔗 관련 이슈
- closes #407

## 연관 백엔드 수정 (main 직푸시)
- \`team2-backend-activity@c8d2b1d\` dev profile InternalApiTokenFilter
- \`team2-backend-documents@fdfe485\` pi_items resultMap PK 교정
- 루트 \`ddl/activity_service.sql\` email_status ENUM 'sending' 추가
- \`team2-manifest@5e63b88\` nginx /actuator/ 외부 차단

## ✅ 체크리스트
- [x] 정상 동작 확인 (코드 레벨)
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게
- ArgoCD write-back-method git 전환 + ProductionOrder/ShipmentOrder insertable 정리 는 운영 파급 고려해 별도 세션으로 분리.
- DB Batch 3 (piId String↔BIGINT) 는 마이그레이션 전략 필요해 보류 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)