### PR TITLE
feat(#434): PO 등록 시 생산/직출하 분기 + 생산·출하 담당자 지정

### DIFF
--- a/src/components/domain/document/POFormModal.vue
+++ b/src/components/domain/document/POFormModal.vue
@@ -4,7 +4,7 @@ import { computed, ref, watch } from 'vue'
 import BaseButton from '@/components/common/BaseButton.vue'
 import BaseModal from '@/components/common/BaseModal.vue'
 import BaseSelect from '@/components/common/BaseSelect.vue'
-import { fetchApprovers } from '@/api/documents'
+import { fetchApprovers, fetchAssignableUsers } from '@/api/documents'
 import { useAuthStore } from '@/stores/auth'
 
 const props = defineProps({
@@ -38,6 +38,10 @@ function createInitialForm() {
     sourceDeliveryDate: '',
     deliveryDateOverride: false,
     approver: '',
+    // Step C — 후속 흐름 분기. 기본값 DIRECT(직출하).
+    productionRoute: 'DIRECT',
+    productionAssigneeId: null,
+    shippingAssigneeId: null,
   }
 }
 
@@ -46,6 +50,10 @@ const errors = ref({})
 const approverOptions = ref([...defaultApproverOptions])
 // fetchApprovers 원본 (userId/userName/userRole). name → userId 해소용.
 const approverDirectory = ref([])
+// Step C — 생산/출하 담당자 후보 (fetchAssignableUsers 응답: {userId, userName, ...})
+const productionAssignees = ref([])
+const shippingAssignees = ref([])
+const assigneesLoaded = ref(false)
 const isLinkedToPi = computed(() => Boolean(form.value.linkedPiId))
 const isDeliveryDateLocked = computed(() => isLinkedToPi.value && !form.value.deliveryDateOverride)
 
@@ -78,12 +86,33 @@ function resolveApproverId(name) {
   return match?.userId ?? null
 }
 
+async function loadAssigneeOptions() {
+  if (assigneesLoaded.value) return
+  try {
+    const [prod, ship] = await Promise.all([
+      fetchAssignableUsers('production').catch(() => []),
+      fetchAssignableUsers('shipping').catch(() => []),
+    ])
+    productionAssignees.value = Array.isArray(prod) ? prod : []
+    shippingAssignees.value = Array.isArray(ship) ? ship : []
+  } finally {
+    assigneesLoaded.value = true
+  }
+}
+
+const productionAssigneeOptions = computed(() =>
+  productionAssignees.value.map((u) => ({ label: u.userName, value: u.userId })),
+)
+const shippingAssigneeOptions = computed(() =>
+  shippingAssignees.value.map((u) => ({ label: u.userName, value: u.userId })),
+)
+
 watch(
   () => props.open,
   async (isOpen) => {
     if (!isOpen) return
 
-    await loadApproverOptions()
+    await Promise.all([loadApproverOptions(), loadAssigneeOptions()])
 
     if (props.mode === 'edit' && props.document) {
       form.value = {
@@ -95,6 +124,9 @@ watch(
         sourceDeliveryDate: props.document.sourceDeliveryDate?.replaceAll('/', '-') ?? props.document.deliveryDate?.replaceAll('/', '-') ?? '',
         deliveryDateOverride: Boolean(props.document.deliveryDateOverride),
         approver: props.document.approver ?? approverOptions.value[0] ?? '',
+        productionRoute: props.document.productionRoute ?? 'DIRECT',
+        productionAssigneeId: props.document.productionAssigneeId ?? null,
+        shippingAssigneeId: props.document.shippingAssigneeId ?? null,
       }
       return
     }
@@ -135,6 +167,10 @@ function handleSave() {
   emit('save', {
     ...form.value,
     approverId: resolveApproverId(form.value.approver),
+    // Step C — DIRECT 면 생산 담당자는 무시 (null 로 넘김).
+    productionAssigneeId: form.value.productionRoute === 'PRODUCTION'
+      ? form.value.productionAssigneeId
+      : null,
   })
 }
 
@@ -314,6 +350,54 @@ watch(
           placeholder="결재자 선택"
         />
         <p v-if="errors.approver" class="mt-1 text-xs text-red-500">{{ errors.approver }}</p>
+      </div>
+
+      <!-- Step C — 후속 흐름 분기: 생산 경유 vs 직출하 -->
+      <div class="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3">
+        <label class="mb-2 block text-sm font-semibold text-slate-700">후속 흐름 *</label>
+        <div class="flex gap-4 text-sm">
+          <label class="inline-flex items-center gap-2 cursor-pointer">
+            <input
+              v-model="form.productionRoute"
+              type="radio"
+              value="DIRECT"
+              class="h-4 w-4 text-brand-600 focus:ring-brand-500"
+            >
+            직출하 (MO 없음)
+          </label>
+          <label class="inline-flex items-center gap-2 cursor-pointer">
+            <input
+              v-model="form.productionRoute"
+              type="radio"
+              value="PRODUCTION"
+              class="h-4 w-4 text-brand-600 focus:ring-brand-500"
+            >
+            생산 경유 (MO 자동 발행)
+          </label>
+        </div>
+      </div>
+
+      <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <div v-if="form.productionRoute === 'PRODUCTION'">
+          <label class="mb-1 block text-slate-600">생산 담당자</label>
+          <BaseSelect
+            v-model="form.productionAssigneeId"
+            :options="productionAssigneeOptions"
+            placeholder="담당자 선택 (미지정 허용)"
+          />
+          <p class="mt-1 text-xs text-slate-500">
+            생산 경유 선택 시 PO 승인과 동시에 MO 가 자동 발행되며, 여기서 고른 담당자가 바로 할당됩니다.
+          </p>
+        </div>
+
+        <div>
+          <label class="mb-1 block text-slate-600">출하 담당자</label>
+          <BaseSelect
+            v-model="form.shippingAssigneeId"
+            :options="shippingAssigneeOptions"
+            placeholder="출하 담당자 선택 (미지정 시 영업담당자가 기본)"
+          />
+        </div>
       </div>
 
       <p class="text-xs text-gray-400">

--- a/src/views/documents/POPage.vue
+++ b/src/views/documents/POPage.vue
@@ -534,6 +534,10 @@ function buildCreatePayload(formValue) {
     userId: authStore.currentUser?.userId ?? null,
     // 특기사항 (N4): POFormModal 은 폼에 reason 필드가 없어도 미래 대비 pass-through.
     remarks: formValue.reason ?? '',
+    // Step C — 후속 흐름 분기 + 담당자. 백엔드가 미전달 시 DIRECT 기본.
+    productionRoute: formValue.productionRoute ?? 'DIRECT',
+    productionAssigneeId: formValue.productionAssigneeId ?? null,
+    shippingAssigneeId: formValue.shippingAssigneeId ?? null,
     items,
   }
 }


### PR DESCRIPTION
## 📋 작업 내용

4차 QA 사용자 요구 중 "PO 등록 시점에 생산 경유 / 직출하 선택 + 담당자 지정" 반영.

### Backend (main 푸시 완료)
- team2-backend-documents [`4c142b9`](https://github.com/hanhwa-swcamp-22th-final/team2-backend-documents/commit/4c142b9)
- PurchaseOrder 엔티티 3 컬럼 + CreateRequest DTO 확장
- `generateOnConfirmation`: SO.managerId 전이 + PRODUCTION 시 MO 자동 발행

### Frontend (이 PR)
- POFormModal 에 `productionRoute` 라디오 (직출하 / 생산 경유)
- PRODUCTION 선택 시 "생산 담당자" BaseSelect 노출
- "출하 담당자" BaseSelect 상시 노출
- `fetchAssignableUsers('production')`, `fetchAssignableUsers('shipping')` 로 후보 로드
- 수정 모드에서 기존값 복원
- POPage.buildCreatePayload 에 3 필드 pass-through

## 🔗 관련 이슈
- closes #434

## ✅ 체크리스트
- [x] 정상 동작 확인 — vite build 7.80s, documents gradle build 성공
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게
- PRODUCTION 경로에서 생산 담당자 미지정도 허용 (`fetchAssignableUsers` 응답이 비어 있는 경우 자연스럽게 null 전송). 백엔드 `PurchaseOrderProductionOrderGenerationService` 가 "담당자 미지정" 분기를 이미 허용.
- 출하 담당자 미지정 시 백엔드 fallback 은 `purchaseOrder.getManagerId()` (영업담당자). 회귀 없음.
- 수정 모드(edit) 의 기존 PO document 에 `productionRoute` 필드가 없던 레거시 레코드는 `'DIRECT'` 기본값으로 바인딩.

## 다음 단계
- Step E(UI minor — 출하현황 컬럼 폭·MO 자동 할당) 후속 PR 진행 예정.
- Step D(단가 표시 정합성 + 폼 편집 정책) 가 가장 큰 작업이라 마지막.