### PR TITLE
fix(#418): 팀장 본인 결재를 PI/PO 상세에서 직접 승인·반려

### DIFF
--- a/src/api/documents.js
+++ b/src/api/documents.js
@@ -158,3 +158,12 @@ export const fetchApprovers = (teamId = null) =>
   api
     .get('/approval-requests/approvers', { params: teamId != null ? { teamId } : {} })
     .then((r) => (Array.isArray(r.data) ? r.data : unwrapCollection(r.data)))
+
+/**
+ * 결재 요청 승인/반려. 백엔드 PUT /approval-requests/{id} 로 상태 전환 + 연결된 문서
+ * (PI/PO 등) 상태까지 일괄 갱신한다. 대시보드 승인/반려 액션에서 사용.
+ * @param {string|number} approvalRequestId
+ * @param {{ status: 'APPROVED'|'REJECTED', comment?: string, reason?: string }} payload
+ */
+export const updateApprovalRequest = (approvalRequestId, payload) =>
+  api.put(`/approval-requests/${approvalRequestId}`, payload).then((r) => r.data)

--- a/src/components/domain/document/PIFormModal.vue
+++ b/src/components/domain/document/PIFormModal.vue
@@ -100,7 +100,18 @@ function getTodayDateInput() {
 }
 
 function getDefaultApprover() {
+  // 요청자의 직속 팀장(= non-ADMIN) 을 우선. approverDirectory 가 비어 있으면 approverOptions fallback.
+  const leader = approverDirectory.value.find(
+    (u) => String(u.userRole ?? '').toUpperCase() !== 'ADMIN',
+  )
+  if (leader?.userName) return leader.userName
   return approverOptions.value[0] ?? defaultApproverOptions[0]
+}
+
+function resolveApproverId(name) {
+  if (!name) return null
+  const match = approverDirectory.value.find((u) => u.userName === name)
+  return match?.userId ?? null
 }
 
 function createInitialForm() {
@@ -140,6 +151,8 @@ const clientCatalog = ref([])
 const buyerRows = ref([])
 const currencyOptions = ref([...defaultCurrencyOptions])
 const approverOptions = ref([...defaultApproverOptions])
+// fetchApprovers 응답 원본 (userId/userName/userRole). 제출 시 name → userId 해소용.
+const approverDirectory = ref([])
 const productCatalog = ref([...fallbackProductCatalog])
 const incotermCatalog = ref([...fallbackIncotermsCatalog])
 const exchangeRateHint = ref(createExchangeRateHint('USD', getTodayDateInput()))
@@ -327,9 +340,14 @@ async function loadReferenceData() {
       .filter((item) => item.code)
 
     // 결재자 후보: 우리팀 팀장 + ADMIN (팀장/ADMIN 본인이 포함되면 셀프 결재 테스트 가능)
-    const approverNames = (approversData ?? [])
-      .map((user) => user.userName)
-      .filter(Boolean)
+    approverDirectory.value = Array.isArray(approversData) ? approversData : []
+    // non-ADMIN(팀장)이 먼저 노출되도록 정렬 → 기본값이 admin 으로 고정되는 UX 버그 방지.
+    approverDirectory.value.sort((a, b) => {
+      const aAdmin = String(a.userRole ?? '').toUpperCase() === 'ADMIN' ? 1 : 0
+      const bAdmin = String(b.userRole ?? '').toUpperCase() === 'ADMIN' ? 1 : 0
+      return aAdmin - bAdmin
+    })
+    const approverNames = approverDirectory.value.map((user) => user.userName).filter(Boolean)
 
     if (approverNames.length) {
       approverOptions.value = approverNames
@@ -725,6 +743,9 @@ function handleSave() {
 
   emit('save', {
     ...form.value,
+    // 결재자 userId 를 함께 전달. 백엔드 request-registration 의 approverId 로 들어가
+    // 요청자 팀장(이영업 등)이 실제로 승인 가능해진다.
+    approverId: resolveApproverId(form.value.approver),
     items: form.value.items.map(({ baseUnitPrice, ...item }) => ({ ...item })),
   })
 }

--- a/src/components/domain/document/POFormModal.vue
+++ b/src/components/domain/document/POFormModal.vue
@@ -44,6 +44,8 @@ function createInitialForm() {
 const form = ref(createInitialForm())
 const errors = ref({})
 const approverOptions = ref([...defaultApproverOptions])
+// fetchApprovers 원본 (userId/userName/userRole). name → userId 해소용.
+const approverDirectory = ref([])
 const isLinkedToPi = computed(() => Boolean(form.value.linkedPiId))
 const isDeliveryDateLocked = computed(() => isLinkedToPi.value && !form.value.deliveryDateOverride)
 
@@ -52,15 +54,28 @@ async function loadApproverOptions() {
     // 결재자 후보: 우리팀 팀장 + ADMIN (셀프 결재 가능)
     const teamId = authStore.currentUser?.teamId ?? null
     const approvers = await fetchApprovers(teamId)
-    const names = (approvers ?? []).map((u) => u.userName).filter(Boolean)
-    approverOptions.value = names
+    approverDirectory.value = Array.isArray(approvers) ? approvers : []
+    // non-ADMIN 을 앞으로: 기본값이 admin 에 고정되는 UX 버그 방지.
+    approverDirectory.value.sort((a, b) => {
+      const aAdmin = String(a.userRole ?? '').toUpperCase() === 'ADMIN' ? 1 : 0
+      const bAdmin = String(b.userRole ?? '').toUpperCase() === 'ADMIN' ? 1 : 0
+      return aAdmin - bAdmin
+    })
+    approverOptions.value = approverDirectory.value.map((u) => u.userName).filter(Boolean)
   } catch {
     approverOptions.value = []
+    approverDirectory.value = []
   }
 
   if (!approverOptions.value.includes(form.value.approver)) {
     form.value.approver = approverOptions.value[0] ?? ''
   }
+}
+
+function resolveApproverId(name) {
+  if (!name) return null
+  const match = approverDirectory.value.find((u) => u.userName === name)
+  return match?.userId ?? null
 }
 
 watch(
@@ -117,7 +132,10 @@ function validate() {
 
 function handleSave() {
   if (!validate()) return
-  emit('save', { ...form.value })
+  emit('save', {
+    ...form.value,
+    approverId: resolveApproverId(form.value.approver),
+  })
 }
 
 watch(

--- a/src/stores/approvalRequests.js
+++ b/src/stores/approvalRequests.js
@@ -1,0 +1,59 @@
+import { ref } from 'vue'
+import { fetchApprovalRequests } from '@/api/documents'
+import { useAuthStore } from './auth'
+
+const approvalRequests = ref([])
+let loading = null
+
+/**
+ * 결재 요청 원본 리스트 로드.
+ * piDocuments/poDocuments 가 각 문서에 결재자/반려사유를 병합할 때 참조하고,
+ * 대시보드 승인/반려가 실행된 뒤 re-fetch 용으로도 쓰인다.
+ */
+export async function loadApprovalRequests() {
+  try {
+    const list = await fetchApprovalRequests()
+    approvalRequests.value = Array.isArray(list) ? list : []
+  } catch (e) {
+    console.error('Failed to load approval requests:', e)
+    approvalRequests.value = []
+  }
+  return approvalRequests.value
+}
+
+export function useApprovalRequests() {
+  if (!loading && useAuthStore().isLoggedIn) {
+    loading = loadApprovalRequests()
+  }
+  return approvalRequests
+}
+
+/**
+ * 특정 문서(PI/PO 등)에 대한 "표시용 결재 요청" 한 건을 뽑는다.
+ * 우선순위:
+ *   1) PENDING(대기중) 중 가장 최신
+ *   2) PENDING 없으면 가장 최신(승인/반려 포함)
+ * 이 규칙은 QA 리포트의 I9 (반려된 문서 상세에 반려 사유 노출) 를 만족시키기 위함.
+ */
+export function pickLatestRequestFor(documentType, documentId) {
+  const all = approvalRequests.value.filter(
+    (r) => r.documentType === documentType && r.documentId === documentId,
+  )
+  if (all.length === 0) return null
+  const pending = all
+    .filter((r) => String(r.status ?? '').toLowerCase() === 'pending')
+    .sort(byRequestedAtDesc)
+  if (pending.length > 0) return pending[0]
+  return all.slice().sort(byRequestedAtDesc)[0]
+}
+
+function byRequestedAtDesc(a, b) {
+  const ta = a?.requestedAt ? new Date(a.requestedAt).getTime() : 0
+  const tb = b?.requestedAt ? new Date(b.requestedAt).getTime() : 0
+  return tb - ta
+}
+
+export function clearApprovalRequests() {
+  approvalRequests.value = []
+  loading = null
+}

--- a/src/stores/auth.js
+++ b/src/stores/auth.js
@@ -62,6 +62,7 @@ export const useAuthStore = defineStore('auth', () => {
       import('./shipmentOrderDocuments').then((m) => m.clearShipmentOrderDocuments()),
       import('./shipmentStatusDocuments').then((m) => m.clearShipmentStatusDocuments()),
       import('./salesCollectionDocuments').then((m) => m.clearSalesCollectionDocuments()),
+      import('./approvalRequests').then((m) => m.clearApprovalRequests()),
     ]).catch((e) => console.error('document store reset 중 오류', e))
   }
 

--- a/src/stores/ciDocuments.js
+++ b/src/stores/ciDocuments.js
@@ -25,6 +25,26 @@ function parseJsonSafe(value, fallback = []) {
   try { return JSON.parse(value) } catch { return fallback }
 }
 
+const DOC_STATUS_LABEL = {
+  pending: '발행대기',
+  issued: '발행완료',
+  sent: '발송완료',
+  draft: '초안',
+  cancelled: '취소',
+  canceled: '취소',
+  deleted: '삭제',
+  '발행대기': '발행대기',
+  '발행완료': '발행완료',
+  '발송완료': '발송완료',
+  '초안': '초안',
+  '취소': '취소',
+}
+
+function normalizeDocStatus(raw, fallback = '발행대기') {
+  if (raw == null || raw === '') return fallback
+  return DOC_STATUS_LABEL[String(raw).toLowerCase()] ?? DOC_STATUS_LABEL[raw] ?? String(raw)
+}
+
 function mapCiResponse(row) {
   const rawItems = row.items?.length ? row.items : parseJsonSafe(row.itemsSnapshot)
   const items = rawItems.map((item) => ({
@@ -38,7 +58,7 @@ function mapCiResponse(row) {
 
   return {
     id: row.ciId,
-    status: row.status ?? '발행대기',
+    status: normalizeDocStatus(row.status),
     issueDate: formatDate(row.invoiceDate ?? row.issueDate),
     clientId: row.clientId ?? row.client_id ?? null,
     clientName: row.clientName ?? '-',

--- a/src/stores/piDocuments.js
+++ b/src/stores/piDocuments.js
@@ -1,6 +1,7 @@
 import { useAuthStore } from './auth'
 import { ref } from 'vue'
 import { fetchProformaInvoicesPaged } from '@/api/documents'
+import { loadApprovalRequests, pickLatestRequestFor } from './approvalRequests'
 
 function tryParseJson(value, fallback = null) {
   if (typeof value !== 'string') return value ?? fallback
@@ -80,11 +81,32 @@ let loading = null
  */
 export async function loadPiDocuments({ page = 0, size = 1000 } = {}) {
   try {
-    const { content, page: pageInfo } = await fetchProformaInvoicesPaged({ page, size })
-    piDocuments.value = (Array.isArray(content) ? content : []).map(mapPiResponse)
+    // PI 목록과 결재 요청 리스트를 동시에 가져와, 각 PI 에 결재자/반려사유를 병합한다.
+    // 백엔드 proforma_invoices 뷰에는 approverId/reason 이 없어서 approval-requests 를
+    // 별도 조회해 documentId 로 매칭시킨다.
+    const [{ content, page: pageInfo }] = await Promise.all([
+      fetchProformaInvoicesPaged({ page, size }),
+      loadApprovalRequests(),
+    ])
+    const mapped = (Array.isArray(content) ? content : []).map(mapPiResponse)
+    piDocuments.value = mapped.map((row) => attachApprovalInfo(row))
     piPageInfo.value = pageInfo
   } catch (e) {
     console.error('Failed to load PI documents:', e)
+  }
+}
+
+function attachApprovalInfo(row) {
+  const req = pickLatestRequestFor('PI', row.id)
+  if (!req) return row
+  const statusLower = String(req.status ?? '').toLowerCase()
+  return {
+    ...row,
+    approvalRequestId: req.approvalRequestId ?? row.approvalRequestId ?? null,
+    approverId: req.approverId ?? row.approverId ?? null,
+    approverName: req.approverName ?? row.approverName ?? null,
+    approvalRejectReason:
+      statusLower === 'rejected' ? (req.reason ?? row.approvalRejectReason ?? null) : (row.approvalRejectReason ?? null),
   }
 }
 

--- a/src/stores/plDocuments.js
+++ b/src/stores/plDocuments.js
@@ -19,6 +19,26 @@ function parseJsonSafe(value, fallback = []) {
   try { return JSON.parse(value) } catch { return fallback }
 }
 
+const DOC_STATUS_LABEL = {
+  pending: '발행대기',
+  issued: '발행완료',
+  sent: '발송완료',
+  draft: '초안',
+  cancelled: '취소',
+  canceled: '취소',
+  deleted: '삭제',
+  '발행대기': '발행대기',
+  '발행완료': '발행완료',
+  '발송완료': '발송완료',
+  '초안': '초안',
+  '취소': '취소',
+}
+
+function normalizeDocStatus(raw, fallback = '발행대기') {
+  if (raw == null || raw === '') return fallback
+  return DOC_STATUS_LABEL[String(raw).toLowerCase()] ?? DOC_STATUS_LABEL[raw] ?? String(raw)
+}
+
 function mapPlResponse(row) {
   const rawItems = row.items?.length ? row.items : parseJsonSafe(row.itemsSnapshot)
   const items = rawItems.map((item) => ({
@@ -36,7 +56,7 @@ function mapPlResponse(row) {
 
   return {
     id: row.plId,
-    status: row.status ?? '발행대기',
+    status: normalizeDocStatus(row.status),
     issueDate: formatDate(row.invoiceDate ?? row.issueDate),
     clientId: row.clientId ?? row.client_id ?? null,
     clientName: row.clientName ?? '-',

--- a/src/stores/poDocuments.js
+++ b/src/stores/poDocuments.js
@@ -1,6 +1,7 @@
 import { useAuthStore } from './auth'
 import { ref } from 'vue'
 import { fetchPurchaseOrdersPaged } from '@/api/documents'
+import { loadApprovalRequests, pickLatestRequestFor } from './approvalRequests'
 
 function formatDate(value) {
   return String(value ?? '').replace(/-/g, '/')
@@ -91,11 +92,29 @@ let loading = null
 
 export async function loadPoDocuments({ page = 0, size = 1000 } = {}) {
   try {
-    const { content, page: pageInfo } = await fetchPurchaseOrdersPaged({ page, size })
-    poDocuments.value = (Array.isArray(content) ? content : []).map(mapPoResponse)
+    const [{ content, page: pageInfo }] = await Promise.all([
+      fetchPurchaseOrdersPaged({ page, size }),
+      loadApprovalRequests(),
+    ])
+    const mapped = (Array.isArray(content) ? content : []).map(mapPoResponse)
+    poDocuments.value = mapped.map((row) => attachApprovalInfo(row))
     poPageInfo.value = pageInfo
   } catch (e) {
     console.error('Failed to load PO documents:', e)
+  }
+}
+
+function attachApprovalInfo(row) {
+  const req = pickLatestRequestFor('PO', row.id)
+  if (!req) return row
+  const statusLower = String(req.status ?? '').toLowerCase()
+  return {
+    ...row,
+    approvalRequestId: req.approvalRequestId ?? row.approvalRequestId ?? null,
+    approverId: req.approverId ?? row.approverId ?? null,
+    approverName: req.approverName ?? row.approverName ?? null,
+    approvalRejectReason:
+      statusLower === 'rejected' ? (req.reason ?? row.approvalRejectReason ?? null) : (row.approvalRejectReason ?? null),
   }
 }
 

--- a/src/utils/documentApproval.js
+++ b/src/utils/documentApproval.js
@@ -92,10 +92,26 @@ export function buildApprovalInfoRows(document) {
     return []
   }
 
-  return [
+  const rows = [
     { label: '상태', value: resolveCompositeStatus(document) },
-    { label: '결재자', value: document.approver || '미지정' },
+    // approvalRequests 병합 결과로 붙는 approverName 을 우선. 과거 로컬 뮤테이션으로만
+    // 채워지던 document.approver 는 백업 fallback.
+    { label: '결재자', value: document.approverName || document.approver || '미지정' },
     { label: '요청자', value: document.approvalRequestedBy || '미지정' },
     { label: '요청 시각', value: document.approvalRequestedAt || '-' },
   ]
+
+  // 반려 상태일 때 사유 노출 (I9). 상태 정규화는 resolveCompositeStatus 와 동일 규칙.
+  const statusNorm = String(document.status ?? '').trim().toLowerCase()
+  const approvalNorm = String(document.approvalStatus ?? '').trim().toLowerCase()
+  const isRejected =
+    statusNorm === '반려' ||
+    statusNorm === 'rejected' ||
+    approvalNorm === '반려' ||
+    approvalNorm === 'rejected'
+  if (isRejected && document.approvalRejectReason) {
+    rows.push({ label: '반려 사유', value: document.approvalRejectReason, fullWidth: true })
+  }
+
+  return rows
 }

--- a/src/views/DashboardPage.vue
+++ b/src/views/DashboardPage.vue
@@ -15,6 +15,9 @@ import { useShipmentStatusDocuments, loadShipmentStatusDocuments } from '@/store
 import { fetchActivities } from '@/api/activity'
 import { fetchClients } from '@/api/master'
 import { fetchPackages, deletePackage as deletePackageApi } from '@/api/package'
+import { updateApprovalRequest } from '@/api/documents'
+import { loadApprovalRequests } from '@/stores/approvalRequests'
+import { label as enumLabel, PI_PO_STATUS_LABEL } from '@/utils/enumLabels'
 import { useToast } from '@/composables/useToast'
 import PackageDetailModal from '@/components/domain/activity/PackageDetailModal.vue'
 
@@ -221,9 +224,10 @@ function buildFallbackReview(docType, row) {
     message: '요청 시점의 검토 데이터가 없어 현재 문서 스냅샷 기준으로 표시합니다.',
     requestRows: [
       { label: '요청 유형', value: `${row.approvalAction || '-'} 요청` },
-      { label: '결재자', value: row.approver || '미지정' },
+      { label: '결재자', value: row.approverName || row.approver || '미지정' },
       { label: '요청자', value: row.approvalRequestedBy || '미지정' },
-      { label: '문서 상태', value: row.status || '-' },
+      // 백엔드가 내려주는 raw enum(pending_approval 등)이 그대로 노출되는 UX 결함을 방지.
+      { label: '문서 상태', value: enumLabel(PI_PO_STATUS_LABEL, row.status) || '-' },
       { label: '요청 상태', value: row.requestStatus || '-' },
       { label: '요청 시각', value: row.approvalRequestedAt || '-' },
       ...(row.approvalRejectReason
@@ -266,10 +270,12 @@ function createRequestItem(docType, row) {
     id: `${docType}-${row.id}`,
     docType,
     docId: row.id,
+    // 실제 승인/반려 PUT 에 필요한 approvalRequestId (piDocuments/poDocuments 가 병합해둠)
+    approvalRequestId: row.approvalRequestId ?? null,
     actionLabel: row.approvalAction || row.requestStatus?.replace('요청', '') || '결재',
     company: row.clientName || '-',
     requester: row.approvalRequestedBy || '미지정',
-    approver: row.approver || '미지정',
+    approver: row.approverName || row.approver || '미지정',
     status: row.approvalStatus || '-',
     requestStatus: row.requestStatus || '-',
     requestedAt: row.approvalRequestedAt || '-',
@@ -330,15 +336,6 @@ function closeDecisionConfirm() {
   rejectReason.value = ''
 }
 
-function updateRequestDocument(item, patch) {
-  const targetStore = item.docType === 'PI' ? piDocuments : poDocuments
-  targetStore.value = targetStore.value.map((row) => (
-    row.id === item.docId
-      ? { ...row, ...patch }
-      : row
-  ))
-}
-
 function getReviewedAt() {
   const now = new Date()
   const year = now.getFullYear()
@@ -384,29 +381,40 @@ function openRejectConfirm() {
   decisionConfirmOpen.value = true
 }
 
-function confirmDecision() {
+async function confirmDecision() {
   if (!selectedRequest.value || !pendingDecision.value) return
 
-  if (pendingDecision.value === 'approve') {
-    const nextStatus = selectedRequest.value.actionLabel === '삭제' ? '취소' : '확정'
-    updateRequestDocument(selectedRequest.value, {
-      status: nextStatus,
-      approvalStatus: '승인',
-      approvalReviewedBy: currentUser.value?.name || '',
-      approvalReviewedAt: getReviewedAt(),
-    })
-  } else {
-    updateRequestDocument(selectedRequest.value, {
-      status: '반려',
-      approvalStatus: '반려',
-      approvalReviewedBy: currentUser.value?.name || '',
-      approvalReviewedAt: getReviewedAt(),
-      approvalRejectReason: rejectReason.value.trim() || '',
-    })
+  const item = selectedRequest.value
+  const approvalRequestId = item.approvalRequestId
+  if (!approvalRequestId) {
+    toastError('해당 요청의 결재 요청 ID를 찾을 수 없습니다. 새로고침 후 다시 시도해주세요.')
+    closeDecisionConfirm()
+    closeRequestReview()
+    return
   }
 
-  closeDecisionConfirm()
-  closeRequestReview()
+  try {
+    if (pendingDecision.value === 'approve') {
+      await updateApprovalRequest(approvalRequestId, { status: 'APPROVED' })
+    } else {
+      await updateApprovalRequest(approvalRequestId, {
+        status: 'REJECTED',
+        reason: rejectReason.value.trim() || '',
+      })
+    }
+
+    // 백엔드가 approval_requests + 원본 문서(PI/PO) 상태를 모두 갱신하므로
+    // 양쪽 store 를 모두 다시 fetch 해 UI 에 즉시 반영. approvalRequests 는
+    // PI/PO loader 가 내부에서 다시 호출한다.
+    await Promise.all([loadPiDocuments(), loadPoDocuments(), loadApprovalRequests()])
+
+    success(pendingDecision.value === 'approve' ? '결재가 승인되었습니다.' : '결재가 반려되었습니다.')
+  } catch (e) {
+    toastError(e?.response?.data?.message || '결재 처리 중 오류가 발생했습니다.')
+  } finally {
+    closeDecisionConfirm()
+    closeRequestReview()
+  }
 }
 
 function goToRequestDetail() {

--- a/src/views/documents/PIDetailPage.vue
+++ b/src/views/documents/PIDetailPage.vue
@@ -18,7 +18,9 @@ import {
   requestPiModification,
   deleteProformaInvoiceDraft,
   cancelProformaInvoiceApproval,
+  updateApprovalRequest,
 } from '@/api/documents'
+import { loadApprovalRequests } from '@/stores/approvalRequests'
 import { fetchBuyers, fetchClients, fetchCountries, fetchCurrencies } from '@/api/master'
 import { useToast } from '@/composables/useToast'
 import { useAuthStore } from '@/stores/auth'
@@ -737,6 +739,61 @@ async function handleCancelApproval() {
     error(e.response?.data?.message || '결재 요청 취소 중 오류가 발생했습니다.')
   }
 }
+
+// --- 팀장(결재자)이 본인 대기 건을 상세에서 직접 승인/반려 ----------------------
+// OOS-1 ("결재 요청함" 위젯 부재) 로 인해 팀장은 대시보드에서 자기 팀 결재 진입점이
+// 없음. 상세 페이지에 승인/반려 버튼을 노출해 최소 경로를 보장.
+const approveConfirmOpen = ref(false)
+const rejectConfirmOpen = ref(false)
+const rejectReason = ref('')
+
+const isPendingApprovalStatus = computed(() =>
+  ['결재대기', 'pending_approval', 'APPROVAL_PENDING'].includes(String(sourceRow.value?.status ?? '')),
+)
+const isCurrentUserApprover = computed(() => {
+  const currentId = Number(authStore.currentUser?.userId)
+  const approverId = Number(sourceRow.value?.approverId)
+  return Boolean(currentId && approverId && currentId === approverId)
+})
+const canReviewAsApprover = computed(() =>
+  Boolean(sourceRow.value?.approvalRequestId) && isPendingApprovalStatus.value && isCurrentUserApprover.value,
+)
+
+function openApproveConfirm() {
+  approveConfirmOpen.value = true
+}
+function openRejectConfirm() {
+  rejectReason.value = ''
+  rejectConfirmOpen.value = true
+}
+async function confirmApprove() {
+  if (!sourceRow.value?.approvalRequestId) return
+  try {
+    await updateApprovalRequest(sourceRow.value.approvalRequestId, { status: 'APPROVED' })
+    await Promise.all([loadPiDocuments(), loadApprovalRequests()])
+    success(`${sourceRow.value.id} 결재가 승인되었습니다.`)
+  } catch (e) {
+    error(e?.response?.data?.message || '결재 승인 중 오류가 발생했습니다.')
+  } finally {
+    approveConfirmOpen.value = false
+  }
+}
+async function confirmReject() {
+  if (!sourceRow.value?.approvalRequestId) return
+  try {
+    await updateApprovalRequest(sourceRow.value.approvalRequestId, {
+      status: 'REJECTED',
+      reason: rejectReason.value.trim(),
+    })
+    await Promise.all([loadPiDocuments(), loadApprovalRequests()])
+    success(`${sourceRow.value.id} 결재가 반려되었습니다.`)
+  } catch (e) {
+    error(e?.response?.data?.message || '결재 반려 중 오류가 발생했습니다.')
+  } finally {
+    rejectConfirmOpen.value = false
+    rejectReason.value = ''
+  }
+}
 </script>
 
 <template>
@@ -757,7 +814,28 @@ async function handleCancelApproval() {
             {{ ['확정','confirmed','CONFIRMED'].includes(detail.status) ? '삭제요청' : '삭제' }}
           </BaseButton>
           <BaseButton
-            v-if="['결재대기','pending_approval','APPROVAL_PENDING'].includes(detail.status)"
+            v-if="canReviewAsApprover"
+            size="sm"
+            @click="openApproveConfirm"
+          >
+            <template #leading>
+              <i class="fas fa-check text-xs" aria-hidden="true"></i>
+            </template>
+            승인
+          </BaseButton>
+          <BaseButton
+            v-if="canReviewAsApprover"
+            variant="secondary"
+            size="sm"
+            @click="openRejectConfirm"
+          >
+            <template #leading>
+              <i class="fas fa-times text-xs" aria-hidden="true"></i>
+            </template>
+            반려
+          </BaseButton>
+          <BaseButton
+            v-if="['결재대기','pending_approval','APPROVAL_PENDING'].includes(detail.status) && !canReviewAsApprover"
             variant="secondary"
             size="sm"
             @click="handleCancelApproval"
@@ -1084,6 +1162,37 @@ async function handleCancelApproval() {
       @close="clientSearchOpen = false"
       @select="handleClientSelect"
     />
+
+    <ConfirmModal
+      :open="approveConfirmOpen"
+      title="PI 결재 승인"
+      :message="`해당 PI 결재 요청을 승인하시겠습니까?`"
+      :detail="sourceRow?.id || ''"
+      confirm-label="승인"
+      @confirm="confirmApprove"
+      @cancel="approveConfirmOpen = false"
+    />
+
+    <ConfirmModal
+      :open="rejectConfirmOpen"
+      title="PI 결재 반려"
+      :message="`해당 PI 결재 요청을 반려하시겠습니까? 반려 사유는 요청자에게 노출됩니다.`"
+      :detail="sourceRow?.id || ''"
+      confirm-label="반려"
+      confirm-variant="secondary"
+      @confirm="confirmReject"
+      @cancel="rejectConfirmOpen = false"
+    >
+      <div>
+        <label class="text-sm font-semibold text-slate-700">반려 사유</label>
+        <textarea
+          v-model="rejectReason"
+          rows="3"
+          class="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
+          placeholder="반려 사유를 입력하세요."
+        ></textarea>
+      </div>
+    </ConfirmModal>
   </div>
 
   <div v-else class="flex items-center justify-center py-20 text-slate-400">

--- a/src/views/documents/PIPage.vue
+++ b/src/views/documents/PIPage.vue
@@ -519,6 +519,13 @@ function getDefaultDeleteApprover(row) {
   return row?.approver || ''
 }
 
+// 결재대기 중인 행은 요청자 본인도 임의 수정/삭제 불가(I2 불변식).
+// 상세 페이지는 이미 이 가드를 적용 중이므로 목록도 parity 를 맞춘다.
+const PENDING_APPROVAL_STATUSES = new Set(['결재대기', 'pending_approval', 'APPROVAL_PENDING'])
+function isPendingApproval(row) {
+  return PENDING_APPROVAL_STATUSES.has(row?.status)
+}
+
 function getRequestedAt() {
   const now = new Date()
   const year = now.getFullYear()
@@ -662,7 +669,9 @@ const createApprovalDocumentRows = computed(() => {
   const { nextRow } = buildRowPayload(pendingCreateFormValue.value)
 
   return [
-    { label: '예정 PI 번호', value: buildNextPiId() },
+    // 서버의 채번규칙과 화면 추정값이 다르면 사용자가 "같은 문서"를 추적하기 어려워져
+    // QA 리포트(PI 번호 생성 불일치)로 지적됨. 예측값 대신 안내 문구로 대체.
+    { label: '예정 PI 번호', value: '저장 후 자동 생성' },
     { label: '거래처', value: nextRow.clientName },
     { label: '영문주소', value: nextRow.clientAddress || '-', fullWidth: true },
     { label: '바이어', value: nextRow.buyerName || '-' },
@@ -822,7 +831,8 @@ async function confirmCreateApprovalRequest() {
     const payload = buildCreatePayload(pendingCreateFormValue.value)
     const { piId } = await createProformaInvoice(payload)
     const userId = authStore.currentUser?.userId
-    await requestPiRegistration({ piId, userId })
+    const approverId = pendingCreateFormValue.value.approverId ?? null
+    await requestPiRegistration({ piId, userId, approverId })
     await loadPiDocuments()
 
     createApprovalRequestOpen.value = false
@@ -1168,8 +1178,8 @@ function handleProductSelect(product) {
 
       <template #cell-actions="{ row }">
         <TableActions
-          :show-edit="!shipmentLockInfoByPiId.get(row.id)?.locked && !collectionLockInfoByPiId.get(row.id)?.locked && canMutateDocument(row, authStore.currentUser)"
-          :show-delete="!shipmentLockInfoByPiId.get(row.id)?.locked && !collectionLockInfoByPiId.get(row.id)?.locked && canMutateDocument(row, authStore.currentUser)"
+          :show-edit="!shipmentLockInfoByPiId.get(row.id)?.locked && !collectionLockInfoByPiId.get(row.id)?.locked && canMutateDocument(row, authStore.currentUser) && !isPendingApproval(row)"
+          :show-delete="!shipmentLockInfoByPiId.get(row.id)?.locked && !collectionLockInfoByPiId.get(row.id)?.locked && canMutateDocument(row, authStore.currentUser) && !isPendingApproval(row)"
           @edit="openEditForm(row)"
           @delete="openDeleteApprovalRequest(row)"
         />

--- a/src/views/documents/PODetailPage.vue
+++ b/src/views/documents/PODetailPage.vue
@@ -20,7 +20,9 @@ import {
   deletePurchaseOrderDraft,
   cancelPurchaseOrderApproval,
   generateProductionOrder,
+  updateApprovalRequest,
 } from '@/api/documents'
+import { loadApprovalRequests } from '@/stores/approvalRequests'
 import { useSearchModalLookups } from '@/composables/useSearchModalLookups'
 import { useToast } from '@/composables/useToast'
 import { useAuthStore } from '@/stores/auth'
@@ -863,6 +865,59 @@ async function handleCancelApproval() {
     error(e.response?.data?.message || '결재 요청 취소 중 오류가 발생했습니다.')
   }
 }
+
+// --- 팀장 본인 결재 승인/반려 (R3) -----------------------------------------
+const approveConfirmOpen = ref(false)
+const rejectConfirmOpen = ref(false)
+const rejectReason = ref('')
+
+const isPendingApprovalStatus = computed(() =>
+  ['결재대기', 'pending_approval', 'APPROVAL_PENDING'].includes(String(sourceRow.value?.status ?? '')),
+)
+const isCurrentUserApprover = computed(() => {
+  const currentId = Number(authStore.currentUser?.userId)
+  const approverId = Number(sourceRow.value?.approverId)
+  return Boolean(currentId && approverId && currentId === approverId)
+})
+const canReviewAsApprover = computed(() =>
+  Boolean(sourceRow.value?.approvalRequestId) && isPendingApprovalStatus.value && isCurrentUserApprover.value,
+)
+
+function openApproveConfirm() {
+  approveConfirmOpen.value = true
+}
+function openRejectConfirm() {
+  rejectReason.value = ''
+  rejectConfirmOpen.value = true
+}
+async function confirmApprove() {
+  if (!sourceRow.value?.approvalRequestId) return
+  try {
+    await updateApprovalRequest(sourceRow.value.approvalRequestId, { status: 'APPROVED' })
+    await Promise.all([loadPoDocuments(), loadApprovalRequests()])
+    success(`${sourceRow.value.id} 결재가 승인되었습니다.`)
+  } catch (e) {
+    error(e?.response?.data?.message || '결재 승인 중 오류가 발생했습니다.')
+  } finally {
+    approveConfirmOpen.value = false
+  }
+}
+async function confirmReject() {
+  if (!sourceRow.value?.approvalRequestId) return
+  try {
+    await updateApprovalRequest(sourceRow.value.approvalRequestId, {
+      status: 'REJECTED',
+      reason: rejectReason.value.trim(),
+    })
+    await Promise.all([loadPoDocuments(), loadApprovalRequests()])
+    success(`${sourceRow.value.id} 결재가 반려되었습니다.`)
+  } catch (e) {
+    error(e?.response?.data?.message || '결재 반려 중 오류가 발생했습니다.')
+  } finally {
+    rejectConfirmOpen.value = false
+    rejectReason.value = ''
+  }
+}
 </script>
 
 <template>
@@ -894,7 +949,28 @@ async function handleCancelApproval() {
             {{ ['확정','confirmed','CONFIRMED'].includes(detail.status) ? '삭제요청' : '삭제' }}
           </BaseButton>
           <BaseButton
-            v-if="['결재대기','pending_approval','APPROVAL_PENDING'].includes(detail.status)"
+            v-if="canReviewAsApprover"
+            size="sm"
+            @click="openApproveConfirm"
+          >
+            <template #leading>
+              <i class="fas fa-check text-xs" aria-hidden="true"></i>
+            </template>
+            승인
+          </BaseButton>
+          <BaseButton
+            v-if="canReviewAsApprover"
+            variant="secondary"
+            size="sm"
+            @click="openRejectConfirm"
+          >
+            <template #leading>
+              <i class="fas fa-times text-xs" aria-hidden="true"></i>
+            </template>
+            반려
+          </BaseButton>
+          <BaseButton
+            v-if="['결재대기','pending_approval','APPROVAL_PENDING'].includes(detail.status) && !canReviewAsApprover"
             variant="secondary"
             size="sm"
             @click="handleCancelApproval"
@@ -1245,6 +1321,37 @@ async function handleCancelApproval() {
       @close="clientSearchOpen = false"
       @select="handleClientSelect"
     />
+
+    <ConfirmModal
+      :open="approveConfirmOpen"
+      title="PO 결재 승인"
+      message="해당 PO 결재 요청을 승인하시겠습니까?"
+      :detail="sourceRow?.id || ''"
+      confirm-label="승인"
+      @confirm="confirmApprove"
+      @cancel="approveConfirmOpen = false"
+    />
+
+    <ConfirmModal
+      :open="rejectConfirmOpen"
+      title="PO 결재 반려"
+      message="해당 PO 결재 요청을 반려하시겠습니까? 반려 사유는 요청자에게 노출됩니다."
+      :detail="sourceRow?.id || ''"
+      confirm-label="반려"
+      confirm-variant="secondary"
+      @confirm="confirmReject"
+      @cancel="rejectConfirmOpen = false"
+    >
+      <div>
+        <label class="text-sm font-semibold text-slate-700">반려 사유</label>
+        <textarea
+          v-model="rejectReason"
+          rows="3"
+          class="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
+          placeholder="반려 사유를 입력하세요."
+        ></textarea>
+      </div>
+    </ConfirmModal>
   </div>
 
   <div v-else class="flex items-center justify-center py-20 text-slate-400">

--- a/src/views/documents/POPage.vue
+++ b/src/views/documents/POPage.vue
@@ -545,6 +545,12 @@ function getDefaultDeleteApprover(row) {
   return row?.approver || ''
 }
 
+// 결재대기 중인 행은 요청자 본인도 임의 수정/삭제 불가(I2 불변식).
+const PENDING_APPROVAL_STATUSES = new Set(['결재대기', 'pending_approval', 'APPROVAL_PENDING'])
+function isPendingApproval(row) {
+  return PENDING_APPROVAL_STATUSES.has(row?.status)
+}
+
 function getRequestedAt() {
   const now = new Date()
   const year = now.getFullYear()
@@ -614,7 +620,8 @@ const createApprovalDocumentRows = computed(() => {
   const isDeliveryOverride = Boolean(nextRow.deliveryDateOverride && nextRow.sourceDeliveryDate && nextRow.deliveryDate !== nextRow.sourceDeliveryDate)
 
   return [
-    { label: '예정 PO 번호', value: buildNextPoId() },
+    // 예측 번호와 실제 부여 번호가 달라 QA 리포트로 지적됨. 안내 문구로 대체.
+    { label: '예정 PO 번호', value: '저장 후 자동 생성' },
     { label: '발행일', value: nextRow.issueDate },
     { label: '납기일', value: nextRow.deliveryDate },
     { label: '납기 처리', value: isDeliveryOverride ? 'PI 기준값에서 별도 조정' : 'PI 기준값 사용' },
@@ -832,7 +839,8 @@ async function confirmCreateApprovalRequest() {
     const payload = buildCreatePayload(pendingCreateFormValue.value)
     const { poId } = await createPurchaseOrder(payload)
     const userId = authStore.currentUser?.userId
-    await requestPoRegistration({ poId, userId })
+    const approverId = pendingCreateFormValue.value.approverId ?? null
+    await requestPoRegistration({ poId, userId, approverId })
     await loadPoDocuments()
 
     createApprovalRequestOpen.value = false
@@ -1195,8 +1203,8 @@ function handleProductSelect(product) {
 
       <template #cell-actions="{ row }">
         <TableActions
-          :show-edit="!shipmentLockInfoByPoId.get(row.id)?.locked && !collectionLockInfoByPoId.get(row.id)?.locked && canMutateDocument(row, authStore.currentUser)"
-          :show-delete="!shipmentLockInfoByPoId.get(row.id)?.locked && !collectionLockInfoByPoId.get(row.id)?.locked && canMutateDocument(row, authStore.currentUser)"
+          :show-edit="!shipmentLockInfoByPoId.get(row.id)?.locked && !collectionLockInfoByPoId.get(row.id)?.locked && canMutateDocument(row, authStore.currentUser) && !isPendingApproval(row)"
+          :show-delete="!shipmentLockInfoByPoId.get(row.id)?.locked && !collectionLockInfoByPoId.get(row.id)?.locked && canMutateDocument(row, authStore.currentUser) && !isPendingApproval(row)"
           @edit="openEditForm(row)"
           @delete="openDeleteApprovalRequest(row)"
         />


### PR DESCRIPTION
## 📋 작업 내용

재검증 QA(2026-04-19, PR #417 merge 이후) 에서 발견된 R3 FAIL 을 해결.

팀장(이영업) 이 결재자로 지정된 PI/PO 의 상세 페이지에 "승인"/"반려" 버튼이 없어서
본인이 결재해야 할 문서를 처리할 1차 UI 가 존재하지 않았다. 대시보드에도 팀장 전용
"결재 요청함" 위젯이 없어(OOS-1), 현실적으로 admin 이 "전체 결재 현황" fallback
모달로만 처리 가능했던 구조.

### 변경
- `PIDetailPage.vue` / `PODetailPage.vue` 상단 액션에 "승인" · "반려" 버튼 추가
- 반려 시 사유 입력을 위한 `ConfirmModal` 슬롯 textarea
- 승인: `PUT /api/approval-requests/{id}` body `{status:'APPROVED'}`
- 반려: `{status:'REJECTED', reason}`
- 성공 후 `loadPiDocuments`/`loadPoDocuments` + `loadApprovalRequests` refresh
- 버튼 노출 조건: `sourceRow.approvalRequestId` 존재 + 상태 결재대기 +
  `currentUser.userId === sourceRow.approverId`
- "결재 요청 취소" 버튼은 `canReviewAsApprover` 이 false 일 때만 노출(결재자 본인
  화면에서는 노출 안 함 — 요청자가 본인 이외의 결재자 계정으로 왔을 때만 의미 있음)

### 기반 전제
- 백엔드 team2-backend-auth [`8ac4478`](https://github.com/hanhwa-swcamp-22th-final/team2-backend-auth/commit/8ac4478)
  가 먼저 배포되어야 함. refresh 응답 JWT 의 `teamId` 누락 버그(N1) 가 해결되지 않으면
  SALES 계정은 조회가 통째로 막혀 이 PR 의 UX 개선이 발동할 조건에 도달하지 못함.

## 🔗 관련 이슈
- closes #418

## 📸 스크린샷 (선택)
N/A — E2E 재검증으로 확인

## ✅ 체크리스트
- [x] 정상 동작 확인 — vite build 6.00s 성공
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게
- 기존 "결재 요청 취소" 버튼의 노출 조건을 `!canReviewAsApprover` 로 좁혔습니다. 요청자 본인이
  결재 취소하려는 일반 경로는 여전히 동작하지만, "요청자이자 결재자" (셀프 결재) 인 경우 어느
  쪽을 기본으로 보여줄지는 서비스 정책 차원에서 재확인 필요. 현재 구현은 "승인/반려 우선" 노출.
- 반려 사유 `textarea` 는 빈 입력 허용(trim 후 빈 문자열 가능). 필수로 바꿀지 여부는 별도.