### PR TITLE
fix(#413): 수금 렌더 크래시·출하 필드 누락·PI 편집 환율 회귀 등 정리

### DIFF
--- a/src/api/emails.js
+++ b/src/api/emails.js
@@ -1,10 +1,18 @@
 import { api } from '@/lib/api'
 import { unwrapCollection } from '@/utils/apiResponse'
 
+function normalizeEmailStatus(raw) {
+  if (!raw) return ''
+  const value = String(raw).toLowerCase()
+  if (value === 'failed') return '실패'
+  if (value === 'sent') return '발송'
+  return String(raw)
+}
+
 export async function fetchActivityEmails() {
   const { data } = await api.get('/email-logs')
-  // 백엔드 응답은 { clientName, types: [{emailLogTypeId, emailDocType}], ... } 형태.
-  // UI 는 e.client (문자열), e.types (문자열 배열) 를 기대하므로 여기서 평탄화.
+  // 백엔드 응답은 { clientName, types: [{emailLogTypeId, emailDocType}], status: 'failed'|'sent', ... } 형태.
+  // UI 는 e.client (문자열), e.types (문자열 배열), e.status (한글 라벨) 을 기대하므로 여기서 평탄화.
   return unwrapCollection(data).map((row) => ({
     ...row,
     client: row.client ?? row.clientName ?? '-',
@@ -15,6 +23,7 @@ export async function fetchActivityEmails() {
     email: row.email ?? row.recipientEmail ?? row.emailRecipientEmail ?? '',
     sender: row.sender ?? row.senderName ?? '-',
     sentAt: row.sentAt ?? row.sentDate ?? row.emailSentAt ?? '',
+    status: normalizeEmailStatus(row.status),
   }))
 }
 

--- a/src/components/domain/document/PIFormModal.vue
+++ b/src/components/domain/document/PIFormModal.vue
@@ -718,6 +718,8 @@ function handleSave() {
   // 외화 PI 인데 환율 미확보면 단가가 KRW 값 그대로 남아 서버 환산 시 금액이 비정상으로 저장된다.
   if (form.value.currency && form.value.currency !== 'KRW' && !exchangeRatesLoaded.value) {
     validationErrors.value.currency = '환율 로딩이 완료되지 않았습니다. 잠시 후 다시 시도해주세요.'
+    // 인라인 메시지만으로는 사용자가 버튼 근처를 보고 있어 인지가 어렵다 — validateForm 과 동일하게 toast 도 발생.
+    error(validationErrors.value.currency, '입력 확인')
     return
   }
 
@@ -779,10 +781,14 @@ watch(
   { immediate: true },
 )
 
-// 환율 데이터가 늦게 로드되는 경우 (catalog 적용 시점에 rates 비어있을 때)
-// loaded 가 true 로 바뀌면 자동 환산 다시 실행. 수정 모드에서도 baseUnitPrice 기반 재환산.
+// 환율 데이터가 늦게 로드되는 경우 (생성 모드에서 catalog 적용 시점에 rates 비어있을 때)
+// loaded 가 true 로 바뀌면 자동 환산 다시 실행.
+// 수정 모드에서는 저장된 외화 unitPrice 가 late-rates 에 의해 (catalog KRW × 현재 환율) 로
+// 덮어써지는 데이터 손실이 있어 발동하지 않는다. 수정 시 통화/발행일 변경은 기존 watcher 가 처리.
 watch(exchangeRatesLoaded, (ready) => {
-  if (ready) refreshAutoPricedItems()
+  if (!ready) return
+  if (props.mode === 'edit') return
+  refreshAutoPricedItems()
 })
 </script>
 

--- a/src/stores/productionOrderDocuments.js
+++ b/src/stores/productionOrderDocuments.js
@@ -52,6 +52,7 @@ function mapProductionOrderResponse(row) {
 
 const productionOrderDocuments = ref([])
 const productionOrderPageInfo = ref({ size: 1000, number: 0, totalElements: 0, totalPages: 0 })
+const productionOrdersLoaded = ref(false)
 let loading = null
 
 export async function loadProductionOrderDocuments({ page = 0, size = 1000 } = {}) {
@@ -59,8 +60,11 @@ export async function loadProductionOrderDocuments({ page = 0, size = 1000 } = {
     const { content, page: pageInfo } = await fetchProductionOrdersPaged({ page, size })
     productionOrderDocuments.value = (Array.isArray(content) ? content : []).map(mapProductionOrderResponse)
     productionOrderPageInfo.value = pageInfo
+    productionOrdersLoaded.value = true
   } catch (e) {
     console.error('Failed to load production order documents:', e)
+    // 실패여도 gate 가 무한 blocked 로 남지 않도록 loaded=true 처리 (race 방지용도로는 충분)
+    productionOrdersLoaded.value = true
   }
 }
 
@@ -68,17 +72,23 @@ export function useProductionOrderPageInfo() {
   return productionOrderPageInfo
 }
 
+export function useProductionOrdersLoaded() {
+  return productionOrdersLoaded
+}
+
 export function clearProductionOrderDocuments() {
   productionOrderDocuments.value = []
   productionOrderPageInfo.value = { size: 1000, number: 0, totalElements: 0, totalPages: 0 }
+  productionOrdersLoaded.value = false
   loading = null
 }
 
 export function useProductionOrderDocuments() {
   const auth = useAuthStore()
   const role = auth.currentUser?.role
-  // 생산지시서는 admin/sales/production 만 조회 권한. shipping 에서 401/403 유발 방지.
-  const allowed = ['admin', 'sales', 'production'].includes(role)
+  // 생산지시서 조회는 모든 인증 사용자 허용 (DocumentQueryController class-level @PreAuthorize=isAuthenticated).
+  // 출하팀도 "MO 완료 여부" 를 확인해 출하완료 처리 전 gate 로 활용.
+  const allowed = ['admin', 'sales', 'production', 'shipping'].includes(role)
   if (!loading && auth.isLoggedIn && allowed) {
     loading = loadProductionOrderDocuments()
   }

--- a/src/stores/salesCollectionDocuments.js
+++ b/src/stores/salesCollectionDocuments.js
@@ -18,12 +18,20 @@ function normalizeCollectionStatus(raw) {
   return COLLECTION_STATUS_LABEL[String(raw).toLowerCase()] ?? COLLECTION_STATUS_LABEL[raw] ?? '미수금'
 }
 
+function toSlashDate(value) {
+  if (!value) return ''
+  return String(value).replace(/-/g, '/')
+}
+
 function normalizeCollectionRow(row) {
   const status = normalizeCollectionStatus(row.status)
   return {
     ...row,
     status,
     poId: row.poId ? normalizeDocumentCode(row.poId) : (row.poNo ?? ''),
+    // 정렬/표시용 필드 — 백엔드가 일부를 null 로 내려주는 경우 페이지 렌더가 localeCompare 에서 죽는다.
+    currency: row.currency ?? row.currencyCode ?? row.poCurrencyCode ?? '',
+    issueDate: toSlashDate(row.issueDate ?? row.collectionIssueDate ?? row.createdAt ?? ''),
     collectionDate: status === '수금완료' ? row.collectionDate || null : null,
   }
 }

--- a/src/views/activity/ActivityListPage.vue
+++ b/src/views/activity/ActivityListPage.vue
@@ -319,6 +319,17 @@ const columns = [
           <span class="font-medium text-slate-800">{{ row.title }}</span>
         </template>
 
+        <!-- PO — poId 없으면 거래처명으로 대체 (미연결 활동 기록) -->
+        <template #cell-poId="{ row }">
+          <span v-if="row.poId" class="text-slate-800">{{ row.poId }}</span>
+          <span
+            v-else-if="clientMap[row.clientId]"
+            class="text-xs text-slate-500"
+            :title="`${clientMap[row.clientId].clientName} — PO 미연결 기록`"
+          >{{ clientMap[row.clientId].clientName }}</span>
+          <span v-else class="text-slate-400">-</span>
+        </template>
+
         <!-- 작업 버튼 -->
         <template #cell-actions="{ row }">
           <div @click.stop>

--- a/src/views/documents/CollectionsPage.vue
+++ b/src/views/documents/CollectionsPage.vue
@@ -93,13 +93,19 @@ const enrichedRows = computed(() => filteredRows.value.map((row) => ({
 
 const sortedRows = computed(() => {
   return [...enrichedRows.value].sort((left, right) => {
-    const currencyCompare = left.currency.localeCompare(right.currency)
+    // currency / issueDate 가 undefined 인 행이 섞이면 localeCompare 가 throw 되어
+    // 페이지 전체가 렌더되지 않는다. 기본값으로 빈 문자열 coalesce.
+    const leftCurrency = String(left.currency ?? '')
+    const rightCurrency = String(right.currency ?? '')
+    const currencyCompare = leftCurrency.localeCompare(rightCurrency)
 
     if (currencyCompare !== 0) {
       return currencyCompare
     }
 
-    return right.issueDate.localeCompare(left.issueDate)
+    const leftIssue = String(left.issueDate ?? '')
+    const rightIssue = String(right.issueDate ?? '')
+    return rightIssue.localeCompare(leftIssue)
   })
 })
 

--- a/src/views/documents/ShipmentsDetailPage.vue
+++ b/src/views/documents/ShipmentsDetailPage.vue
@@ -11,7 +11,7 @@ import { useAuthStore } from '@/stores/auth'
 import { usePoDocuments } from '@/stores/poDocuments'
 import { useShipmentOrderDocuments } from '@/stores/shipmentOrderDocuments'
 import { useShipmentStatusDocuments } from '@/stores/shipmentStatusDocuments'
-import { useProductionOrderDocuments } from '@/stores/productionOrderDocuments'
+import { useProductionOrderDocuments, useProductionOrdersLoaded } from '@/stores/productionOrderDocuments'
 import { useToast } from '@/composables/useToast'
 import { formatReferenceDocumentStatus } from '@/utils/referenceDocumentStatus'
 import { getPoProductionGate, formatPoProductionGateMessage } from '@/utils/documentShipmentLock'
@@ -24,8 +24,9 @@ const authStore = useAuthStore()
 const poDocuments = usePoDocuments()
 const shipmentOrderDocuments = useShipmentOrderDocuments()
 const shipmentStatusDocuments = useShipmentStatusDocuments()
-// 출하팀은 productionOrder 조회가 막혀있을 수 있음 (store 가 permission 체크). 결과가 빈 배열이면 gate 미적용.
+// 모든 인증 사용자에게 허용됨 (shipping 포함). loaded 플래그로 race 방지.
 const productionOrderDocuments = useProductionOrderDocuments()
+const productionOrdersLoaded = useProductionOrdersLoaded()
 const { loadItemCatalog, enrichDocumentItems } = useDocumentItemCatalog()
 
 function enrichShipmentStatusRow(row) {
@@ -97,6 +98,10 @@ function goToShipmentOrder() {
 
 async function completeShipment() {
   if (!detail.value || detail.value.status === '출하완료') return
+  if (!productionOrdersLoaded.value) {
+    toast.warning('생산지시 상태를 확인 중입니다. 잠시 후 다시 시도해주세요.')
+    return
+  }
   if (productionGate.value.blocked) {
     toast.warning(formatPoProductionGateMessage(productionGate.value))
     return
@@ -160,8 +165,8 @@ onMounted(() => {
           <BaseButton
             v-if="canCompleteShipment"
             size="sm"
-            :disabled="detail.status === '출하완료' || productionGate.blocked"
-            :title="productionGate.blocked ? formatPoProductionGateMessage(productionGate) : ''"
+            :disabled="detail.status === '출하완료' || !productionOrdersLoaded || productionGate.blocked"
+            :title="productionGate.blocked ? formatPoProductionGateMessage(productionGate) : (!productionOrdersLoaded ? '생산지시 상태 확인 중...' : '')"
             @click="completeShipment"
           >
             <template #leading>


### PR DESCRIPTION
## 📋 작업 내용

사용자 제보 3건 + 리모트 리뷰 4건 통합.

| # | 항목 | 주요 변경 |
|---|---|---|
| 1 | 매출수금 렌더 크래시 | `CollectionsPage` sort 에 `?? ''` 가드. `salesCollectionDocuments` 가 currency/issueDate 파생 |
| 2 | 출하현황 필드 누락 | backend-documents `c728f6e` 에서 ShipmentView 확장. 프런트는 기존 매퍼 그대로 |
| 3 | 활동기록 PO '-' | `ActivityListPage` `#cell-poId` slot: poId 없으면 거래처명 fallback |
| 4 | PI 편집 환율 회귀 | `exchangeRatesLoaded` watcher 에 `mode==='edit'` 가드 (data loss 방지) |
| 5 | PI 환율 toast | handleSave 에 `error()` 호출 추가 |
| 6 | 이메일 status | fetchActivityEmails 에 `normalizeEmailStatus` 추가 |
| 7 | Production gate | shipping role 도 MO 조회 허용 + `useProductionOrdersLoaded` 플래그 + race 차단 |

## 🔗 관련 이슈
- closes #413

## 🔗 관련 커밋 (backend)
- team2-backend-documents `c728f6e` (ShipmentView/CollectionView 확장)

## ⚠️ 배포 순서
backend-documents 이미지 먼저 rollout (ArgoCD 자동) → 프런트 PR 머지. 프런트가 먼저 배포되면 새 응답 필드가 없어 출하현황은 여전히 '-' 로 표시됨.

## ✅ 체크리스트
- [x] 빌드 구조상 문제 없음 (매퍼 SQL + View 필드 매칭)
- [x] 회귀 체크: Phase 1 status 정규화 유지
- [x] 로컬 검증 (수금 페이지 렌더, 출하현황 필드, PI 편집 저장, 이메일 '실패' 필터, 출하팀 gate)

## 💬 리뷰어에게

- CollectionView `currencyCode` 는 `po.po_currency_code` snapshot 을 쓴다. Collection 엔티티 자체의 currencyId 와 다른 통화가 될 수는 없지만, 혹시 불일치가 발생하면 po snapshot 이 우선.
- PI 편집 모드에서 사용자가 **통화 변경** 시에는 기존 watcher (`currency/issueDate` watch) 가 재환산. late-rate watcher 만 block 되어 있으니 기능 손상 없음.
- Production gate 를 shipping 에 열어도 backend 는 이미 `isAuthenticated` 라 권한 문제 없음. 단, PUT /api/shipments/{id} 의 MO-완료 체크는 여전히 backend 에 없으므로 API 직접 호출로는 우회 가능. 서버 가드는 후속 티켓.