### PR TITLE
fix(#411): 잔여 운영 버그 7건 일괄 정리

### DIFF
--- a/src/api/emails.js
+++ b/src/api/emails.js
@@ -3,7 +3,19 @@ import { unwrapCollection } from '@/utils/apiResponse'
 
 export async function fetchActivityEmails() {
   const { data } = await api.get('/email-logs')
-  return unwrapCollection(data)
+  // 백엔드 응답은 { clientName, types: [{emailLogTypeId, emailDocType}], ... } 형태.
+  // UI 는 e.client (문자열), e.types (문자열 배열) 를 기대하므로 여기서 평탄화.
+  return unwrapCollection(data).map((row) => ({
+    ...row,
+    client: row.client ?? row.clientName ?? '-',
+    types: (row.types ?? row.docTypes ?? [])
+      .map((t) => (typeof t === 'string' ? t : (t?.emailDocType ?? t?.docType ?? t?.type ?? t?.name)))
+      .filter(Boolean),
+    recipient: row.recipient ?? row.recipientName ?? row.emailRecipientName ?? '',
+    email: row.email ?? row.recipientEmail ?? row.emailRecipientEmail ?? '',
+    sender: row.sender ?? row.senderName ?? '-',
+    sentAt: row.sentAt ?? row.sentDate ?? row.emailSentAt ?? '',
+  }))
 }
 
 /**

--- a/src/api/package.js
+++ b/src/api/package.js
@@ -21,11 +21,26 @@ export function deletePackage(id) {
   return api.delete(`/activity-packages/${id}`)
 }
 
-export function fetchAllUsers() {
+export async function fetchAllUsers() {
   // 뷰어 선택용 최소 정보 엔드포인트. ADMIN 외 사용자도 조회 가능.
-  return api.get('/users/viewable').then((r) => {
-    const data = r.data
-    if (Array.isArray(data)) return data
-    return unwrapCollection(data)
-  })
+  // /users/viewable 미배포 구간에서는 /users 로 2단 fallback.
+  const normalize = (data) => (Array.isArray(data) ? data : unwrapCollection(data))
+  try {
+    const r = await api.get('/users/viewable')
+    return normalize(r.data)
+  } catch (e) {
+    const status = e?.response?.status
+    if ([401, 403, 404].includes(status)) {
+      try {
+        const r2 = await api.get('/users', { params: { size: 1000 } })
+        return normalize(r2.data)
+      } catch (e2) {
+        const status2 = e2?.response?.status
+        // /users 도 ADMIN 전용이라 영업 계정은 403 받음. 빈 배열로 degrade.
+        if ([401, 403, 404].includes(status2)) return []
+        throw e2
+      }
+    }
+    throw e
+  }
 }

--- a/src/components/domain/document/PIFormModal.vue
+++ b/src/components/domain/document/PIFormModal.vue
@@ -31,6 +31,7 @@ import {
   createExchangeRateHint,
   convertFromKrw,
   getKrwRate,
+  useExchangeRates,
 } from '@/stores/exchangeRates'
 
 const props = defineProps({
@@ -142,6 +143,7 @@ const approverOptions = ref([...defaultApproverOptions])
 const productCatalog = ref([...fallbackProductCatalog])
 const incotermCatalog = ref([...fallbackIncotermsCatalog])
 const exchangeRateHint = ref(createExchangeRateHint('USD', getTodayDateInput()))
+const { loaded: exchangeRatesLoaded } = useExchangeRates()
 const currentCurrency = computed(() => form.value.currency || 'USD')
 
 const currentCurrencySymbol = computed(() => currencySymbolMap[currentCurrency.value] ?? currentCurrency.value)
@@ -254,7 +256,14 @@ const reasonFieldPlaceholder = computed(() => (
 ))
 
 const isReasonRequired = computed(() => props.mode === 'edit')
-const showApproverField = computed(() => true)
+// 팀장(positionLevel=1)·ADMIN 은 결재 없이 즉시 확정되므로 결재자 필드 숨김.
+const isTeamLeaderOrAdmin = computed(() => {
+  const user = authStore.currentUser
+  if (!user) return false
+  if (user.role === 'admin') return true
+  return Number(user.positionLevel) === 1
+})
+const showApproverField = computed(() => !isTeamLeaderOrAdmin.value)
 
 function mapBuyerLabel(buyer) {
   if (!buyer?.name) return ''
@@ -706,6 +715,11 @@ function removeItem(index) {
 
 function handleSave() {
   if (!validateForm()) return
+  // 외화 PI 인데 환율 미확보면 단가가 KRW 값 그대로 남아 서버 환산 시 금액이 비정상으로 저장된다.
+  if (form.value.currency && form.value.currency !== 'KRW' && !exchangeRatesLoaded.value) {
+    validationErrors.value.currency = '환율 로딩이 완료되지 않았습니다. 잠시 후 다시 시도해주세요.'
+    return
+  }
 
   emit('save', {
     ...form.value,
@@ -764,6 +778,12 @@ watch(
   },
   { immediate: true },
 )
+
+// 환율 데이터가 늦게 로드되는 경우 (catalog 적용 시점에 rates 비어있을 때)
+// loaded 가 true 로 바뀌면 자동 환산 다시 실행. 수정 모드에서도 baseUnitPrice 기반 재환산.
+watch(exchangeRatesLoaded, (ready) => {
+  if (ready) refreshAutoPricedItems()
+})
 </script>
 
 <template>

--- a/src/components/domain/document/POFormModal.vue
+++ b/src/components/domain/document/POFormModal.vue
@@ -19,6 +19,15 @@ const emit = defineEmits(['close', 'save', 'open-pi-search', 'open-client-search
 const defaultApproverOptions = []
 const authStore = useAuthStore()
 
+// 팀장·ADMIN 은 결재 없이 즉시 확정되므로 결재자 필드 숨김.
+const isTeamLeaderOrAdmin = computed(() => {
+  const user = authStore.currentUser
+  if (!user) return false
+  if (user.role === 'admin') return true
+  return Number(user.positionLevel) === 1
+})
+const showApproverField = computed(() => !isTeamLeaderOrAdmin.value)
+
 function createInitialForm() {
   return {
     linkedPiId: '',
@@ -101,7 +110,7 @@ function validate() {
   if (!form.value.clientName?.trim()) e.clientName = '거래처를 선택해주세요.'
   if (!form.value.deliveryDate) e.deliveryDate = '납기일을 입력해주세요.'
   if (!form.value.currency?.trim()) e.currency = '통화가 지정되지 않았습니다.'
-  if (!form.value.approver?.trim()) e.approver = '결재자를 선택해주세요.'
+  if (showApproverField.value && !form.value.approver?.trim()) e.approver = '결재자를 선택해주세요.'
   errors.value = e
   return Object.keys(e).length === 0
 }
@@ -279,7 +288,7 @@ watch(
         </div>
       </div>
 
-      <div>
+      <div v-if="showApproverField">
         <label class="mb-1 block text-slate-600">결재자</label>
         <BaseSelect
           v-model="form.approver"

--- a/src/stores/ciDocuments.js
+++ b/src/stores/ciDocuments.js
@@ -48,7 +48,12 @@ function mapCiResponse(row) {
     country: row.country ?? '-',
     currencyCode: row.currencyCode ?? 'USD',
     currency: row.currencyCode ?? 'USD',
-    itemName: items[0]?.name ?? row.itemName ?? '-',
+    itemName: items[0]?.name
+      ?? row.itemName
+      ?? row.firstItemName
+      ?? row.representativeItemName
+      ?? row.ciItemName
+      ?? '-',
     amount: formatCurrencyAmount(row.totalAmount, row.currencyCode),
     totalAmount: formatNumber(Number(row.totalAmount ?? 0), 2),
     incotermCode: row.incotermsCode ?? '',

--- a/src/stores/plDocuments.js
+++ b/src/stores/plDocuments.js
@@ -44,7 +44,12 @@ function mapPlResponse(row) {
     clientAddress: row.clientAddress ?? '-',
     buyer: row.buyerName ?? '-',
     country: row.country ?? '-',
-    itemName: items[0]?.name ?? row.itemName ?? '-',
+    itemName: items[0]?.name
+      ?? row.itemName
+      ?? row.firstItemName
+      ?? row.representativeItemName
+      ?? row.plItemName
+      ?? '-',
     grossWeight: formatNumber(Number(row.grossWeight ?? totalGrossWeight), 2),
     bookingNo: row.bookingNo ?? '-',
     incotermCode: row.incotermsCode ?? '',

--- a/src/utils/documentShipmentLock.js
+++ b/src/utils/documentShipmentLock.js
@@ -132,6 +132,24 @@ export function formatPiCollectionLockMessage(lockInfo) {
   return `수금완료된 건이 연결된 PO ${reference.poId}가 있어 이 PI는 수정/삭제할 수 없습니다.`
 }
 
+/**
+ * 생산지시서(MO) 발행된 PO 는 MO 가 '생산완료' 되기 전까지 출하완료 처리 불가.
+ * MO 자체가 없으면 출하만으로 진행 (영업담당자가 재고 보유 가정).
+ */
+export function getPoProductionGate(poId, productionOrderDocuments = []) {
+  if (!poId) return { blocked: false, pendingIds: [] }
+  const mos = productionOrderDocuments.filter((row) => row.poId === poId)
+  if (mos.length === 0) return { blocked: false, pendingIds: [] }
+  const pending = mos.filter((row) => row.status !== '생산완료')
+  return { blocked: pending.length > 0, pendingIds: pending.map((r) => r.id) }
+}
+
+export function formatPoProductionGateMessage(gate) {
+  if (!gate?.blocked) return ''
+  const first = gate.pendingIds[0]
+  return `생산지시서${first ? ` ${first}` : ''}가 생산완료 상태가 아니므로 출하완료 처리할 수 없습니다.`
+}
+
 export function formatPiShipmentLockMessage(lockInfo) {
   if (!lockInfo?.locked || !lockInfo.references?.length) {
     return ''

--- a/src/views/auth/LoginPage.vue
+++ b/src/views/auth/LoginPage.vue
@@ -45,7 +45,7 @@ const quickGroups = [
   {
     department: '출하부',
     accounts: [
-      { team: '출하1팀', role: '팀원', name: '정출하', email: 'jung.ship@hanwha.com' },
+      { team: '출하1팀', role: '팀장', name: '정출하', email: 'jung.ship@hanwha.com' },
     ],
   },
 ]

--- a/src/views/documents/ProductionOrderDetailPage.vue
+++ b/src/views/documents/ProductionOrderDetailPage.vue
@@ -87,7 +87,7 @@ const previewFields = computed(() => {
     { label: '국가', value: detail.value.country },
     { label: '거래처', value: detail.value.clientName },
     { label: '품목명', value: detail.value.itemName },
-    { label: '영업담당자', value: detail.value.manager },
+    { label: '담당자', value: detail.value.manager },
     { label: '상태', value: detail.value.status },
     { label: '납기일', value: detail.value.dueDate },
   ]
@@ -98,7 +98,7 @@ const summaryRows = computed(() => {
 
   return [
     { label: '거래처', value: detail.value.clientName },
-    { label: '영업담당자', value: detail.value.manager || '-' },
+    { label: '담당자', value: detail.value.manager || '-' },
     { label: '총수량', value: `${totalQuantity.value} EA` },
     { label: '납기일', value: detail.value.dueDate || '-' },
   ]
@@ -250,7 +250,7 @@ onMounted(() => {
             <div><span class="text-slate-500">지시번호</span><div class="mt-0.5 font-medium">{{ detail.id }}</div></div>
             <div><span class="text-slate-500">거래처</span><div class="mt-0.5 font-medium">{{ detail.clientName }}</div></div>
             <div><span class="text-slate-500">국가</span><div class="mt-0.5">{{ detail.country }}</div></div>
-            <div><span class="text-slate-500">영업담당자</span><div class="mt-0.5">{{ detail.manager }}</div></div>
+            <div><span class="text-slate-500">담당자</span><div class="mt-0.5">{{ detail.manager }}</div></div>
             <div><span class="text-slate-500">납기일</span><div class="mt-0.5">{{ detail.dueDate }}</div></div>
             <div><span class="text-slate-500">완료 목표일</span><div class="mt-0.5">{{ detail.completionTarget }}</div></div>
             <div class="sm:col-span-2"><span class="text-slate-500">영문주소</span><div class="mt-0.5 break-words">{{ detail.clientAddress }}</div></div>

--- a/src/views/documents/ProductionOrderPage.vue
+++ b/src/views/documents/ProductionOrderPage.vue
@@ -46,7 +46,7 @@ const columns = [
   { key: 'clientName', label: '거래처', align: 'left', width: '220px' },
   { key: 'country', label: '국가', align: 'center', width: '120px' },
   { key: 'itemName', label: '품목명', align: 'left', width: '220px' },
-  { key: 'manager', label: '영업담당자', align: 'left', width: '120px' },
+  { key: 'manager', label: '담당자', align: 'left', width: '120px' },
   { key: 'status', label: '상태', align: 'center', width: '120px' },
   { key: 'dueDate', label: '납기', align: 'center', width: '130px' },
   { key: 'actions', label: '', align: 'center', width: '120px', sortable: false },
@@ -77,7 +77,7 @@ const previewFields = computed(() => {
     { label: '국가', value: previewTarget.value.country },
     { label: '거래처', value: previewTarget.value.clientName },
     { label: '품목명', value: previewTarget.value.itemName },
-    { label: '영업담당자', value: previewTarget.value.manager },
+    { label: '담당자', value: previewTarget.value.manager },
     { label: '상태', value: previewTarget.value.status },
     { label: '납기일', value: previewTarget.value.dueDate },
   ]
@@ -192,7 +192,7 @@ function downloadPdf(row) {
           </div>
         </FormField>
 
-        <FormField label="영업담당자">
+        <FormField label="담당자">
           <SearchableCombobox
             v-model="filters.manager"
             :options="managerOptions"

--- a/src/views/documents/ShipmentOrderDetailPage.vue
+++ b/src/views/documents/ShipmentOrderDetailPage.vue
@@ -98,7 +98,7 @@ const previewFields = computed(() => {
     { label: '거래처', value: detail.value.clientName },
     { label: '국가', value: detail.value.country },
     { label: '품목명', value: detail.value.itemName },
-    { label: '영업담당자', value: detail.value.manager },
+    { label: '담당자', value: detail.value.manager },
     { label: '상태', value: detail.value.status },
     { label: '납기일', value: detail.value.dueDate },
   ]
@@ -109,7 +109,7 @@ const summaryRows = computed(() => {
 
   return [
     { label: '거래처', value: detail.value.clientName },
-    { label: '영업담당자', value: detail.value.manager || '-' },
+    { label: '담당자', value: detail.value.manager || '-' },
     { label: '총수량', value: `${totalQuantity.value} EA` },
     { label: '납기일', value: detail.value.dueDate || '-' },
   ]
@@ -196,7 +196,7 @@ onMounted(() => {
             <div><span class="text-slate-500">PO</span><div class="mt-0.5 font-medium">{{ detail.poId }}</div></div>
             <div><span class="text-slate-500">거래처</span><div class="mt-0.5 font-medium">{{ detail.clientName }}</div></div>
             <div><span class="text-slate-500">국가</span><div class="mt-0.5">{{ detail.country }}</div></div>
-            <div><span class="text-slate-500">영업담당자</span><div class="mt-0.5">{{ detail.manager }}</div></div>
+            <div><span class="text-slate-500">담당자</span><div class="mt-0.5">{{ detail.manager }}</div></div>
             <div><span class="text-slate-500">납기일</span><div class="mt-0.5">{{ detail.dueDate }}</div></div>
             <div><span class="text-slate-500">출하지시번호</span><div class="mt-0.5 font-medium">{{ detail.id }}</div></div>
             <div><span class="text-slate-500">출하 예정일</span><div class="mt-0.5">{{ detail.plannedShipDate }}</div></div>

--- a/src/views/documents/ShipmentOrderPage.vue
+++ b/src/views/documents/ShipmentOrderPage.vue
@@ -46,7 +46,7 @@ const columns = [
   { key: 'clientName', label: '거래처', align: 'left', width: '220px' },
   { key: 'country', label: '국가', align: 'center', width: '120px' },
   { key: 'itemName', label: '품목명', align: 'left', width: '220px' },
-  { key: 'manager', label: '영업담당자', align: 'left', width: '120px' },
+  { key: 'manager', label: '담당자', align: 'left', width: '120px' },
   { key: 'status', label: '상태', align: 'center', width: '120px' },
   { key: 'dueDate', label: '납기일', align: 'center', width: '130px' },
   { key: 'actions', label: '', align: 'center', width: '120px', sortable: false },
@@ -77,7 +77,7 @@ const previewFields = computed(() => {
     { label: '거래처', value: previewTarget.value.clientName },
     { label: '국가', value: previewTarget.value.country },
     { label: '품목명', value: previewTarget.value.itemName },
-    { label: '영업담당자', value: previewTarget.value.manager },
+    { label: '담당자', value: previewTarget.value.manager },
     { label: '상태', value: previewTarget.value.status },
     { label: '납기일', value: previewTarget.value.dueDate },
   ]
@@ -192,7 +192,7 @@ function downloadPdf(row) {
           </div>
         </FormField>
 
-        <FormField label="영업담당자">
+        <FormField label="담당자">
           <SearchableCombobox
             v-model="filters.manager"
             :options="managerOptions"

--- a/src/views/documents/ShipmentsDetailPage.vue
+++ b/src/views/documents/ShipmentsDetailPage.vue
@@ -11,8 +11,10 @@ import { useAuthStore } from '@/stores/auth'
 import { usePoDocuments } from '@/stores/poDocuments'
 import { useShipmentOrderDocuments } from '@/stores/shipmentOrderDocuments'
 import { useShipmentStatusDocuments } from '@/stores/shipmentStatusDocuments'
+import { useProductionOrderDocuments } from '@/stores/productionOrderDocuments'
 import { useToast } from '@/composables/useToast'
 import { formatReferenceDocumentStatus } from '@/utils/referenceDocumentStatus'
+import { getPoProductionGate, formatPoProductionGateMessage } from '@/utils/documentShipmentLock'
 import { canAccessRouteByRole } from '@/utils/roleAccess'
 
 const route = useRoute()
@@ -22,6 +24,8 @@ const authStore = useAuthStore()
 const poDocuments = usePoDocuments()
 const shipmentOrderDocuments = useShipmentOrderDocuments()
 const shipmentStatusDocuments = useShipmentStatusDocuments()
+// 출하팀은 productionOrder 조회가 막혀있을 수 있음 (store 가 permission 체크). 결과가 빈 배열이면 gate 미적용.
+const productionOrderDocuments = useProductionOrderDocuments()
 const { loadItemCatalog, enrichDocumentItems } = useDocumentItemCatalog()
 
 function enrichShipmentStatusRow(row) {
@@ -47,6 +51,9 @@ const displayItems = computed(() => enrichDocumentItems(detail.value?.items ?? [
 const currentStep = computed(() => (detail.value?.status === '출하완료' ? 2 : 1))
 const currentRole = computed(() => (authStore.currentUser?.role ?? '').toLowerCase())
 const canCompleteShipment = computed(() => currentRole.value === 'admin' || currentRole.value === 'shipping')
+
+// 생산지시서가 연결된 PO 는 MO 완료 전에 출하 완료 금지.
+const productionGate = computed(() => getPoProductionGate(detail.value?.poId, productionOrderDocuments.value))
 function parseNumericValue(value) {
   const numeric = Number.parseFloat(String(value ?? '').replace(/[^0-9.]/g, ''))
   return Number.isFinite(numeric) ? numeric : 0
@@ -66,7 +73,7 @@ const summaryRows = computed(() => {
 
   return [
     { label: '거래처', value: detail.value.clientName },
-    { label: '영업담당자', value: detail.value.manager || '-' },
+    { label: '담당자', value: detail.value.manager || '-' },
     { label: '품목 건수', value: `${detail.value.items.length}건` },
     { label: '납기일', value: detail.value.dueDate || '-' },
   ]
@@ -90,6 +97,10 @@ function goToShipmentOrder() {
 
 async function completeShipment() {
   if (!detail.value || detail.value.status === '출하완료') return
+  if (productionGate.value.blocked) {
+    toast.warning(formatPoProductionGateMessage(productionGate.value))
+    return
+  }
   try {
     // 백엔드 PUT /api/shipments/{id} (controller @PreAuthorize ADMIN/SHIPPING)
     await updateShipment(detail.value.id, { status: 'completed' })
@@ -149,7 +160,8 @@ onMounted(() => {
           <BaseButton
             v-if="canCompleteShipment"
             size="sm"
-            :disabled="detail.status === '출하완료'"
+            :disabled="detail.status === '출하완료' || productionGate.blocked"
+            :title="productionGate.blocked ? formatPoProductionGateMessage(productionGate) : ''"
             @click="completeShipment"
           >
             <template #leading>
@@ -188,7 +200,7 @@ onMounted(() => {
             <div><span class="text-slate-500">출하지시서</span><div class="mt-0.5">{{ detail.shipmentOrderId }}</div></div>
             <div><span class="text-slate-500">출하요청일</span><div class="mt-0.5 font-medium">{{ detail.requestDate }}</div></div>
             <div><span class="text-slate-500">납기일</span><div class="mt-0.5 font-medium">{{ detail.dueDate }}</div></div>
-            <div><span class="text-slate-500">영업담당자</span><div class="mt-0.5">{{ detail.manager || '-' }}</div></div>
+            <div><span class="text-slate-500">담당자</span><div class="mt-0.5">{{ detail.manager || '-' }}</div></div>
             <div><span class="text-slate-500">최종 업데이트</span><div class="mt-0.5 text-xs text-slate-400">{{ detail.updatedAt }}</div></div>
           </div>
         </div>

--- a/src/views/emails/EmailListPage.vue
+++ b/src/views/emails/EmailListPage.vue
@@ -104,7 +104,9 @@ const filteredEmails = computed(() => {
   return emails.value
     .filter((e) => {
       const q = applied.value.keyword.trim().toLowerCase()
-      const matchKeyword   = !q || e.title.toLowerCase().includes(q) || e.client.toLowerCase().includes(q)
+      const matchKeyword   = !q
+        || (e.title ?? '').toLowerCase().includes(q)
+        || (e.client ?? '').toLowerCase().includes(q)
       const matchType      = !applied.value.type      || (e.types ?? []).includes(applied.value.type)
       const matchStatus    = !applied.value.status    || e.status === applied.value.status
       const matchSender    = !applied.value.sender    || e.sender === applied.value.sender


### PR DESCRIPTION
## 📋 작업 내용

운영 중 누적된 리포트 7 건을 한 번에 정리.

| # | 항목 | 주요 변경 |
|---|---|---|
| 1 | PI 환율 반영 정상화 | `PIFormModal` — `useExchangeRates().loaded` watch 추가, 저장 전 rates 미확보 체크 + 차단 |
| 2 | 결재자 후보 개선 | `PIFormModal` / `POFormModal` — 팀장·ADMIN 은 결재자 필드 자체 숨김 (`showApproverField`). 팀원은 팀장+ADMIN 후보 노출 (seed 레벨 수정으로 근본 해결) |
| 3 | CI/PL 품목명 fallback | `ciDocuments` / `plDocuments` — `itemName/firstItemName/representativeItemName` 다단 fallback |
| 4 | 지시서 헤더 라벨 | `ProductionOrderPage` / `ShipmentOrderPage` / 각 DetailPage / `ShipmentsDetailPage` — 영업담당자 → 담당자 |
| 5 | 생산 → 출하 단계 제약 | `utils/documentShipmentLock.getPoProductionGate` 신규, `ShipmentsDetailPage.completeShipment` 에 반영 |
| 6 | 메일 이력 필드 평탄화 | `api/emails.fetchActivityEmails` — 백엔드 `clientName`/`types[].emailDocType` 응답을 UI 기대 shape 로 변환 |
| 7 | 패키지 뷰어 fallback | `api/package.fetchAllUsers` — `/users/viewable` 실패 시 `/users` 재시도, 그래도 실패면 `[]` degrade |

UX: `LoginPage` 빠른 로그인 '정출하' 배지 '팀원' → '팀장' (seed 직급 정합).

## 🔗 관련 이슈
- closes #411

## 🔗 관련 커밋 (루트 seed)
- `D:\Users\Documents\be22-final-team2-project` main `8eb62dc` (positions/users 재배치 + CI/PL items_snapshot)

## 📸 스크린샷
n/a (기능/데이터 수정)

## ✅ 체크리스트
- [x] 불필요한 코드/주석 제거
- [x] 로컬 테스트 (PI 환율, 팀원 결재자 후보, CI/PL 품목명, 생산→출하 gate, 메일 이력, 패키지 뷰어)
- [x] 충돌 없음

## 💬 리뷰어에게

- `isTeamLeaderOrAdmin` 은 `user.positionLevel === 1 || user.role === 'admin'` 기준. JWT claim 에 `positionLevel` 이 없으면 결재자 필드 항상 노출 — 현재 JWT 가 해당 claim 을 포함하는지 한 번 확인 부탁.
- 생산 gate 는 프론트에서만 동작. 백엔드에서 동일 체크가 필요하면 후속 티켓으로 분리.
- 메일 이력 `types` 평탄화는 `emailDocType` 기준. enum 쪽 추가 필드 생기면 여기서 대응.

## 배포 순서

1. 루트 레포 seed 커밋(`8eb62dc`)을 스테이징에 반영해야 결재자/품목명 변경이 유효. (기존 DB 면 `UPDATE positions SET position_level = ...` 스크립트 실행 or 재시드)
2. 이 PR 머지 후 프런트 rollout.