### PR TITLE
fix(#429)(#430): 출하완료 blocker 2건 + PI 참조문서 CI/PL · Shipment 링크 복구

### DIFF
--- a/src/utils/documentShipmentLock.js
+++ b/src/utils/documentShipmentLock.js
@@ -135,12 +135,16 @@ export function formatPiCollectionLockMessage(lockInfo) {
 /**
  * 생산지시서(MO) 발행된 PO 는 MO 가 '생산완료' 되기 전까지 출하완료 처리 불가.
  * MO 자체가 없으면 출하만으로 진행 (영업담당자가 재고 보유 가정).
+ *
+ * 상태 비교는 백엔드 영문 enum('completed') 과 프론트 라벨('생산완료') 양쪽 허용.
+ * 3차→4차 QA 에서 백엔드 raw 값이 store 로 들어오면서 A-8 blocker 발생한 케이스.
  */
+const MO_COMPLETED_STATES = new Set(['생산완료', 'completed', 'COMPLETED'])
 export function getPoProductionGate(poId, productionOrderDocuments = []) {
   if (!poId) return { blocked: false, pendingIds: [] }
   const mos = productionOrderDocuments.filter((row) => row.poId === poId)
   if (mos.length === 0) return { blocked: false, pendingIds: [] }
-  const pending = mos.filter((row) => row.status !== '생산완료')
+  const pending = mos.filter((row) => !MO_COMPLETED_STATES.has(String(row.status ?? '').trim()))
   return { blocked: pending.length > 0, pendingIds: pending.map((r) => r.id) }
 }
 

--- a/src/views/documents/PIDetailPage.vue
+++ b/src/views/documents/PIDetailPage.vue
@@ -184,23 +184,38 @@ function formatSlashDate(value) {
 }
 
 function buildLinkedDocuments(documentId) {
-  // NEW-7: 직계 PO 뿐 아니라 그 PO 로부터 파생된 CI/PL/SO/출하현황까지 전이 표시.
+  // NEW-7: PI 역참조는 PO.linkedDocuments JSON 을 중간 매개로 사용. 이유:
+  // 백엔드 CI/PL 응답의 poId 가 Long PK 로 내려오는데 poDocuments 의 id 는 PO code 문자열.
+  // 그래서 `ciDocuments.filter(r => linkedPoIds.includes(r.poId))` 는 매칭 실패.
+  // PO.linkedDocuments 는 자동 생성된 CI/PL/SO code 를 문자열로 담고 있으니 그걸로 매칭.
   const linkedPos = poDocuments.value
     .filter((row) => (row.piId || row.linkedPiId) === documentId)
-  const linkedPoIds = linkedPos.map((row) => row.id)
+
+  const childCodesByType = { CI: new Set(), PL: new Set(), SO: new Set() }
+  for (const po of linkedPos) {
+    const list = Array.isArray(po.linkedDocuments) ? po.linkedDocuments : []
+    for (const doc of list) {
+      if (!doc?.id || !doc?.type) continue
+      if (childCodesByType[doc.type]) {
+        childCodesByType[doc.type].add(doc.id)
+      }
+    }
+  }
 
   const childDocs = [
     ...ciDocuments.value
-      .filter((row) => linkedPoIds.includes(row.poId))
+      .filter((row) => childCodesByType.CI.has(row.id))
       .map((row) => ({ id: row.id, status: row.status, type: 'CI' })),
     ...plDocuments.value
-      .filter((row) => linkedPoIds.includes(row.poId))
+      .filter((row) => childCodesByType.PL.has(row.id))
       .map((row) => ({ id: row.id, status: row.status, type: 'PL' })),
     ...shipmentOrderDocuments.value
-      .filter((row) => linkedPoIds.includes(row.poId))
+      .filter((row) => childCodesByType.SO.has(row.id))
       .map((row) => ({ id: row.id, status: row.status, type: 'SO' })),
+    // 출하현황(Shipment) 은 PO.linkedDocuments 에 들어가지 않아 poId 로 역매칭.
+    // poDocuments.id 가 PO code 이고 shipmentStatusDocuments.poId 도 PO code 라 OK.
     ...shipmentStatusDocuments.value
-      .filter((row) => linkedPoIds.includes(row.poId))
+      .filter((row) => linkedPos.some((po) => po.id === row.poId))
       .map((row) => ({ id: row.id, status: row.status, type: '출하현황' })),
   ]
 
@@ -693,20 +708,29 @@ function handleClientSelect(client) {
   clientSearchKeyword.value = ''
 }
 
-function goToLinkedDocument(documentId) {
-  // NEW-7 지원: 문서 prefix 기반으로 적절한 상세 라우트로 분기.
-  // PI260015/PO260004/CI260005/PL260005/SO260005/SH... 등.
+function goToLinkedDocument(documentId, docType) {
+  // NEW-7 지원: type 을 1순위로, prefix 를 fallback 으로 라우트 분기.
+  // Shipment 는 ID 가 숫자("8") 라 prefix 매칭 실패해서 type 직접 전달 필수.
   if (!documentId) return
-  const prefix = documentId.substring(0, 2).toUpperCase()
-  const routeName = ({
+  const routeByType = {
+    PO: 'po-detail',
+    CI: 'ci-detail',
+    PL: 'pl-detail',
+    SO: 'shipment-order-detail',
+    출하현황: 'shipment-detail',
+  }
+  const routeByPrefix = {
     PO: 'po-detail',
     CI: 'ci-detail',
     PL: 'pl-detail',
     SO: 'shipment-order-detail',
     SH: 'shipment-detail',
-  })[prefix]
+  }
+  const routeName =
+    routeByType[docType] ||
+    routeByPrefix[String(documentId).substring(0, 2).toUpperCase()]
   if (!routeName) return
-  router.push({ name: routeName, params: { id: documentId } })
+  router.push({ name: routeName, params: { id: String(documentId) } })
 }
 
 function confirmEditRequestIntent() {
@@ -1056,7 +1080,7 @@ async function confirmReject() {
                 :key="document.id"
                 type="button"
                 class="flex items-center gap-2 rounded-lg p-2.5 text-brand-500 transition hover:bg-slate-50"
-                @click="goToLinkedDocument(document.id)"
+                @click="goToLinkedDocument(document.id, document.type)"
               >
                 <i class="fas fa-file-contract" aria-hidden="true"></i>
                 {{ document.id }}

--- a/src/views/documents/ShipmentsDetailPage.vue
+++ b/src/views/documents/ShipmentsDetailPage.vue
@@ -107,13 +107,15 @@ async function completeShipment() {
     return
   }
   try {
-    // 백엔드 PUT /api/shipments/{id} (controller @PreAuthorize ADMIN/SHIPPING)
-    await updateShipment(detail.value.id, { status: 'completed' })
+    // 백엔드 PUT /api/shipments/{id} (controller @PreAuthorize ADMIN/SHIPPING).
+    // Jackson 이 JSON 문자열 → ShipmentStatus enum 을 name() 기준으로 역직렬화하므로
+    // 'completed' 소문자로 보내면 400 → UI hang 처럼 관측되던 B-6 blocker. enum name 사용.
+    await updateShipment(detail.value.id, { status: 'COMPLETED' })
   } catch (e) {
     if (e.response?.status === 403) {
       toast.error('출하완료 처리 권한이 없습니다.')
     } else {
-      toast.error('출하완료 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.')
+      toast.error(e?.response?.data?.message || '출하완료 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.')
     }
     return
   }


### PR DESCRIPTION
## 📋 작업 내용

4차 E2E 재검증 리포트의 Critical blocker 2건(A-8/B-6) + RA5 PI 역참조 보완을 한 PR 로 정리.

### #429 출하완료 blocker
- **A-8 (Shipment MO 상태 비교)**: `getPoProductionGate` 가 MO status 를 한글 "생산완료" 만 체크했는데 백엔드는 영문 "completed" 반환 → 영구 disabled. `MO_COMPLETED_STATES` Set 으로 한영 양쪽 허용.
- **B-6 (/shipments/{id} 클릭 hang)**: PUT body 가 `{ status: 'completed' }` 소문자였는데 백엔드 `ShipmentStatus` enum name 은 `COMPLETED`. Jackson 이 case-sensitive 역직렬화해서 400 응답 → UI hang 으로 관측. enum name 으로 수정 + 에러 메시지에 서버 응답 표시.

### #430 PI 참조문서 + Shipment 링크
- **CI/PL 미노출**: 백엔드 CI/PL Response 의 `poId` 는 Long PK 인데 프론트 `poDocuments.id` 는 PO code 문자열. 매칭 실패였음. `PO.linkedDocuments` JSON (자동 생성 CI/PL/SO code 배열) 을 중간 매개로 교차 매칭하도록 재작성.
- **Shipment 링크 onClick 미작동**: `goToLinkedDocument` 가 id prefix 기반인데 Shipment id 는 숫자 "8". `(id, type)` 로 시그니처 확장해 type 1순위 라우팅. `"출하현황"` type → `shipment-detail`.

### 미포함 (다음 단계)
- RA3 (PI remarks 응답 누락): 백엔드 e29fab9 는 이미 main 에 있음. 배포 지연 가능성. 재배포 후 재검증 필요.
- RA4 (MO itemsSnapshot 응답 누락): 동일하게 252a9c2 main 반영. 배포 확인 필요.
- NEW-3 단가 환율 곱셈: spike #424 별도 트랙.
- 사용자 신규 요구(바이어 CRUD/PO 등록 분기/품목 정책/UI minor): Step B~E 후속 PR 예정.

## 🔗 관련 이슈
- closes #429
- closes #430

## ✅ 체크리스트
- [x] 정상 동작 확인 — vite build 6.08s 성공
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료