### PR TITLE
fix(#416): PI/PO 결재 플로우 blocker 2건 + 파급 UX 정리

### DIFF
--- a/src/api/documents.js
+++ b/src/api/documents.js
@@ -158,3 +158,12 @@ export const fetchApprovers = (teamId = null) =>
   api
     .get('/approval-requests/approvers', { params: teamId != null ? { teamId } : {} })
     .then((r) => (Array.isArray(r.data) ? r.data : unwrapCollection(r.data)))
+
+/**
+ * 결재 요청 승인/반려. 백엔드 PUT /approval-requests/{id} 로 상태 전환 + 연결된 문서
+ * (PI/PO 등) 상태까지 일괄 갱신한다. 대시보드 승인/반려 액션에서 사용.
+ * @param {string|number} approvalRequestId
+ * @param {{ status: 'APPROVED'|'REJECTED', comment?: string, reason?: string }} payload
+ */
+export const updateApprovalRequest = (approvalRequestId, payload) =>
+  api.put(`/approval-requests/${approvalRequestId}`, payload).then((r) => r.data)

--- a/src/components/domain/document/PIFormModal.vue
+++ b/src/components/domain/document/PIFormModal.vue
@@ -100,7 +100,18 @@ function getTodayDateInput() {
 }
 
 function getDefaultApprover() {
+  // 요청자의 직속 팀장(= non-ADMIN) 을 우선. approverDirectory 가 비어 있으면 approverOptions fallback.
+  const leader = approverDirectory.value.find(
+    (u) => String(u.userRole ?? '').toUpperCase() !== 'ADMIN',
+  )
+  if (leader?.userName) return leader.userName
   return approverOptions.value[0] ?? defaultApproverOptions[0]
+}
+
+function resolveApproverId(name) {
+  if (!name) return null
+  const match = approverDirectory.value.find((u) => u.userName === name)
+  return match?.userId ?? null
 }
 
 function createInitialForm() {
@@ -140,6 +151,8 @@ const clientCatalog = ref([])
 const buyerRows = ref([])
 const currencyOptions = ref([...defaultCurrencyOptions])
 const approverOptions = ref([...defaultApproverOptions])
+// fetchApprovers 응답 원본 (userId/userName/userRole). 제출 시 name → userId 해소용.
+const approverDirectory = ref([])
 const productCatalog = ref([...fallbackProductCatalog])
 const incotermCatalog = ref([...fallbackIncotermsCatalog])
 const exchangeRateHint = ref(createExchangeRateHint('USD', getTodayDateInput()))
@@ -327,9 +340,14 @@ async function loadReferenceData() {
       .filter((item) => item.code)
 
     // 결재자 후보: 우리팀 팀장 + ADMIN (팀장/ADMIN 본인이 포함되면 셀프 결재 테스트 가능)
-    const approverNames = (approversData ?? [])
-      .map((user) => user.userName)
-      .filter(Boolean)
+    approverDirectory.value = Array.isArray(approversData) ? approversData : []
+    // non-ADMIN(팀장)이 먼저 노출되도록 정렬 → 기본값이 admin 으로 고정되는 UX 버그 방지.
+    approverDirectory.value.sort((a, b) => {
+      const aAdmin = String(a.userRole ?? '').toUpperCase() === 'ADMIN' ? 1 : 0
+      const bAdmin = String(b.userRole ?? '').toUpperCase() === 'ADMIN' ? 1 : 0
+      return aAdmin - bAdmin
+    })
+    const approverNames = approverDirectory.value.map((user) => user.userName).filter(Boolean)
 
     if (approverNames.length) {
       approverOptions.value = approverNames
@@ -725,6 +743,9 @@ function handleSave() {
 
   emit('save', {
     ...form.value,
+    // 결재자 userId 를 함께 전달. 백엔드 request-registration 의 approverId 로 들어가
+    // 요청자 팀장(이영업 등)이 실제로 승인 가능해진다.
+    approverId: resolveApproverId(form.value.approver),
     items: form.value.items.map(({ baseUnitPrice, ...item }) => ({ ...item })),
   })
 }

--- a/src/components/domain/document/POFormModal.vue
+++ b/src/components/domain/document/POFormModal.vue
@@ -44,6 +44,8 @@ function createInitialForm() {
 const form = ref(createInitialForm())
 const errors = ref({})
 const approverOptions = ref([...defaultApproverOptions])
+// fetchApprovers 원본 (userId/userName/userRole). name → userId 해소용.
+const approverDirectory = ref([])
 const isLinkedToPi = computed(() => Boolean(form.value.linkedPiId))
 const isDeliveryDateLocked = computed(() => isLinkedToPi.value && !form.value.deliveryDateOverride)
 
@@ -52,15 +54,28 @@ async function loadApproverOptions() {
     // 결재자 후보: 우리팀 팀장 + ADMIN (셀프 결재 가능)
     const teamId = authStore.currentUser?.teamId ?? null
     const approvers = await fetchApprovers(teamId)
-    const names = (approvers ?? []).map((u) => u.userName).filter(Boolean)
-    approverOptions.value = names
+    approverDirectory.value = Array.isArray(approvers) ? approvers : []
+    // non-ADMIN 을 앞으로: 기본값이 admin 에 고정되는 UX 버그 방지.
+    approverDirectory.value.sort((a, b) => {
+      const aAdmin = String(a.userRole ?? '').toUpperCase() === 'ADMIN' ? 1 : 0
+      const bAdmin = String(b.userRole ?? '').toUpperCase() === 'ADMIN' ? 1 : 0
+      return aAdmin - bAdmin
+    })
+    approverOptions.value = approverDirectory.value.map((u) => u.userName).filter(Boolean)
   } catch {
     approverOptions.value = []
+    approverDirectory.value = []
   }
 
   if (!approverOptions.value.includes(form.value.approver)) {
     form.value.approver = approverOptions.value[0] ?? ''
   }
+}
+
+function resolveApproverId(name) {
+  if (!name) return null
+  const match = approverDirectory.value.find((u) => u.userName === name)
+  return match?.userId ?? null
 }
 
 watch(
@@ -117,7 +132,10 @@ function validate() {
 
 function handleSave() {
   if (!validate()) return
-  emit('save', { ...form.value })
+  emit('save', {
+    ...form.value,
+    approverId: resolveApproverId(form.value.approver),
+  })
 }
 
 watch(

--- a/src/stores/approvalRequests.js
+++ b/src/stores/approvalRequests.js
@@ -1,0 +1,59 @@
+import { ref } from 'vue'
+import { fetchApprovalRequests } from '@/api/documents'
+import { useAuthStore } from './auth'
+
+const approvalRequests = ref([])
+let loading = null
+
+/**
+ * 결재 요청 원본 리스트 로드.
+ * piDocuments/poDocuments 가 각 문서에 결재자/반려사유를 병합할 때 참조하고,
+ * 대시보드 승인/반려가 실행된 뒤 re-fetch 용으로도 쓰인다.
+ */
+export async function loadApprovalRequests() {
+  try {
+    const list = await fetchApprovalRequests()
+    approvalRequests.value = Array.isArray(list) ? list : []
+  } catch (e) {
+    console.error('Failed to load approval requests:', e)
+    approvalRequests.value = []
+  }
+  return approvalRequests.value
+}
+
+export function useApprovalRequests() {
+  if (!loading && useAuthStore().isLoggedIn) {
+    loading = loadApprovalRequests()
+  }
+  return approvalRequests
+}
+
+/**
+ * 특정 문서(PI/PO 등)에 대한 "표시용 결재 요청" 한 건을 뽑는다.
+ * 우선순위:
+ *   1) PENDING(대기중) 중 가장 최신
+ *   2) PENDING 없으면 가장 최신(승인/반려 포함)
+ * 이 규칙은 QA 리포트의 I9 (반려된 문서 상세에 반려 사유 노출) 를 만족시키기 위함.
+ */
+export function pickLatestRequestFor(documentType, documentId) {
+  const all = approvalRequests.value.filter(
+    (r) => r.documentType === documentType && r.documentId === documentId,
+  )
+  if (all.length === 0) return null
+  const pending = all
+    .filter((r) => String(r.status ?? '').toLowerCase() === 'pending')
+    .sort(byRequestedAtDesc)
+  if (pending.length > 0) return pending[0]
+  return all.slice().sort(byRequestedAtDesc)[0]
+}
+
+function byRequestedAtDesc(a, b) {
+  const ta = a?.requestedAt ? new Date(a.requestedAt).getTime() : 0
+  const tb = b?.requestedAt ? new Date(b.requestedAt).getTime() : 0
+  return tb - ta
+}
+
+export function clearApprovalRequests() {
+  approvalRequests.value = []
+  loading = null
+}

--- a/src/stores/auth.js
+++ b/src/stores/auth.js
@@ -62,6 +62,7 @@ export const useAuthStore = defineStore('auth', () => {
       import('./shipmentOrderDocuments').then((m) => m.clearShipmentOrderDocuments()),
       import('./shipmentStatusDocuments').then((m) => m.clearShipmentStatusDocuments()),
       import('./salesCollectionDocuments').then((m) => m.clearSalesCollectionDocuments()),
+      import('./approvalRequests').then((m) => m.clearApprovalRequests()),
     ]).catch((e) => console.error('document store reset 중 오류', e))
   }
 

--- a/src/stores/ciDocuments.js
+++ b/src/stores/ciDocuments.js
@@ -25,6 +25,26 @@ function parseJsonSafe(value, fallback = []) {
   try { return JSON.parse(value) } catch { return fallback }
 }
 
+const DOC_STATUS_LABEL = {
+  pending: '발행대기',
+  issued: '발행완료',
+  sent: '발송완료',
+  draft: '초안',
+  cancelled: '취소',
+  canceled: '취소',
+  deleted: '삭제',
+  '발행대기': '발행대기',
+  '발행완료': '발행완료',
+  '발송완료': '발송완료',
+  '초안': '초안',
+  '취소': '취소',
+}
+
+function normalizeDocStatus(raw, fallback = '발행대기') {
+  if (raw == null || raw === '') return fallback
+  return DOC_STATUS_LABEL[String(raw).toLowerCase()] ?? DOC_STATUS_LABEL[raw] ?? String(raw)
+}
+
 function mapCiResponse(row) {
   const rawItems = row.items?.length ? row.items : parseJsonSafe(row.itemsSnapshot)
   const items = rawItems.map((item) => ({
@@ -38,7 +58,7 @@ function mapCiResponse(row) {
 
   return {
     id: row.ciId,
-    status: row.status ?? '발행대기',
+    status: normalizeDocStatus(row.status),
     issueDate: formatDate(row.invoiceDate ?? row.issueDate),
     clientId: row.clientId ?? row.client_id ?? null,
     clientName: row.clientName ?? '-',

--- a/src/stores/piDocuments.js
+++ b/src/stores/piDocuments.js
@@ -1,6 +1,7 @@
 import { useAuthStore } from './auth'
 import { ref } from 'vue'
 import { fetchProformaInvoicesPaged } from '@/api/documents'
+import { loadApprovalRequests, pickLatestRequestFor } from './approvalRequests'
 
 function tryParseJson(value, fallback = null) {
   if (typeof value !== 'string') return value ?? fallback
@@ -80,11 +81,32 @@ let loading = null
  */
 export async function loadPiDocuments({ page = 0, size = 1000 } = {}) {
   try {
-    const { content, page: pageInfo } = await fetchProformaInvoicesPaged({ page, size })
-    piDocuments.value = (Array.isArray(content) ? content : []).map(mapPiResponse)
+    // PI 목록과 결재 요청 리스트를 동시에 가져와, 각 PI 에 결재자/반려사유를 병합한다.
+    // 백엔드 proforma_invoices 뷰에는 approverId/reason 이 없어서 approval-requests 를
+    // 별도 조회해 documentId 로 매칭시킨다.
+    const [{ content, page: pageInfo }] = await Promise.all([
+      fetchProformaInvoicesPaged({ page, size }),
+      loadApprovalRequests(),
+    ])
+    const mapped = (Array.isArray(content) ? content : []).map(mapPiResponse)
+    piDocuments.value = mapped.map((row) => attachApprovalInfo(row))
     piPageInfo.value = pageInfo
   } catch (e) {
     console.error('Failed to load PI documents:', e)
+  }
+}
+
+function attachApprovalInfo(row) {
+  const req = pickLatestRequestFor('PI', row.id)
+  if (!req) return row
+  const statusLower = String(req.status ?? '').toLowerCase()
+  return {
+    ...row,
+    approvalRequestId: req.approvalRequestId ?? row.approvalRequestId ?? null,
+    approverId: req.approverId ?? row.approverId ?? null,
+    approverName: req.approverName ?? row.approverName ?? null,
+    approvalRejectReason:
+      statusLower === 'rejected' ? (req.reason ?? row.approvalRejectReason ?? null) : (row.approvalRejectReason ?? null),
   }
 }
 

--- a/src/stores/plDocuments.js
+++ b/src/stores/plDocuments.js
@@ -19,6 +19,26 @@ function parseJsonSafe(value, fallback = []) {
   try { return JSON.parse(value) } catch { return fallback }
 }
 
+const DOC_STATUS_LABEL = {
+  pending: '발행대기',
+  issued: '발행완료',
+  sent: '발송완료',
+  draft: '초안',
+  cancelled: '취소',
+  canceled: '취소',
+  deleted: '삭제',
+  '발행대기': '발행대기',
+  '발행완료': '발행완료',
+  '발송완료': '발송완료',
+  '초안': '초안',
+  '취소': '취소',
+}
+
+function normalizeDocStatus(raw, fallback = '발행대기') {
+  if (raw == null || raw === '') return fallback
+  return DOC_STATUS_LABEL[String(raw).toLowerCase()] ?? DOC_STATUS_LABEL[raw] ?? String(raw)
+}
+
 function mapPlResponse(row) {
   const rawItems = row.items?.length ? row.items : parseJsonSafe(row.itemsSnapshot)
   const items = rawItems.map((item) => ({
@@ -36,7 +56,7 @@ function mapPlResponse(row) {
 
   return {
     id: row.plId,
-    status: row.status ?? '발행대기',
+    status: normalizeDocStatus(row.status),
     issueDate: formatDate(row.invoiceDate ?? row.issueDate),
     clientId: row.clientId ?? row.client_id ?? null,
     clientName: row.clientName ?? '-',

--- a/src/stores/poDocuments.js
+++ b/src/stores/poDocuments.js
@@ -1,6 +1,7 @@
 import { useAuthStore } from './auth'
 import { ref } from 'vue'
 import { fetchPurchaseOrdersPaged } from '@/api/documents'
+import { loadApprovalRequests, pickLatestRequestFor } from './approvalRequests'
 
 function formatDate(value) {
   return String(value ?? '').replace(/-/g, '/')
@@ -91,11 +92,29 @@ let loading = null
 
 export async function loadPoDocuments({ page = 0, size = 1000 } = {}) {
   try {
-    const { content, page: pageInfo } = await fetchPurchaseOrdersPaged({ page, size })
-    poDocuments.value = (Array.isArray(content) ? content : []).map(mapPoResponse)
+    const [{ content, page: pageInfo }] = await Promise.all([
+      fetchPurchaseOrdersPaged({ page, size }),
+      loadApprovalRequests(),
+    ])
+    const mapped = (Array.isArray(content) ? content : []).map(mapPoResponse)
+    poDocuments.value = mapped.map((row) => attachApprovalInfo(row))
     poPageInfo.value = pageInfo
   } catch (e) {
     console.error('Failed to load PO documents:', e)
+  }
+}
+
+function attachApprovalInfo(row) {
+  const req = pickLatestRequestFor('PO', row.id)
+  if (!req) return row
+  const statusLower = String(req.status ?? '').toLowerCase()
+  return {
+    ...row,
+    approvalRequestId: req.approvalRequestId ?? row.approvalRequestId ?? null,
+    approverId: req.approverId ?? row.approverId ?? null,
+    approverName: req.approverName ?? row.approverName ?? null,
+    approvalRejectReason:
+      statusLower === 'rejected' ? (req.reason ?? row.approvalRejectReason ?? null) : (row.approvalRejectReason ?? null),
   }
 }
 

--- a/src/utils/documentApproval.js
+++ b/src/utils/documentApproval.js
@@ -92,10 +92,26 @@ export function buildApprovalInfoRows(document) {
     return []
   }
 
-  return [
+  const rows = [
     { label: '상태', value: resolveCompositeStatus(document) },
-    { label: '결재자', value: document.approver || '미지정' },
+    // approvalRequests 병합 결과로 붙는 approverName 을 우선. 과거 로컬 뮤테이션으로만
+    // 채워지던 document.approver 는 백업 fallback.
+    { label: '결재자', value: document.approverName || document.approver || '미지정' },
     { label: '요청자', value: document.approvalRequestedBy || '미지정' },
     { label: '요청 시각', value: document.approvalRequestedAt || '-' },
   ]
+
+  // 반려 상태일 때 사유 노출 (I9). 상태 정규화는 resolveCompositeStatus 와 동일 규칙.
+  const statusNorm = String(document.status ?? '').trim().toLowerCase()
+  const approvalNorm = String(document.approvalStatus ?? '').trim().toLowerCase()
+  const isRejected =
+    statusNorm === '반려' ||
+    statusNorm === 'rejected' ||
+    approvalNorm === '반려' ||
+    approvalNorm === 'rejected'
+  if (isRejected && document.approvalRejectReason) {
+    rows.push({ label: '반려 사유', value: document.approvalRejectReason, fullWidth: true })
+  }
+
+  return rows
 }

--- a/src/views/DashboardPage.vue
+++ b/src/views/DashboardPage.vue
@@ -15,6 +15,9 @@ import { useShipmentStatusDocuments, loadShipmentStatusDocuments } from '@/store
 import { fetchActivities } from '@/api/activity'
 import { fetchClients } from '@/api/master'
 import { fetchPackages, deletePackage as deletePackageApi } from '@/api/package'
+import { updateApprovalRequest } from '@/api/documents'
+import { loadApprovalRequests } from '@/stores/approvalRequests'
+import { label as enumLabel, PI_PO_STATUS_LABEL } from '@/utils/enumLabels'
 import { useToast } from '@/composables/useToast'
 import PackageDetailModal from '@/components/domain/activity/PackageDetailModal.vue'
 
@@ -221,9 +224,10 @@ function buildFallbackReview(docType, row) {
     message: '요청 시점의 검토 데이터가 없어 현재 문서 스냅샷 기준으로 표시합니다.',
     requestRows: [
       { label: '요청 유형', value: `${row.approvalAction || '-'} 요청` },
-      { label: '결재자', value: row.approver || '미지정' },
+      { label: '결재자', value: row.approverName || row.approver || '미지정' },
       { label: '요청자', value: row.approvalRequestedBy || '미지정' },
-      { label: '문서 상태', value: row.status || '-' },
+      // 백엔드가 내려주는 raw enum(pending_approval 등)이 그대로 노출되는 UX 결함을 방지.
+      { label: '문서 상태', value: enumLabel(PI_PO_STATUS_LABEL, row.status) || '-' },
       { label: '요청 상태', value: row.requestStatus || '-' },
       { label: '요청 시각', value: row.approvalRequestedAt || '-' },
       ...(row.approvalRejectReason
@@ -266,10 +270,12 @@ function createRequestItem(docType, row) {
     id: `${docType}-${row.id}`,
     docType,
     docId: row.id,
+    // 실제 승인/반려 PUT 에 필요한 approvalRequestId (piDocuments/poDocuments 가 병합해둠)
+    approvalRequestId: row.approvalRequestId ?? null,
     actionLabel: row.approvalAction || row.requestStatus?.replace('요청', '') || '결재',
     company: row.clientName || '-',
     requester: row.approvalRequestedBy || '미지정',
-    approver: row.approver || '미지정',
+    approver: row.approverName || row.approver || '미지정',
     status: row.approvalStatus || '-',
     requestStatus: row.requestStatus || '-',
     requestedAt: row.approvalRequestedAt || '-',
@@ -330,15 +336,6 @@ function closeDecisionConfirm() {
   rejectReason.value = ''
 }
 
-function updateRequestDocument(item, patch) {
-  const targetStore = item.docType === 'PI' ? piDocuments : poDocuments
-  targetStore.value = targetStore.value.map((row) => (
-    row.id === item.docId
-      ? { ...row, ...patch }
-      : row
-  ))
-}
-
 function getReviewedAt() {
   const now = new Date()
   const year = now.getFullYear()
@@ -384,29 +381,40 @@ function openRejectConfirm() {
   decisionConfirmOpen.value = true
 }
 
-function confirmDecision() {
+async function confirmDecision() {
   if (!selectedRequest.value || !pendingDecision.value) return
 
-  if (pendingDecision.value === 'approve') {
-    const nextStatus = selectedRequest.value.actionLabel === '삭제' ? '취소' : '확정'
-    updateRequestDocument(selectedRequest.value, {
-      status: nextStatus,
-      approvalStatus: '승인',
-      approvalReviewedBy: currentUser.value?.name || '',
-      approvalReviewedAt: getReviewedAt(),
-    })
-  } else {
-    updateRequestDocument(selectedRequest.value, {
-      status: '반려',
-      approvalStatus: '반려',
-      approvalReviewedBy: currentUser.value?.name || '',
-      approvalReviewedAt: getReviewedAt(),
-      approvalRejectReason: rejectReason.value.trim() || '',
-    })
+  const item = selectedRequest.value
+  const approvalRequestId = item.approvalRequestId
+  if (!approvalRequestId) {
+    toastError('해당 요청의 결재 요청 ID를 찾을 수 없습니다. 새로고침 후 다시 시도해주세요.')
+    closeDecisionConfirm()
+    closeRequestReview()
+    return
   }
 
-  closeDecisionConfirm()
-  closeRequestReview()
+  try {
+    if (pendingDecision.value === 'approve') {
+      await updateApprovalRequest(approvalRequestId, { status: 'APPROVED' })
+    } else {
+      await updateApprovalRequest(approvalRequestId, {
+        status: 'REJECTED',
+        reason: rejectReason.value.trim() || '',
+      })
+    }
+
+    // 백엔드가 approval_requests + 원본 문서(PI/PO) 상태를 모두 갱신하므로
+    // 양쪽 store 를 모두 다시 fetch 해 UI 에 즉시 반영. approvalRequests 는
+    // PI/PO loader 가 내부에서 다시 호출한다.
+    await Promise.all([loadPiDocuments(), loadPoDocuments(), loadApprovalRequests()])
+
+    success(pendingDecision.value === 'approve' ? '결재가 승인되었습니다.' : '결재가 반려되었습니다.')
+  } catch (e) {
+    toastError(e?.response?.data?.message || '결재 처리 중 오류가 발생했습니다.')
+  } finally {
+    closeDecisionConfirm()
+    closeRequestReview()
+  }
 }
 
 function goToRequestDetail() {

--- a/src/views/documents/PIPage.vue
+++ b/src/views/documents/PIPage.vue
@@ -519,6 +519,13 @@ function getDefaultDeleteApprover(row) {
   return row?.approver || ''
 }
 
+// 결재대기 중인 행은 요청자 본인도 임의 수정/삭제 불가(I2 불변식).
+// 상세 페이지는 이미 이 가드를 적용 중이므로 목록도 parity 를 맞춘다.
+const PENDING_APPROVAL_STATUSES = new Set(['결재대기', 'pending_approval', 'APPROVAL_PENDING'])
+function isPendingApproval(row) {
+  return PENDING_APPROVAL_STATUSES.has(row?.status)
+}
+
 function getRequestedAt() {
   const now = new Date()
   const year = now.getFullYear()
@@ -662,7 +669,9 @@ const createApprovalDocumentRows = computed(() => {
   const { nextRow } = buildRowPayload(pendingCreateFormValue.value)
 
   return [
-    { label: '예정 PI 번호', value: buildNextPiId() },
+    // 서버의 채번규칙과 화면 추정값이 다르면 사용자가 "같은 문서"를 추적하기 어려워져
+    // QA 리포트(PI 번호 생성 불일치)로 지적됨. 예측값 대신 안내 문구로 대체.
+    { label: '예정 PI 번호', value: '저장 후 자동 생성' },
     { label: '거래처', value: nextRow.clientName },
     { label: '영문주소', value: nextRow.clientAddress || '-', fullWidth: true },
     { label: '바이어', value: nextRow.buyerName || '-' },
@@ -822,7 +831,8 @@ async function confirmCreateApprovalRequest() {
     const payload = buildCreatePayload(pendingCreateFormValue.value)
     const { piId } = await createProformaInvoice(payload)
     const userId = authStore.currentUser?.userId
-    await requestPiRegistration({ piId, userId })
+    const approverId = pendingCreateFormValue.value.approverId ?? null
+    await requestPiRegistration({ piId, userId, approverId })
     await loadPiDocuments()
 
     createApprovalRequestOpen.value = false
@@ -1168,8 +1178,8 @@ function handleProductSelect(product) {
 
       <template #cell-actions="{ row }">
         <TableActions
-          :show-edit="!shipmentLockInfoByPiId.get(row.id)?.locked && !collectionLockInfoByPiId.get(row.id)?.locked && canMutateDocument(row, authStore.currentUser)"
-          :show-delete="!shipmentLockInfoByPiId.get(row.id)?.locked && !collectionLockInfoByPiId.get(row.id)?.locked && canMutateDocument(row, authStore.currentUser)"
+          :show-edit="!shipmentLockInfoByPiId.get(row.id)?.locked && !collectionLockInfoByPiId.get(row.id)?.locked && canMutateDocument(row, authStore.currentUser) && !isPendingApproval(row)"
+          :show-delete="!shipmentLockInfoByPiId.get(row.id)?.locked && !collectionLockInfoByPiId.get(row.id)?.locked && canMutateDocument(row, authStore.currentUser) && !isPendingApproval(row)"
           @edit="openEditForm(row)"
           @delete="openDeleteApprovalRequest(row)"
         />

--- a/src/views/documents/POPage.vue
+++ b/src/views/documents/POPage.vue
@@ -545,6 +545,12 @@ function getDefaultDeleteApprover(row) {
   return row?.approver || ''
 }
 
+// 결재대기 중인 행은 요청자 본인도 임의 수정/삭제 불가(I2 불변식).
+const PENDING_APPROVAL_STATUSES = new Set(['결재대기', 'pending_approval', 'APPROVAL_PENDING'])
+function isPendingApproval(row) {
+  return PENDING_APPROVAL_STATUSES.has(row?.status)
+}
+
 function getRequestedAt() {
   const now = new Date()
   const year = now.getFullYear()
@@ -614,7 +620,8 @@ const createApprovalDocumentRows = computed(() => {
   const isDeliveryOverride = Boolean(nextRow.deliveryDateOverride && nextRow.sourceDeliveryDate && nextRow.deliveryDate !== nextRow.sourceDeliveryDate)
 
   return [
-    { label: '예정 PO 번호', value: buildNextPoId() },
+    // 예측 번호와 실제 부여 번호가 달라 QA 리포트로 지적됨. 안내 문구로 대체.
+    { label: '예정 PO 번호', value: '저장 후 자동 생성' },
     { label: '발행일', value: nextRow.issueDate },
     { label: '납기일', value: nextRow.deliveryDate },
     { label: '납기 처리', value: isDeliveryOverride ? 'PI 기준값에서 별도 조정' : 'PI 기준값 사용' },
@@ -832,7 +839,8 @@ async function confirmCreateApprovalRequest() {
     const payload = buildCreatePayload(pendingCreateFormValue.value)
     const { poId } = await createPurchaseOrder(payload)
     const userId = authStore.currentUser?.userId
-    await requestPoRegistration({ poId, userId })
+    const approverId = pendingCreateFormValue.value.approverId ?? null
+    await requestPoRegistration({ poId, userId, approverId })
     await loadPoDocuments()
 
     createApprovalRequestOpen.value = false
@@ -1195,8 +1203,8 @@ function handleProductSelect(product) {
 
       <template #cell-actions="{ row }">
         <TableActions
-          :show-edit="!shipmentLockInfoByPoId.get(row.id)?.locked && !collectionLockInfoByPoId.get(row.id)?.locked && canMutateDocument(row, authStore.currentUser)"
-          :show-delete="!shipmentLockInfoByPoId.get(row.id)?.locked && !collectionLockInfoByPoId.get(row.id)?.locked && canMutateDocument(row, authStore.currentUser)"
+          :show-edit="!shipmentLockInfoByPoId.get(row.id)?.locked && !collectionLockInfoByPoId.get(row.id)?.locked && canMutateDocument(row, authStore.currentUser) && !isPendingApproval(row)"
+          :show-delete="!shipmentLockInfoByPoId.get(row.id)?.locked && !collectionLockInfoByPoId.get(row.id)?.locked && canMutateDocument(row, authStore.currentUser) && !isPendingApproval(row)"
           @edit="openEditForm(row)"
           @delete="openDeleteApprovalRequest(row)"
         />


### PR DESCRIPTION
## 📋 작업 내용

E2E QA 리포트(2026-04-19) 에서 지적된 결재 플로우 **blocker 2건**과 그 파급 UX 이슈를 일괄 정리. 시나리오 A/B 가 모두 PI 등록 결재 단계에서 막혀 이후 PO·생산·출하·수금 구간을 실행조차 못 하던 문제를 해소한다.

### 근본 결함

1. **등록 결재자 하드코딩** — 백엔드 `ProformaInvoiceService` / `PurchaseOrderRegistrationService` 가 `new ApprovalRequest(..., userId, 1L)` 로 결재자를 admin(1) 고정. 프론트 드롭다운 선택이 무효화됨.
   - 수정: 백엔드 PR [team2-backend-documents 6ddc899](https://github.com/hanhwa-swcamp-22th-final/team2-backend-documents/commit/6ddc899) 에서 `ApproverResolver.resolveApproverId(userId)` 주입 + `approverId` override DTO 필드 추가
   - 본 PR: PIFormModal/POFormModal 이 선택한 결재자 userId 를 emit → PIPage/POPage 가 requestPi/PoRegistration body 에 포함

2. **대시보드 승인/반려가 로컬 뮤테이션** — `DashboardPage.confirmDecision` 이 `piDocuments`/`poDocuments` ref 만 패치하고 `PUT /api/approval-requests/{id}` 를 호출하지 않음. 요청자 재로그인 시 fresh fetch 로 pending 복원.
   - 수정: 실 API 호출로 교체, 성공 후 `loadPiDocuments`/`loadPoDocuments`/`loadApprovalRequests` refresh

### 구조적 추가
- `stores/approvalRequests.js` 신규 — documentId → latest request 해소기(PENDING 우선, 없으면 최신 requestedAt)
- `stores/piDocuments.js` / `poDocuments.js` — load 시 approvals 동시 fetch, 각 row 에 `approverId/approverName/approvalRequestId/approvalRejectReason` 병합 (I9 반려 사유 노출의 데이터 소스)

### 파급 UX 정리
- PI/POPage: 결재대기 행의 수정/삭제 버튼 숨김 — `isPendingApproval(row)` 가드 (I2)
- PI/POPage: "예정 PI/PO 번호" 예측값 → "저장 후 자동 생성" 안내 (QA 리포트 번호 불일치)
- PIFormModal/POFormModal: 결재자 드롭다운 기본값을 non-ADMIN(요청자 팀장) 우선
- `utils/documentApproval.js`: 반려 상태일 때 "반려 사유" row 추가 + 결재자 표시 `approverName` 우선 (I9)
- `DashboardPage` fallback review: 문서 상태를 `PI_PO_STATUS_LABEL` 로 한글화 (`pending_approval` 노출 제거)

### 명시적으로 out-of-scope
- 세션/캐시 이슈(상세→목록 시 0건)
- 팀원/팀장 대시보드의 "내 요청 현황"/"결재 요청함" 위젯 부재
- 목록 "발행일" 컬럼이 작성일로 채워지는 문제

## 🔗 관련 이슈
- closes #416

## 📸 스크린샷 (선택)
N/A — E2E 환경(http://playdata4.iptime.org:8001) 에서 재검증 예정

## ✅ 체크리스트

- [x] 정상 동작 확인 — vite build 6.03s 성공, Node syntax check/SFC parse 전부 OK, backend gradle build 성공
- [x] 불필요한 코드/주석 제거 — `updateRequestDocument` (로컬 뮤테이션 헬퍼) 삭제
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

- `stores/approvalRequests.js` 의 `pickLatestRequestFor` 우선순위(PENDING → 최신 requestedAt)가 관리자 "전체 결재 현황"과 요청자 반려 이력 표시 양쪽 모두를 만족시키는지 확인 부탁드립니다.
- `DashboardPage.confirmDecision` 에서 승인/반려 직후 3개 store 를 병렬 `Promise.all` refresh 하는데, 세션/캐시 이슈(별도 out-of-scope) 와 상호작용이 있는지 1차 테스트 필요.
- 백엔드 커밋 `6ddc899` 가 이미 main 에 푸시되어 있어, 이 PR 은 백엔드 배포 후 E2E 로 돌려야 완전한 블로커 해소 확인 가능합니다.