### PR TITLE
fix(#409): 잔여 논리/정책 버그 정리 (상태·스코프·오너십·완료 락)

### DIFF
--- a/src/api/activity.js
+++ b/src/api/activity.js
@@ -2,9 +2,11 @@ import { api } from '@/lib/api'
 import { unwrapCollection } from '@/utils/apiResponse'
 
 // ── 거래처 ─────────────────────────────────────────────────
+// master 의 /api/clients/all 은 HATEOAS PagedModel 로 응답한다. unwrapCollection 으로
+// 배열만 꺼내야 호출자(활동기록 드롭다운 등)의 .map 이 정상 동작.
 export async function fetchActivityClients() {
-  const { data } = await api.get('/clients/all')
-  return data
+  const { data } = await api.get('/clients/all', { params: { size: 1000 } })
+  return unwrapCollection(data)
 }
 
 // ── 활동기록 ───────────────────────────────────────────────
@@ -28,9 +30,13 @@ export async function deleteActivity(id) {
 }
 
 // ── PO 검색 ────────────────────────────────────────────────
+// documents 의 /api/purchase-orders 는 clientId 쿼리 파라미터를 지원하지 않는다.
+// 전체 목록을 가져와 클라이언트 사이드에서 필터. 활동기록은 소량 PO 대상이라 허용.
 export async function fetchPOsByClient(clientId) {
-  const { data } = await api.get('/purchase-orders', { params: { clientId: Number(clientId) } })
-  return unwrapCollection(data)
+  const pos = await fetchAllActivityPOs()
+  const target = Number(clientId)
+  if (!Number.isFinite(target)) return pos
+  return (pos ?? []).filter((po) => Number(po.clientId) === target)
 }
 
 export async function fetchAllActivityPOs() {

--- a/src/api/package.js
+++ b/src/api/package.js
@@ -22,5 +22,10 @@ export function deletePackage(id) {
 }
 
 export function fetchAllUsers() {
-  return api.get('/users', { params: { size: 1000 } }).then((r) => unwrapCollection(r.data))
+  // 뷰어 선택용 최소 정보 엔드포인트. ADMIN 외 사용자도 조회 가능.
+  return api.get('/users/viewable').then((r) => {
+    const data = r.data
+    if (Array.isArray(data)) return data
+    return unwrapCollection(data)
+  })
 }

--- a/src/stores/piDocuments.js
+++ b/src/stores/piDocuments.js
@@ -41,6 +41,7 @@ function mapPiResponse(row) {
 
   return {
     id: row.piId,
+    managerId: row.managerId ?? null,
     issueDate: formatDate(row.issueDate),
     clientName: row.clientName ?? '-',
     clientAddress: row.clientAddress ?? '-',

--- a/src/stores/poDocuments.js
+++ b/src/stores/poDocuments.js
@@ -49,6 +49,7 @@ function mapPoResponse(row) {
 
   return {
     id: row.poId,
+    managerId: row.managerId ?? null,
     piId: row.piId ?? '',
     linkedPiId: row.piId ?? '',
     issueDate: formatDate(row.issueDate),

--- a/src/stores/salesCollectionDocuments.js
+++ b/src/stores/salesCollectionDocuments.js
@@ -6,11 +6,25 @@ function normalizeDocumentCode(value = '') {
   return String(value ?? '').replace(/[^A-Za-z0-9]/g, '')
 }
 
+const COLLECTION_STATUS_LABEL = {
+  paid: '수금완료',
+  unpaid: '미수금',
+  '수금완료': '수금완료',
+  '미수금': '미수금',
+}
+
+function normalizeCollectionStatus(raw) {
+  if (raw == null || raw === '') return '미수금'
+  return COLLECTION_STATUS_LABEL[String(raw).toLowerCase()] ?? COLLECTION_STATUS_LABEL[raw] ?? '미수금'
+}
+
 function normalizeCollectionRow(row) {
+  const status = normalizeCollectionStatus(row.status)
   return {
     ...row,
+    status,
     poId: row.poId ? normalizeDocumentCode(row.poId) : (row.poNo ?? ''),
-    collectionDate: row.status === '수금완료' ? row.collectionDate || null : null,
+    collectionDate: status === '수금완료' ? row.collectionDate || null : null,
   }
 }
 

--- a/src/stores/shipmentStatusDocuments.js
+++ b/src/stores/shipmentStatusDocuments.js
@@ -6,10 +6,22 @@ function formatDate(value) {
   return String(value ?? '').replace(/-/g, '/')
 }
 
+const SHIPMENT_STATUS_LABEL = {
+  preparing: '출하준비',
+  completed: '출하완료',
+  '출하준비': '출하준비',
+  '출하완료': '출하완료',
+}
+
+function normalizeShipmentStatus(raw) {
+  if (raw == null || raw === '') return '출하준비'
+  return SHIPMENT_STATUS_LABEL[String(raw).toLowerCase()] ?? SHIPMENT_STATUS_LABEL[raw] ?? '출하준비'
+}
+
 function mapShipmentResponse(row) {
   return {
     id: String(row.shipmentId ?? row.id ?? ''),
-    status: row.shipmentStatus ?? row.status ?? '출하준비',
+    status: normalizeShipmentStatus(row.shipmentStatus ?? row.status),
     clientName: row.clientName ?? '-',
     country: row.country ?? '-',
     poId: row.poId ?? '',

--- a/src/utils/documentApproval.js
+++ b/src/utils/documentApproval.js
@@ -67,19 +67,24 @@ export function buildApprovalRequestRows({
   ]
 }
 
-// 문서 상태 + 요청 상태 + 결재 상태를 단일 라벨로 합산
+// 문서 상태 + 요청 상태 + 결재 상태를 단일 라벨로 합산.
+// 백엔드가 영문 code('pending_approval','pending','approved','rejected')를 내려줄 때와
+// 프론트 로컬 뮤테이션으로 한글('결재대기','대기','승인','반려')을 박아 둔 상태를 둘 다 수용.
 function resolveCompositeStatus(document) {
-  const status = document.status || ''
+  const normalize = (v) => String(v ?? '').trim().toLowerCase()
+  const statusNorm = normalize(document.status)
+  const approvalNorm = normalize(document.approvalStatus)
   const request = document.requestStatus || ''
-  const approval = document.approvalStatus || ''
 
-  if (status === '결재대기' && request) {
-    if (approval === '대기') return `${request} 결재대기`
-    if (approval === '승인') return `${request} 승인`
-    if (approval === '반려') return `${request} 반려`
+  const isPendingApproval =
+      statusNorm === '결재대기' || statusNorm === 'approval_pending' || statusNorm === 'pending_approval'
+  if (isPendingApproval && request) {
+    if (approvalNorm === '대기' || approvalNorm === 'pending') return `${request} 결재대기`
+    if (approvalNorm === '승인' || approvalNorm === 'approved') return `${request} 승인`
+    if (approvalNorm === '반려' || approvalNorm === 'rejected') return `${request} 반려`
     return `${request} 결재대기`
   }
-  return status || '-'
+  return document.status || '-'
 }
 
 export function buildApprovalInfoRows(document) {

--- a/src/utils/documentOwnership.js
+++ b/src/utils/documentOwnership.js
@@ -1,0 +1,17 @@
+// PI/PO 문서 수정·삭제 권한 판정 유틸.
+// 서버가 이미 팀 스코프 필터를 강제하므로 목록에 나오는 행은 모두 같은 팀.
+// 따라서 여기서는 "같은 팀" 조건을 별도 검사하지 않고 (admin || 본인 || 팀장) 만 본다.
+//
+// rules:
+//  - admin: 전체 가능
+//  - positionLevel === 1 (팀장): 목록의 모든 행 가능
+//  - 그 외: row.managerId 가 본인일 때만
+export function canMutateDocument(row, user) {
+  if (!row || !user) return false
+  if (user.role === 'admin') return true
+  const uid = user.userId ?? user.id ?? null
+  const mid = row.managerId ?? null
+  if (uid != null && mid != null && String(uid) === String(mid)) return true
+  if (user.positionLevel === 1) return true
+  return false
+}

--- a/src/utils/documentShipmentLock.js
+++ b/src/utils/documentShipmentLock.js
@@ -93,6 +93,45 @@ export function formatPoShipmentLockMessage(lockInfo) {
   return `출하완료된 ${reference.type} ${reference.id}가 연결되어 있어 이 PO는 수정/삭제할 수 없습니다.`
 }
 
+/**
+ * PO 의 Collection 수금완료 락. collection.status === '수금완료' 인 건이 있으면 잠금.
+ */
+export function getPoCollectionLockInfo(poId, collectionDocuments = []) {
+  if (!poId) return { locked: false, references: [] }
+  const references = collectionDocuments
+    .filter((row) => String(row.poId ?? '') === String(poId) && row.status === '수금완료')
+    .map((row) => ({ type: '수금완료', id: row.collectionId ?? row.id ?? '' }))
+  return { locked: references.length > 0, references }
+}
+
+export function formatPoCollectionLockMessage(lockInfo) {
+  if (!lockInfo?.locked || !lockInfo.references?.length) return ''
+  const reference = lockInfo.references[0]
+  return `수금완료된 건${reference.id ? ` (ID: ${reference.id})` : ''}이 있어 이 PO는 수정/삭제할 수 없습니다.`
+}
+
+/**
+ * PI 의 간접 수금 락 — linked PO 중 하나라도 Collection PAID 이면 잠금.
+ */
+export function getPiCollectionLockInfo(piId, poDocuments = [], collectionDocuments = []) {
+  if (!piId) return { locked: false, references: [] }
+  const linkedPoIds = poDocuments
+    .filter((row) => row.piId === piId || row.linkedPiId === piId)
+    .map((row) => row.id)
+  const references = linkedPoIds.flatMap((poId) => (
+    collectionDocuments
+      .filter((row) => String(row.poId ?? '') === String(poId) && row.status === '수금완료')
+      .map((row) => ({ type: '수금완료', id: row.collectionId ?? row.id ?? '', poId }))
+  ))
+  return { locked: references.length > 0, references }
+}
+
+export function formatPiCollectionLockMessage(lockInfo) {
+  if (!lockInfo?.locked || !lockInfo.references?.length) return ''
+  const reference = lockInfo.references[0]
+  return `수금완료된 건이 연결된 PO ${reference.poId}가 있어 이 PI는 수정/삭제할 수 없습니다.`
+}
+
 export function formatPiShipmentLockMessage(lockInfo) {
   if (!lockInfo?.locked || !lockInfo.references?.length) {
     return ''

--- a/src/views/DashboardPage.vue
+++ b/src/views/DashboardPage.vue
@@ -684,7 +684,7 @@ async function confirmPackageDelete() {
         </div>
       </BaseCard>
 
-      <BaseCard>
+      <BaseCard v-if="!isProductionUser">
         <template #title>
           <h3 class="font-bold text-slate-800">출하 현황</h3>
         </template>

--- a/src/views/documents/CollectionsPage.vue
+++ b/src/views/documents/CollectionsPage.vue
@@ -15,6 +15,7 @@ import SearchableCombobox from '@/components/common/SearchableCombobox.vue'
 import { useDocumentFilter } from '@/composables/useDocumentFilter'
 import { usePagination } from '@/composables/usePagination'
 import { useSearchModalLookups } from '@/composables/useSearchModalLookups'
+import { useToast } from '@/composables/useToast'
 import { useSalesCollectionDocuments, normalizeSalesCollectionRow } from '@/stores/salesCollectionDocuments'
 import { openTableOutput } from '@/utils/documentOutput'
 import { convertCurrencyAmountToKrw } from '@/utils/exchangeRate'
@@ -29,6 +30,7 @@ const poSearchKeyword = ref('')
 const viewScope = ref('all')
 const currencyFilter = ref('')
 const appliedCurrencyFilter = ref('')
+const { warning } = useToast()
 const statusConfirmOpen = ref(false)
 const pendingStatusChange = ref(null)
 
@@ -249,6 +251,10 @@ function handlePoSelect(row) {
 }
 
 function openStatusConfirm(row, nextStatusValue) {
+  if (row.status === '수금완료' && nextStatusValue === 'UNPAID') {
+    warning('수금완료 건은 되돌릴 수 없습니다.')
+    return
+  }
   const nextStatus = nextStatusValue === 'PAID' ? '수금완료' : '미수금'
   const nextCollectionDate = resolveNextCollectionDate(row, nextStatusValue)
 
@@ -557,9 +563,17 @@ function downloadCurrentTablePdf() {
                   {{ formatCollectionDate(row.collectionDate) }}
                 </td>
                 <td class="border-b border-slate-200 px-4 py-3 text-center text-sm">
+                  <span
+                    v-if="row.status === '수금완료'"
+                    class="inline-flex items-center rounded-full bg-emerald-100 px-2.5 py-0.5 text-xs font-medium text-emerald-800"
+                    title="수금완료된 건은 상태를 변경할 수 없습니다."
+                  >
+                    수금완료
+                  </span>
                   <select
+                    v-else
                     class="cursor-pointer rounded-md border border-slate-200 bg-white px-2 py-1 text-xs focus:border-brand-400 focus:outline-none"
-                    :value="row.status === '수금완료' ? 'PAID' : 'UNPAID'"
+                    :value="'UNPAID'"
                     @change="openStatusConfirm(row, $event.target.value)"
                   >
                     <option value="UNPAID">미수금</option>

--- a/src/views/documents/PIDetailPage.vue
+++ b/src/views/documents/PIDetailPage.vue
@@ -41,6 +41,7 @@ import {
   formatPiShipmentLockMessage,
   getPiShipmentLockInfo,
 } from '@/utils/documentShipmentLock'
+import { canMutateDocument } from '@/utils/documentOwnership'
 import { formatReferenceDocumentStatus } from '@/utils/referenceDocumentStatus'
 import { formatIncotermsLabel, resolveIncotermState } from '@/utils/incoterms'
 import { clientSearchColumns } from '@/utils/searchModalColumns'
@@ -377,6 +378,8 @@ const shipmentLockInfo = computed(() => (
   )
 ))
 const shipmentLockMessage = computed(() => formatPiShipmentLockMessage(shipmentLockInfo.value))
+
+const canMutate = computed(() => canMutateDocument(sourceRow.value, authStore.currentUser))
 
 const editApprovalRequestRows = computed(() => {
   if (!pendingEditRequest.value) return []
@@ -767,13 +770,13 @@ async function handleCancelApproval() {
     <div class="mb-6">
       <DetailPageHeader :title="detail.id" :status="detail.status" @back="goBack">
         <template #actions>
-          <BaseButton v-if="!shipmentLockInfo.locked && !['결재대기','pending_approval','APPROVAL_PENDING'].includes(detail.status)" size="sm" @click="handleEdit">
+          <BaseButton v-if="canMutate && !shipmentLockInfo.locked && !['결재대기','pending_approval','APPROVAL_PENDING'].includes(detail.status)" size="sm" @click="handleEdit">
             <template #leading>
               <i class="fas fa-edit text-xs" aria-hidden="true"></i>
             </template>
             {{ ['확정','confirmed','CONFIRMED'].includes(detail.status) ? '수정요청' : '수정' }}
           </BaseButton>
-          <BaseButton v-if="!shipmentLockInfo.locked && !['결재대기','pending_approval','APPROVAL_PENDING'].includes(detail.status)" variant="secondary" size="sm" @click="handleDelete">
+          <BaseButton v-if="canMutate && !shipmentLockInfo.locked && !['결재대기','pending_approval','APPROVAL_PENDING'].includes(detail.status)" variant="secondary" size="sm" @click="handleDelete">
             <template #leading>
               <i class="fas fa-trash text-xs" aria-hidden="true"></i>
             </template>

--- a/src/views/documents/PIPage.vue
+++ b/src/views/documents/PIPage.vue
@@ -31,6 +31,7 @@ import { useAuthStore } from '@/stores/auth'
 import { loadExchangeRates, clearExchangeRates, getKrwRate } from '@/stores/exchangeRates'
 import { loadPiDocuments, usePiDocuments } from '@/stores/piDocuments'
 import { usePoDocuments } from '@/stores/poDocuments'
+import { useSalesCollectionDocuments } from '@/stores/salesCollectionDocuments'
 import { useShipmentOrderDocuments } from '@/stores/shipmentOrderDocuments'
 import { useShipmentStatusDocuments } from '@/stores/shipmentStatusDocuments'
 import { useToast } from '@/composables/useToast'
@@ -49,8 +50,11 @@ import {
 import { openDocumentOutputByType, openTableOutput } from '@/utils/documentOutput'
 import {
   formatPiShipmentLockMessage,
+  formatPiCollectionLockMessage,
   getPiShipmentLockInfo,
+  getPiCollectionLockInfo,
 } from '@/utils/documentShipmentLock'
+import { canMutateDocument } from '@/utils/documentOwnership'
 import { createDocumentClientRows } from '@/utils/documentClientRows'
 import { formatIncotermsLabel, resolveIncotermState } from '@/utils/incoterms'
 import { clientSearchColumns, productSearchColumns } from '@/utils/searchModalColumns'
@@ -145,6 +149,16 @@ const shipmentLockInfoByPiId = computed(() => (
         shipmentOrderDocuments.value,
         shipmentStatusDocuments.value,
       ),
+    ]),
+  )
+))
+
+const salesCollectionDocuments = useSalesCollectionDocuments()
+const collectionLockInfoByPiId = computed(() => (
+  new Map(
+    rowsData.value.map((row) => [
+      row.id,
+      getPiCollectionLockInfo(row.id, poDocuments.value, salesCollectionDocuments.value),
     ]),
   )
 ))
@@ -257,9 +271,18 @@ function closeForm() {
 }
 
 function openEditForm(row) {
+  if (!canMutateDocument(row, authStore.currentUser)) {
+    warning('본인 또는 팀장·ADMIN 만 수정할 수 있습니다.')
+    return
+  }
   const shipmentLockInfo = shipmentLockInfoByPiId.value.get(row.id)
   if (shipmentLockInfo?.locked) {
     warning(formatPiShipmentLockMessage(shipmentLockInfo))
+    return
+  }
+  const collectionLockInfo = collectionLockInfoByPiId.value.get(row.id)
+  if (collectionLockInfo?.locked) {
+    warning(formatPiCollectionLockMessage(collectionLockInfo))
     return
   }
 
@@ -942,9 +965,18 @@ async function handleSave(formValue) {
 }
 
 async function openDeleteApprovalRequest(row) {
+  if (!canMutateDocument(row, authStore.currentUser)) {
+    warning('본인 또는 팀장·ADMIN 만 삭제할 수 있습니다.')
+    return
+  }
   const shipmentLockInfo = shipmentLockInfoByPiId.value.get(row.id)
   if (shipmentLockInfo?.locked) {
     warning(formatPiShipmentLockMessage(shipmentLockInfo))
+    return
+  }
+  const collectionLockInfo = collectionLockInfoByPiId.value.get(row.id)
+  if (collectionLockInfo?.locked) {
+    warning(formatPiCollectionLockMessage(collectionLockInfo))
     return
   }
 
@@ -1159,8 +1191,8 @@ function handleProductSelect(product) {
 
       <template #cell-actions="{ row }">
         <TableActions
-          :show-edit="!shipmentLockInfoByPiId.get(row.id)?.locked"
-          :show-delete="!shipmentLockInfoByPiId.get(row.id)?.locked"
+          :show-edit="!shipmentLockInfoByPiId.get(row.id)?.locked && !collectionLockInfoByPiId.get(row.id)?.locked && canMutateDocument(row, authStore.currentUser)"
+          :show-delete="!shipmentLockInfoByPiId.get(row.id)?.locked && !collectionLockInfoByPiId.get(row.id)?.locked && canMutateDocument(row, authStore.currentUser)"
           @edit="openEditForm(row)"
           @delete="openDeleteApprovalRequest(row)"
         />

--- a/src/views/documents/PODetailPage.vue
+++ b/src/views/documents/PODetailPage.vue
@@ -31,6 +31,7 @@ import { loadPoDocuments, usePoDocuments } from '@/stores/poDocuments'
 import { loadProductionOrderDocuments, useProductionOrderDocuments } from '@/stores/productionOrderDocuments'
 import { useShipmentOrderDocuments } from '@/stores/shipmentOrderDocuments'
 import { useShipmentStatusDocuments } from '@/stores/shipmentStatusDocuments'
+import { useSalesCollectionDocuments } from '@/stores/salesCollectionDocuments'
 import {
   buildApprovalInfoRows,
   buildApprovalRequestRows,
@@ -44,10 +45,13 @@ import { openDocumentOutputByType } from '@/utils/documentOutput'
 import {
   formatPiPoSelectionMessage,
   formatPoShipmentLockMessage,
+  formatPoCollectionLockMessage,
   getPiPoSelectionInfo,
   getPoShipmentLockInfo,
+  getPoCollectionLockInfo,
   resolvePoShipmentDocumentStatus,
 } from '@/utils/documentShipmentLock'
+import { canMutateDocument } from '@/utils/documentOwnership'
 import { formatReferenceDocumentStatus } from '@/utils/referenceDocumentStatus'
 import { clientSearchColumns } from '@/utils/searchModalColumns'
 
@@ -317,6 +321,7 @@ const shipmentStatusLabel = computed(() => {
 })
 
 const approvalInfoRows = computed(() => buildApprovalInfoRows(detail.value))
+const canMutate = computed(() => canMutateDocument(sourceRow.value, authStore.currentUser))
 const shipmentLockInfo = computed(() => (
   getPoShipmentLockInfo(
     detail.value?.id,
@@ -325,6 +330,9 @@ const shipmentLockInfo = computed(() => (
   )
 ))
 const shipmentLockMessage = computed(() => formatPoShipmentLockMessage(shipmentLockInfo.value))
+const salesCollectionDocuments = useSalesCollectionDocuments()
+const collectionLockInfo = computed(() => getPoCollectionLockInfo(detail.value?.id, salesCollectionDocuments.value))
+const collectionLockMessage = computed(() => formatPoCollectionLockMessage(collectionLockInfo.value))
 const linkedPiDocument = computed(() => piDocuments.value.find((row) => row.id === (detail.value?.piId || detail.value?.linkedPiId)))
 const linkedProductionOrder = computed(() => productionOrderDocuments.value.find((row) => row.poId === detail.value?.id) ?? null)
 const canIssueProductionOrder = computed(() => Boolean(detail.value && !linkedProductionOrder.value && !shipmentLockInfo.value.locked))
@@ -873,13 +881,13 @@ async function handleCancelApproval() {
             </template>
             생산지시서 발행
           </BaseButton>
-          <BaseButton v-if="!shipmentLockInfo.locked && !['결재대기','pending_approval','APPROVAL_PENDING'].includes(detail.status)" size="sm" @click="handleEdit">
+          <BaseButton v-if="canMutate && !shipmentLockInfo.locked && !collectionLockInfo.locked && !['결재대기','pending_approval','APPROVAL_PENDING'].includes(detail.status)" size="sm" @click="handleEdit">
             <template #leading>
               <i class="fas fa-edit text-xs" aria-hidden="true"></i>
             </template>
             {{ ['확정','confirmed','CONFIRMED'].includes(detail.status) ? '수정요청' : '수정' }}
           </BaseButton>
-          <BaseButton v-if="!shipmentLockInfo.locked && !['결재대기','pending_approval','APPROVAL_PENDING'].includes(detail.status)" variant="secondary" size="sm" @click="handleDelete">
+          <BaseButton v-if="canMutate && !shipmentLockInfo.locked && !collectionLockInfo.locked && !['결재대기','pending_approval','APPROVAL_PENDING'].includes(detail.status)" variant="secondary" size="sm" @click="handleDelete">
             <template #leading>
               <i class="fas fa-trash text-xs" aria-hidden="true"></i>
             </template>
@@ -938,6 +946,14 @@ async function handleCancelApproval() {
           {{ reference.type }} {{ reference.id }}
         </span>
       </div>
+    </div>
+
+    <div
+      v-if="collectionLockInfo.locked"
+      class="mb-6 rounded-xl border border-emerald-200 bg-emerald-50 px-5 py-4 text-sm text-emerald-900"
+    >
+      <div class="font-semibold">수금완료된 건이 있어 수정 및 삭제가 제한됩니다.</div>
+      <div class="mt-1">{{ collectionLockMessage }}</div>
     </div>
 
     <div class="grid grid-cols-1 gap-6 lg:grid-cols-3">

--- a/src/views/documents/POPage.vue
+++ b/src/views/documents/POPage.vue
@@ -37,6 +37,7 @@ import { loadPoDocuments, usePoDocuments } from '@/stores/poDocuments'
 import { useProductionOrderDocuments } from '@/stores/productionOrderDocuments'
 import { useShipmentOrderDocuments } from '@/stores/shipmentOrderDocuments'
 import { useShipmentStatusDocuments } from '@/stores/shipmentStatusDocuments'
+import { useSalesCollectionDocuments } from '@/stores/salesCollectionDocuments'
 import { useToast } from '@/composables/useToast'
 import {
   buildApprovalRequestRows,
@@ -51,10 +52,13 @@ import { openDocumentOutputByType, openTableOutput } from '@/utils/documentOutpu
 import {
   formatPiPoSelectionMessage,
   formatPoShipmentLockMessage,
+  formatPoCollectionLockMessage,
   getPiPoSelectionInfo,
   getPoShipmentLockInfo,
+  getPoCollectionLockInfo,
   resolvePoShipmentDocumentStatus,
 } from '@/utils/documentShipmentLock'
+import { canMutateDocument } from '@/utils/documentOwnership'
 import { clientSearchColumns, productSearchColumns } from '@/utils/searchModalColumns'
 import { buildSelectOptionsFromRows } from '@/utils/selectOptions'
 
@@ -187,6 +191,16 @@ const shipmentLockInfoByPoId = computed(() => (
   )
 ))
 
+const salesCollectionDocuments = useSalesCollectionDocuments()
+const collectionLockInfoByPoId = computed(() => (
+  new Map(
+    rowsData.value.map((row) => [
+      row.id,
+      getPoCollectionLockInfo(row.id, salesCollectionDocuments.value),
+    ]),
+  )
+))
+
 // PO 는 결재 확정(CONFIRMED) PI 만 연결 가능. 초안·결재대기·수정요청 상태의 PI 가
 // 드롭다운에 노출되면 결재받지 않은 초안으로 PO 생성이 가능해지므로 프론트에서 먼저 차단.
 function isConfirmedPi(row) {
@@ -275,9 +289,18 @@ function closeForm() {
 }
 
 function openEditForm(row) {
+  if (!canMutateDocument(row, authStore.currentUser)) {
+    warning('본인 또는 팀장·ADMIN 만 수정할 수 있습니다.')
+    return
+  }
   const shipmentLockInfo = shipmentLockInfoByPoId.value.get(row.id)
   if (shipmentLockInfo?.locked) {
     warning(formatPoShipmentLockMessage(shipmentLockInfo))
+    return
+  }
+  const collectionLockInfo = collectionLockInfoByPoId.value.get(row.id)
+  if (collectionLockInfo?.locked) {
+    warning(formatPoCollectionLockMessage(collectionLockInfo))
     return
   }
 
@@ -928,9 +951,18 @@ async function handleSave(formValue) {
 }
 
 async function openDeleteApprovalRequest(row) {
+  if (!canMutateDocument(row, authStore.currentUser)) {
+    warning('본인 또는 팀장·ADMIN 만 삭제할 수 있습니다.')
+    return
+  }
   const shipmentLockInfo = shipmentLockInfoByPoId.value.get(row.id)
   if (shipmentLockInfo?.locked) {
     warning(formatPoShipmentLockMessage(shipmentLockInfo))
+    return
+  }
+  const collectionLockInfo = collectionLockInfoByPoId.value.get(row.id)
+  if (collectionLockInfo?.locked) {
+    warning(formatPoCollectionLockMessage(collectionLockInfo))
     return
   }
 
@@ -1163,8 +1195,8 @@ function handleProductSelect(product) {
 
       <template #cell-actions="{ row }">
         <TableActions
-          :show-edit="!shipmentLockInfoByPoId.get(row.id)?.locked"
-          :show-delete="!shipmentLockInfoByPoId.get(row.id)?.locked"
+          :show-edit="!shipmentLockInfoByPoId.get(row.id)?.locked && !collectionLockInfoByPoId.get(row.id)?.locked && canMutateDocument(row, authStore.currentUser)"
+          :show-delete="!shipmentLockInfoByPoId.get(row.id)?.locked && !collectionLockInfoByPoId.get(row.id)?.locked && canMutateDocument(row, authStore.currentUser)"
           @edit="openEditForm(row)"
           @delete="openDeleteApprovalRequest(row)"
         />


### PR DESCRIPTION
## 📋 작업 내용

5 phase 통합. 상세 내역은 이슈 참고.

**Phase 1 — 상태 라벨 정규화**
- `stores/shipmentStatusDocuments.js` preparing/completed → 출하준비/출하완료 매퍼 변환
- `stores/salesCollectionDocuments.js` paid/unpaid → 수금완료/미수금 매퍼 변환
- 결과: 출하현황 카운터·버튼, Collection lock 로직 모두 정상 동작

**Phase 2 — 뷰어용 사용자 조회**
- `api/package.fetchAllUsers`: `/users` → `/users/viewable` 로 교체 (백엔드 신규 엔드포인트)

**Phase 3 — PI/PO 팀 스코프**
- 프런트 변경 없음. 서버사이드 필터링 (팀원 manager_id IN …) 만 적용되면 기존 로딩 로직이 그대로 동작

**Phase 4 — PI/PO 오너십 기반 수정·삭제**
- `utils/documentOwnership.canMutateDocument(row, user)` 신규 — admin | 본인 | 팀장 통과
- `stores/piDocuments`, `stores/poDocuments`: `managerId` 필드 정규화에 포함
- `PIPage`, `POPage`: `TableActions show-edit/show-delete` 에 canMutate 결합
- `PIDetailPage`, `PODetailPage`: 헤더 액션 버튼 v-if 에 canMutate 결합
- `openEditForm`, `openDeleteApprovalRequest` 진입부 guard (toast + return)

**Phase 5 — 수금완료/출하완료 락**
- `utils/documentShipmentLock`: `getPoCollectionLockInfo`, `getPiCollectionLockInfo` + format*Message 신규
- `CollectionsPage.openStatusConfirm`: 수금완료 → 미수금 되돌리기 차단 (toast)
- `CollectionsPage` 템플릿: 수금완료 행은 select 대신 badge 로 렌더
- `POPage`, `POdetailPage`, `PIPage`: collection lock 반영. 상세는 전용 배너

## 🔗 관련 이슈

- closes #409

백엔드 (team2-backend-auth, team2-backend-documents, team2-gateway) 변경도 동일 phase 로 main 에 직접 푸시됨.

## ✅ 체크리스트

- [ ] 로컬 테스트 (영업/ADMIN 계정으로 상기 시나리오 전부)
- [x] 불필요한 코드/주석 제거
- [x] 빌드 성공 (`team2-backend-*`, `team2-gateway` compileJava 모두 통과)

## 💬 리뷰어에게

- `documentOwnership.canMutateDocument` 규칙은 "서버가 이미 팀 스코프를 강제한다" 전제에 의존 — Phase 3 백엔드 필터 없이 이 규칙만 적용하면 "다른 팀의 문서인데 팀장이면 통과" 가 일어나 버그가 됩니다. 반드시 같이 배포해야 합니다.
- Collection 락 판정은 현재 `row.status === '수금완료'` 기준. Phase 1 매퍼 정규화가 선행되어야 raw `paid` 응답에서도 락이 걸립니다.