### PR TITLE
fix(#413): CI/PL status 정규화 (issued → 발행완료)

### DIFF
--- a/src/stores/ciDocuments.js
+++ b/src/stores/ciDocuments.js
@@ -25,6 +25,26 @@ function parseJsonSafe(value, fallback = []) {
   try { return JSON.parse(value) } catch { return fallback }
 }
 
+const DOC_STATUS_LABEL = {
+  pending: '발행대기',
+  issued: '발행완료',
+  sent: '발송완료',
+  draft: '초안',
+  cancelled: '취소',
+  canceled: '취소',
+  deleted: '삭제',
+  '발행대기': '발행대기',
+  '발행완료': '발행완료',
+  '발송완료': '발송완료',
+  '초안': '초안',
+  '취소': '취소',
+}
+
+function normalizeDocStatus(raw, fallback = '발행대기') {
+  if (raw == null || raw === '') return fallback
+  return DOC_STATUS_LABEL[String(raw).toLowerCase()] ?? DOC_STATUS_LABEL[raw] ?? String(raw)
+}
+
 function mapCiResponse(row) {
   const rawItems = row.items?.length ? row.items : parseJsonSafe(row.itemsSnapshot)
   const items = rawItems.map((item) => ({
@@ -38,7 +58,7 @@ function mapCiResponse(row) {
 
   return {
     id: row.ciId,
-    status: row.status ?? '발행대기',
+    status: normalizeDocStatus(row.status),
     issueDate: formatDate(row.invoiceDate ?? row.issueDate),
     clientId: row.clientId ?? row.client_id ?? null,
     clientName: row.clientName ?? '-',

--- a/src/stores/plDocuments.js
+++ b/src/stores/plDocuments.js
@@ -19,6 +19,26 @@ function parseJsonSafe(value, fallback = []) {
   try { return JSON.parse(value) } catch { return fallback }
 }
 
+const DOC_STATUS_LABEL = {
+  pending: '발행대기',
+  issued: '발행완료',
+  sent: '발송완료',
+  draft: '초안',
+  cancelled: '취소',
+  canceled: '취소',
+  deleted: '삭제',
+  '발행대기': '발행대기',
+  '발행완료': '발행완료',
+  '발송완료': '발송완료',
+  '초안': '초안',
+  '취소': '취소',
+}
+
+function normalizeDocStatus(raw, fallback = '발행대기') {
+  if (raw == null || raw === '') return fallback
+  return DOC_STATUS_LABEL[String(raw).toLowerCase()] ?? DOC_STATUS_LABEL[raw] ?? String(raw)
+}
+
 function mapPlResponse(row) {
   const rawItems = row.items?.length ? row.items : parseJsonSafe(row.itemsSnapshot)
   const items = rawItems.map((item) => ({
@@ -36,7 +56,7 @@ function mapPlResponse(row) {
 
   return {
     id: row.plId,
-    status: row.status ?? '발행대기',
+    status: normalizeDocStatus(row.status),
     issueDate: formatDate(row.invoiceDate ?? row.issueDate),
     clientId: row.clientId ?? row.client_id ?? null,
     clientName: row.clientName ?? '-',


### PR DESCRIPTION
## 📋 작업 내용

#413 의 follow-up. PR #414 머지 이후 확인된 잔여 이슈.

백엔드가 `ci_status`/`pl_status` 를 `'pending'`/`'issued'`/`'sent'`/`'draft'` 등 영문으로 저장하는데 프런트가 그대로 통과시켜 UI 에 **'issued'** 가 노출됨. Phase 1 에서 shipment/collection 만 정규화하고 CI/PL 을 놓친 케이스.

**변경**
- `stores/ciDocuments.js` / `stores/plDocuments.js` 에 `DOC_STATUS_LABEL` 매핑 + `normalizeDocStatus` 추가
- `mapCiResponse` / `mapPlResponse` 의 `status` 필드에 적용
- 이미 한글인 값도 안전하게 통과, 알 수 없는 값은 원본 유지 (새 enum 추가 시 crash 방지)

## 🔗 관련 이슈
- refs #413

## ✅ 체크리스트
- [x] 알려진 모든 status 값 매핑 (pending/issued/sent/draft/cancelled/canceled/deleted)
- [x] 양방향 idempotent (한글 → 한글 유지)

## 💬 리뷰어에게
StatusBadge 등 표시단에서 이미 '발행완료' 전제의 색상 매핑이 있는지 확인 부탁. 없으면 후속 조정.