### PR TITLE
fix(#420): /collections 거래처·담당자·매출액·발행일 표시 정리

### DIFF
--- a/src/stores/salesCollectionDocuments.js
+++ b/src/stores/salesCollectionDocuments.js
@@ -20,7 +20,10 @@ function normalizeCollectionStatus(raw) {
 
 function toSlashDate(value) {
   if (!value) return ''
-  return String(value).replace(/-/g, '/')
+  // LocalDateTime 직렬화("2026-04-18T15:15:38") 가 fallback 으로 내려오면 T 이후를 잘라
+  // "2026/04/18" 만 표시. "2026-04-18" 같은 순수 LocalDate 는 그대로 - → / 치환.
+  const dateOnly = String(value).split('T')[0]
+  return dateOnly.replace(/-/g, '/')
 }
 
 function normalizeCollectionRow(row) {
@@ -31,6 +34,12 @@ function normalizeCollectionRow(row) {
     poId: row.poId ? normalizeDocumentCode(row.poId) : (row.poNo ?? ''),
     // 정렬/표시용 필드 — 백엔드가 일부를 null 로 내려주는 경우 페이지 렌더가 localeCompare 에서 죽는다.
     currency: row.currency ?? row.currencyCode ?? row.poCurrencyCode ?? '',
+    // 화면 column 은 salesAmount/manager 키를 참조. 백엔드 CollectionResponse 는
+    // totalAmount/managerName 로 내려주므로 여기서 정렬.
+    salesAmount: row.salesAmount ?? row.totalAmount ?? null,
+    manager: row.manager ?? row.managerName ?? '',
+    country: row.country ?? '',
+    clientName: row.clientName ?? '',
     issueDate: toSlashDate(row.issueDate ?? row.collectionIssueDate ?? row.createdAt ?? ''),
     collectionDate: status === '수금완료' ? row.collectionDate || null : null,
   }


### PR DESCRIPTION
## 📋 작업 내용

매출·수금 현황(/collections) 페이지에서 4건의 표시 결함을 한꺼번에 수정.

### 증상
- 거래처 / 국가 / 영업담당자 컬럼 전부 빈값
- 매출액(외화) 셀 `-`
- 발행일 `2026/04/18T15:15:38` (LocalDateTime 직렬화 문자열)

### 근본 원인 (백엔드 + 프론트 양쪽)
- 백엔드: `CollectionQueryMapper.xml` 이 PO 스냅샷 컬럼(po_client_name, po_country, po_manager_name)을 SELECT 하지 않음. `CollectionResponse` DTO 에 `country`/`managerName`/`issueDate` 필드 자체 부재.
- 프론트: column 키는 `salesAmount`/`manager` 인데 백엔드는 `totalAmount`/`managerName` 로 내려옴. normalizer 매핑 누락. `collection_issue_date` 가 NULL 인 레거시 레코드가 `createdAt`(LocalDateTime)까지 fallback 되면 `toSlashDate` 가 `-` → `/` 만 치환해 T 이후 시간이 그대로 남음.

### 수정
- Backend (team2-backend-documents `3c49cce`, 이미 main 푸시됨)
  - mapper resultMap/columns 에 po 스냅샷 3컬럼 추가 + `COALESCE(c.collection_issue_date, po.po_issue_date)` 로 issueDate 항상 LocalDate 보장
  - CollectionView + CollectionResponse 에 country/managerName/issueDate 필드 추가
- Frontend (이 PR)
  - normalizer 에서 `totalAmount → salesAmount`, `managerName → manager`, country/clientName 빈 문자열 coalesce
  - `toSlashDate`: 입력을 `T` 기준 앞부분만 남겨 LocalDateTime 잔재 방어

## 🔗 관련 이슈
- closes #420

## 📸 스크린샷 (선택)
N/A — 로컬 빌드 통과

## ✅ 체크리스트
- [x] 정상 동작 확인 — vite build 7.43s 성공, backend gradle build 성공
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게
- `toSlashDate` 의 T-split 은 LocalDate/LocalDateTime 혼합 입력 모두에 안전 — `2026-04-18` → split 해도 `[0]` 이 원본 유지. `2026-04-18T15:15:38` → `2026-04-18`. 부작용 없음.
- 백엔드 배포가 먼저 필요합니다. 백엔드 롤아웃 전에는 `country`/`managerName`/`issueDate` 가 여전히 응답에 없어 프론트 normalizer 의 `?? ''` fallback 이 동작하지만, 본질 수정은 백엔드 쪽.