### PR TITLE
fix(#425)(#426)(#427): 3차 QA 잔여 3건 정리 (remarks/MO items/PI 역참조)

### DIFF
--- a/src/stores/productionOrderDocuments.js
+++ b/src/stores/productionOrderDocuments.js
@@ -14,8 +14,20 @@ function parseLinkedDocuments(value) {
   return Array.isArray(value) ? value : []
 }
 
+function parseItemsSnapshot(value) {
+  if (!value) return []
+  if (typeof value === 'string') {
+    try { return JSON.parse(value) } catch { return [] }
+  }
+  return Array.isArray(value) ? value : []
+}
+
 function mapProductionOrderResponse(row) {
-  const items = (row.items ?? []).map((item) => {
+  // NEW-6: 백엔드가 itemsSnapshot(JSON) 을 내려주면 그걸 우선 사용해 품목/수량 전이.
+  // 빈/미발행 레거시는 row.items (String 배열) 로 fallback.
+  const snapshotItems = parseItemsSnapshot(row.itemsSnapshot)
+  const sourceItems = snapshotItems.length > 0 ? snapshotItems : (row.items ?? [])
+  const items = sourceItems.map((item) => {
     if (typeof item === 'string') {
       return { code: '', name: item, quantity: '1', unit: 'EA', remark: '' }
     }
@@ -24,6 +36,8 @@ function mapProductionOrderResponse(row) {
       name: item.itemName ?? item.name ?? '-',
       quantity: String(item.quantity ?? 1),
       unit: item.unit ?? 'EA',
+      unitPrice: String(item.unitPrice ?? 0),
+      amount: String(item.amount ?? 0),
       remark: item.remark ?? '',
     }
   })

--- a/src/views/documents/PIDetailPage.vue
+++ b/src/views/documents/PIDetailPage.vue
@@ -28,6 +28,8 @@ import { loadPiDocuments, usePiDocuments } from '@/stores/piDocuments'
 import { usePoDocuments } from '@/stores/poDocuments'
 import { useShipmentOrderDocuments } from '@/stores/shipmentOrderDocuments'
 import { useShipmentStatusDocuments } from '@/stores/shipmentStatusDocuments'
+import { useCiDocuments } from '@/stores/ciDocuments'
+import { usePlDocuments } from '@/stores/plDocuments'
 import {
   buildApprovalInfoRows,
   buildApprovalRequestRows,
@@ -68,6 +70,8 @@ const piDocuments = usePiDocuments()
 const poDocuments = usePoDocuments()
 const shipmentOrderDocuments = useShipmentOrderDocuments()
 const shipmentStatusDocuments = useShipmentStatusDocuments()
+const ciDocuments = useCiDocuments()
+const plDocuments = usePlDocuments()
 
 const isTeamLeader = computed(() => Number(authStore.currentUser?.positionId) === 1)
 
@@ -180,9 +184,30 @@ function formatSlashDate(value) {
 }
 
 function buildLinkedDocuments(documentId) {
-  return poDocuments.value
+  // NEW-7: 직계 PO 뿐 아니라 그 PO 로부터 파생된 CI/PL/SO/출하현황까지 전이 표시.
+  const linkedPos = poDocuments.value
     .filter((row) => (row.piId || row.linkedPiId) === documentId)
-    .map((row) => ({ id: row.id, status: row.status }))
+  const linkedPoIds = linkedPos.map((row) => row.id)
+
+  const childDocs = [
+    ...ciDocuments.value
+      .filter((row) => linkedPoIds.includes(row.poId))
+      .map((row) => ({ id: row.id, status: row.status, type: 'CI' })),
+    ...plDocuments.value
+      .filter((row) => linkedPoIds.includes(row.poId))
+      .map((row) => ({ id: row.id, status: row.status, type: 'PL' })),
+    ...shipmentOrderDocuments.value
+      .filter((row) => linkedPoIds.includes(row.poId))
+      .map((row) => ({ id: row.id, status: row.status, type: 'SO' })),
+    ...shipmentStatusDocuments.value
+      .filter((row) => linkedPoIds.includes(row.poId))
+      .map((row) => ({ id: row.id, status: row.status, type: '출하현황' })),
+  ]
+
+  return [
+    ...linkedPos.map((row) => ({ id: row.id, status: row.status, type: 'PO' })),
+    ...childDocs,
+  ]
 }
 
 function getCurrentRequesterName() {
@@ -669,8 +694,19 @@ function handleClientSelect(client) {
 }
 
 function goToLinkedDocument(documentId) {
-  if (!documentId?.startsWith('PO')) return
-  router.push({ name: 'po-detail', params: { id: documentId } })
+  // NEW-7 지원: 문서 prefix 기반으로 적절한 상세 라우트로 분기.
+  // PI260015/PO260004/CI260005/PL260005/SO260005/SH... 등.
+  if (!documentId) return
+  const prefix = documentId.substring(0, 2).toUpperCase()
+  const routeName = ({
+    PO: 'po-detail',
+    CI: 'ci-detail',
+    PL: 'pl-detail',
+    SO: 'shipment-order-detail',
+    SH: 'shipment-detail',
+  })[prefix]
+  if (!routeName) return
+  router.push({ name: routeName, params: { id: documentId } })
 }
 
 function confirmEditRequestIntent() {

--- a/src/views/documents/PIPage.vue
+++ b/src/views/documents/PIPage.vue
@@ -610,6 +610,8 @@ function buildCreatePayload(formValue) {
     exchangeRate: currencyCode === 'KRW' || !krwRate ? null : Number((1 / krwRate).toFixed(8)),
     managerName: authStore.currentUser?.userName || authStore.currentUser?.name || '',
     userId: authStore.currentUser?.userId ?? null,
+    // 특기사항 (N4): 폼의 reason 필드를 백엔드 remarks 컬럼으로 매핑.
+    remarks: formValue.reason ?? '',
     items,
   }
 }

--- a/src/views/documents/POPage.vue
+++ b/src/views/documents/POPage.vue
@@ -532,6 +532,8 @@ function buildCreatePayload(formValue) {
     currencyCode,
     managerName: authStore.currentUser?.userName || authStore.currentUser?.name || '',
     userId: authStore.currentUser?.userId ?? null,
+    // 특기사항 (N4): POFormModal 은 폼에 reason 필드가 없어도 미래 대비 pass-through.
+    remarks: formValue.reason ?? '',
     items,
   }
 }


### PR DESCRIPTION
## 📋 작업 내용

3차 E2E 재검증 리포트에서 드러난 blocker 이외 중·소규모 3건을 한 PR 로 정리.

### N4 (#425) PI/PO 특기사항 end-to-end
- PIPage/POPage `buildCreatePayload` 에 `remarks: formValue.reason ?? ''` 추가.
- piDocuments/poDocuments mapper 는 이미 `row.remarks` 를 읽고 있어 저장→표시 파이프 완성.
- 백엔드 사전 요건: team2-backend-documents [`e29fab9`](https://github.com/hanhwa-swcamp-22th-final/team2-backend-documents/commit/e29fab9) 에서 PI/PO 엔티티·DTO·mapper 전 레이어 보강 및 `pi_remarks`/`po_remarks` 컬럼 ddl-auto 반영.

### NEW-6 (#426) ProductionOrder 품목 스냅샷
- productionOrderDocuments.js 에 `parseItemsSnapshot` 추가. 백엔드가 `itemsSnapshot`(JSON) 을 내려주면 우선 파싱해 items 배열로 사용. unitPrice/amount 도 전이.
- 레거시 레코드(itemsSnapshot 없음) 는 기존 `row.items` fallback 유지.
- 백엔드 사전 요건: team2-backend-documents [`252a9c2`](https://github.com/hanhwa-swcamp-22th-final/team2-backend-documents/commit/252a9c2) 에서 ProductionOrder.items_snapshot 컬럼 추가 + MO 발행 시 PO.items JSON 직렬화.

### NEW-7 (#427) PI 상세 참조문서 역전이
- PIDetailPage `buildLinkedDocuments` 를 linkedPoIds 기반으로 확장. ciDocuments/plDocuments/shipmentOrderDocuments/shipmentStatusDocuments store 에서 해당 POId 를 참조하는 문서를 일괄 수집.
- `goToLinkedDocument`: 문서 prefix(PO/CI/PL/SO/SH) 기반 라우트 분기.
- 역참조 대상: PO 직계 + CI + PL + SO + 출하현황.

### NEW-4 (의도된 동작, 수정 없음)
- QA 관측된 "기연결 PI 재등장" 은 `documentShipmentLock.getPiPoSelectionInfo` 주석에 명시된 "PI→PO 1:N 허용(분할 주문/수정 발주)" 로 의도된 동작. 관측 오해. 이슈 미발행.

## 🔗 관련 이슈
- closes #425
- closes #426
- closes #427

## ✅ 체크리스트
- [x] 정상 동작 확인 — vite build 7.74s 성공, backend gradle build 성공
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료 (main sync 후 분기)

## 💬 리뷰어에게
- NEW-6 의 itemsSnapshot 파싱은 빈 문자열/null/JSON array 모든 케이스 방어 적용. 레거시 MO(itemsSnapshot NULL) 는 여전히 production_item_name 한 줄만 표시되므로 운영 1회 backfill 스크립트가 있으면 완전 회복.
- NEW-7 의 역참조는 store 가 전부 로드된 상태여야 정확. `useCiDocuments/usePlDocuments` 등이 이미 PIDetailPage 초기화 시점에 로드되는지 혹은 onMounted 에서 load 해야 하는지 경계에서 미세 race 가능. 필요시 loader 추가 PR.
- 3차 QA 리포트 중 NEW-3(환율 곱셈) 은 별도 spike #424 로 진행 중.