### PR TITLE
fix(#422): /collections 수금상태 변경을 실 API 호출로 교체

### DIFF
--- a/src/stores/salesCollectionDocuments.js
+++ b/src/stores/salesCollectionDocuments.js
@@ -49,7 +49,7 @@ const salesCollectionDocuments = ref([])
 const salesCollectionPageInfo = ref({ size: 1000, number: 0, totalElements: 0, totalPages: 0 })
 let loading = null
 
-async function loadSalesCollectionDocuments({ page = 0, size = 1000 } = {}) {
+export async function loadSalesCollectionDocuments({ page = 0, size = 1000 } = {}) {
   try {
     const { content, page: pageInfo } = await fetchCollectionsPaged({ page, size })
     salesCollectionDocuments.value = (Array.isArray(content) ? content : []).map(normalizeCollectionRow)

--- a/src/views/documents/CollectionsPage.vue
+++ b/src/views/documents/CollectionsPage.vue
@@ -16,7 +16,8 @@ import { useDocumentFilter } from '@/composables/useDocumentFilter'
 import { usePagination } from '@/composables/usePagination'
 import { useSearchModalLookups } from '@/composables/useSearchModalLookups'
 import { useToast } from '@/composables/useToast'
-import { useSalesCollectionDocuments, normalizeSalesCollectionRow } from '@/stores/salesCollectionDocuments'
+import { updateCollection } from '@/api/documents'
+import { useSalesCollectionDocuments, loadSalesCollectionDocuments, normalizeSalesCollectionRow } from '@/stores/salesCollectionDocuments'
 import { openTableOutput } from '@/utils/documentOutput'
 import { convertCurrencyAmountToKrw } from '@/utils/exchangeRate'
 import { clientSearchColumns } from '@/utils/searchModalColumns'
@@ -30,7 +31,7 @@ const poSearchKeyword = ref('')
 const viewScope = ref('all')
 const currencyFilter = ref('')
 const appliedCurrencyFilter = ref('')
-const { warning } = useToast()
+const { warning, success, error: toastError } = useToast()
 const statusConfirmOpen = ref(false)
 const pendingStatusChange = ref(null)
 
@@ -265,6 +266,8 @@ function openStatusConfirm(row, nextStatusValue) {
   const nextCollectionDate = resolveNextCollectionDate(row, nextStatusValue)
 
   pendingStatusChange.value = {
+    // 실제 백엔드 호출은 collectionId 기준. poId 는 표시용으로만 유지.
+    collectionId: row.collectionId,
     poId: row.poId,
     clientName: row.clientName,
     currentStatus: row.status,
@@ -278,24 +281,40 @@ function openStatusConfirm(row, nextStatusValue) {
   statusConfirmOpen.value = true
 }
 
-function updateStatus(poId, value) {
-  rowsData.value = rowsData.value.map((row) => (
-    row.poId === poId
-      ? normalizeSalesCollectionRow({
-        ...row,
-        status: value === 'PAID' ? '수금완료' : '미수금',
-        collectionDate: resolveNextCollectionDate(row, value),
-      })
-      : row
-  ))
+// resolveNextCollectionDate 는 "YYYY/MM/DD" 를 반환. 백엔드는 LocalDate("YYYY-MM-DD").
+function toIsoDate(slashDate) {
+  if (!slashDate) return null
+  return String(slashDate).replace(/\//g, '-')
 }
 
-function confirmStatusChange() {
+async function confirmStatusChange() {
   if (!pendingStatusChange.value) return
 
-  updateStatus(pendingStatusChange.value.poId, pendingStatusChange.value.nextStatusValue)
-  statusConfirmOpen.value = false
-  pendingStatusChange.value = null
+  const pending = pendingStatusChange.value
+  // 백엔드 complete(id, status, date): 1차 re-verification 에서 로컬 뮤테이션만
+  // 하던 회귀(NEW-2)를 해소. 성공 후 store refresh 로 서버 진실값으로 통일.
+  if (!pending.collectionId) {
+    toastError('수금 ID 를 찾을 수 없습니다. 새로고침 후 다시 시도해주세요.')
+    statusConfirmOpen.value = false
+    pendingStatusChange.value = null
+    return
+  }
+
+  try {
+    await updateCollection(pending.collectionId, {
+      status: pending.nextStatus, // "수금완료" / "미수금"
+      collectionCompletedDate: pending.nextStatusValue === 'PAID'
+        ? toIsoDate(pending.nextCollectionDate)
+        : null,
+    })
+    await loadSalesCollectionDocuments()
+    success(`${pending.poId} 수금 상태가 ${pending.nextStatus} 로 반영되었습니다.`)
+  } catch (e) {
+    toastError(e?.response?.data?.message || '수금 상태 변경 중 오류가 발생했습니다.')
+  } finally {
+    statusConfirmOpen.value = false
+    pendingStatusChange.value = null
+  }
 }
 
 function cancelStatusChange() {


### PR DESCRIPTION
## 📋 작업 내용

3차 E2E 재검증(NEW-2) 에서 드러난 회귀. 1차의 대시보드 승인/반려 블로커와 동형 패턴이 /collections 수금상태 변경 경로에서 재발했던 문제.

### 수정 전
- `confirmStatusChange` 가 `updateStatus(poId, value)` 로 로컬 store row 만 교체
- 백엔드 `PUT /api/collections/{id}` 미호출 → F5 시 원상 복귀

### 수정 후
- `updateCollection(id, {status, collectionCompletedDate})` 실 호출
- 성공 후 `loadSalesCollectionDocuments()` 로 서버 진실값 refresh
- `pendingStatusChange` 에 `collectionId` 동승
- `resolveNextCollectionDate` 는 "YYYY/MM/DD" 반환 → `toIsoDate` 로 LocalDate 변환 후 백엔드 전달

### Step 플랜 위치
3차 재검증 리포트에서 신규로 드러난 이슈 3건(NEW-1 blocker · NEW-2 major · NEW-3 major) 중 **Step 1**. 가장 단순하고 격리 가능해서 먼저 처리.
- Step 2: NEW-1 (Shipment 자동 생성 필드 누락) — 별도 PR
- Step 3: NEW-3 (PI→PO 단가 환율 곱셈 오염) — 별도 PR

N4(특기사항 매핑 누락) 는 원래 Step 1 묶음 후보였으나, PI/PO 엔티티·DB 컬럼 자체가 없어 스키마 추가가 필요 — 범위 커져 별도 후속 PR 로 분리.

## 🔗 관련 이슈
- closes #422

## ✅ 체크리스트
- [x] 정상 동작 확인 — vite build 6.04s 성공
- [x] 불필요한 코드/주석 제거 (`updateStatus` 헬퍼 삭제)
- [x] 충돌(conflict) 해결 완료 (이전 #421 머지 이후 main 동기화 완료)

## 💬 리뷰어에게
- 백엔드 `CollectionCommandService.complete` 가 targetStatus "수금완료" 한글 literal 로 가드. 프론트에서 정확히 "수금완료" 전송. 영문 enum 으로 통일하고 싶으면 별도 리팩토링.
- 미수금 → 수금완료만 현재 지원. UI 에서 수금완료→미수금 되돌리기는 이미 `openStatusConfirm` 에서 warning 으로 차단됨.