### PR TITLE
fix(#432): 바이어 직책 수기입력 + 저장 실패 시 서버 메시지 노출

### DIFF
--- a/src/views/master/ClientDetailPage.vue
+++ b/src/views/master/ClientDetailPage.vue
@@ -4,7 +4,6 @@ import { useRoute, useRouter } from 'vue-router'
 import BaseButton from '@/components/common/BaseButton.vue'
 import BaseCard from '@/components/common/BaseCard.vue'
 import BaseModal from '@/components/common/BaseModal.vue'
-import BaseSelect from '@/components/common/BaseSelect.vue'
 import BaseTextField from '@/components/common/BaseTextField.vue'
 import ConfirmModal from '@/components/common/ConfirmModal.vue'
 import DetailPageHeader from '@/components/common/DetailPageHeader.vue'
@@ -54,11 +53,6 @@ const buyerErrors = ref({})
 const buyerSaving = ref(false)
 const showBuyerDeleteModal = ref(false)
 const buyerToDelete = ref(null)
-
-const positionOptions = [
-  { label: '팀장', value: '팀장' },
-  { label: '팀원', value: '팀원' },
-]
 
 function resolvePortLabel(portName, portId) {
   const candidate = portName || getPortName(portId)
@@ -260,8 +254,10 @@ async function handleBuyerSave() {
     }
     showBuyerModal.value = false
     await reloadBuyers()
-  } catch {
-    error('바이어 저장 중 오류가 발생했습니다.')
+  } catch (e) {
+    // 서버 응답(권한 403, validation 400 등) 를 사용자에게 노출해 디버깅 가능하게.
+    const serverMsg = e?.response?.data?.message || e?.response?.data?.error
+    error(serverMsg || '바이어 저장 중 오류가 발생했습니다.')
   } finally {
     buyerSaving.value = false
   }
@@ -399,7 +395,8 @@ function goBack() {
           <BaseTextField v-model="buyerForm.name" placeholder="바이어 이름" />
         </FormField>
         <FormField label="직책">
-          <BaseSelect v-model="buyerForm.position" :options="positionOptions" placeholder="직책 선택" />
+          <!-- 조직마다 직책 체계가 달라 드롭다운(팀장/팀원) 으로 제한하지 않고 수기 입력. -->
+          <BaseTextField v-model="buyerForm.position" placeholder="직책 (예: 구매팀장, Procurement Manager)" />
         </FormField>
         <FormField label="이메일" required :error="buyerErrors.email">
           <BaseTextField v-model="buyerForm.email" type="email" placeholder="buyer@example.com" />


### PR DESCRIPTION
## 📋 작업 내용

4차 QA 사용자 리포트의 "바이어 추가 등록이 오류나네 / 직책이 드롭다운인데 수기 입력 가능하게" 정리.

### Backend 동반 변경 (main 푸시 완료)
- team2-backend-master [`e8b6cd3`](https://github.com/hanhwa-swcamp-22th-final/team2-backend-master/commit/e8b6cd3)
- `BuyerCommandController` 를 `hasRole('ADMIN')` → `hasAnyRole('ADMIN','SALES')`. sales 계정의 바이어 CRUD 허용.

### Frontend (이 PR)
- 직책 필드 BaseSelect + positionOptions 배열 제거. BaseTextField 로 교체 — Procurement Manager, 구매팀장 등 자유 표기.
- `handleBuyerSave` catch 가 `e.response.data.message/error` 를 토스트에 노출. 향후 400/403/서버 오류 직접 관찰 가능.

## 🔗 관련 이슈
- closes #432

## ✅ 체크리스트
- [x] 정상 동작 확인 — vite build 성공, master gradle build 성공
- [x] 불필요한 코드/주석 제거 (BaseSelect import · positionOptions 배열)
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게
- Step B 완료. 다음 Step C(PO 등록 시 생산/직출하 분기 + 출하 담당자) 로 진행 예정.