### PR TITLE
fix(#436): 출하현황 컬럼 정리 + Shipment 상세 품목 테이블 복구

### DIFF
--- a/src/stores/shipmentStatusDocuments.js
+++ b/src/stores/shipmentStatusDocuments.js
@@ -18,7 +18,28 @@ function normalizeShipmentStatus(raw) {
   return SHIPMENT_STATUS_LABEL[String(raw).toLowerCase()] ?? SHIPMENT_STATUS_LABEL[raw] ?? '출하준비'
 }
 
+function parseItemsSnapshot(value) {
+  if (!value) return []
+  if (Array.isArray(value)) return value
+  if (typeof value === 'string') {
+    try { return JSON.parse(value) } catch { return [] }
+  }
+  return []
+}
+
 function mapShipmentResponse(row) {
+  // Step E — PO.po_items_snapshot 을 JOIN 으로 가져온 row.itemsSnapshot(JSON) 을 우선.
+  // 레거시 레코드(snapshot NULL) 는 row.items fallback.
+  const snapshotItems = parseItemsSnapshot(row.itemsSnapshot)
+  const sourceItems = snapshotItems.length > 0 ? snapshotItems : (row.items ?? [])
+  const items = sourceItems.map((item) => ({
+    code: item.itemCode ?? item.code ?? '',
+    name: item.itemName ?? item.name ?? '-',
+    quantity: String(item.quantity ?? item.qty ?? 1),
+    unit: item.unit ?? 'EA',
+    remark: item.remark ?? '',
+  }))
+
   return {
     id: String(row.shipmentId ?? row.id ?? ''),
     status: normalizeShipmentStatus(row.shipmentStatus ?? row.status),
@@ -31,7 +52,7 @@ function mapShipmentResponse(row) {
     updatedAt: row.updatedAt ?? '',
     manager: row.managerName ?? row.manager ?? '-',
     remarks: row.remarks ?? '-',
-    items: row.items ?? [],
+    items,
     linkedDocuments: row.linkedDocuments ?? [],
   }
 }

--- a/src/views/documents/ShipmentsPage.vue
+++ b/src/views/documents/ShipmentsPage.vue
@@ -39,11 +39,13 @@ const shipmentSearchKeyword = ref('')
 const poDocuments = usePoDocuments()
 const shipmentOrderDocuments = useShipmentOrderDocuments()
 
+// Step E — 출하 번호는 Long PK 라 폭이 컸음(140px). 숫자만 들어가니 70px 충분.
+// PO 번호는 사용자 요구대로 출하지시서(SO) 번호 컬럼으로 대체.
 const columns = [
-  { key: 'id', label: '출하 번호', align: 'center', width: '140px' },
+  { key: 'id', label: '출하 번호', align: 'center', width: '70px' },
   { key: 'clientName', label: '거래처', align: 'left', width: '220px' },
   { key: 'country', label: '국가', align: 'center', width: '120px' },
-  { key: 'poId', label: 'PO 번호', align: 'center', width: '140px' },
+  { key: 'shipmentOrderId', label: '출하지시서', align: 'center', width: '150px' },
   { key: 'requestDate', label: '출하요청일', align: 'center', width: '130px' },
   { key: 'dueDate', label: '납기일', align: 'center', width: '130px' },
   { key: 'status', label: '상태', align: 'center', width: '120px' },
@@ -66,7 +68,7 @@ const countryOptions = computed(() => buildSelectOptionsFromRows(rowsData.value,
 const statusOptions = computed(() => buildSelectOptionsFromRows(rowsData.value, 'status'))
 
 const { filters, filteredRows, resetFilters, applyFilters } = useDocumentFilter(rowsData, {
-  keywordFields: ['id', 'clientName', 'country', 'poId', 'requestDate', 'dueDate', 'status'],
+  keywordFields: ['id', 'clientName', 'country', 'shipmentOrderId', 'poId', 'requestDate', 'dueDate', 'status'],
   issueDateField: 'requestDate',
   deliveryDateField: 'dueDate',
   codeField: 'id',


### PR DESCRIPTION
## 📋 작업 내용

4차 QA 사용자 리포트 UI minor 묶음 정리.

### Backend (main 푸시 완료)
- team2-backend-documents [`8a4fb6d`](https://github.com/hanhwa-swcamp-22th-final/team2-backend-documents/commit/8a4fb6d)
- ShipmentQueryMapper JOIN 에 `po.po_items_snapshot` 포함 → ShipmentView/Response 에 `itemsSnapshot` JSON 추가

### Frontend (이 PR)
- **출하현황 컬럼**: "출하 번호" 140→70px (숫자만이라 충분), "PO 번호" 컬럼을 "출하지시서" 로 교체. keywordFields 에 shipmentOrderId 추가.
- **Shipment 상세 품목 테이블**: shipmentStatusDocuments store 에 `parseItemsSnapshot` 추가. 백엔드에서 내려주는 PO itemsSnapshot 을 우선 파싱해 items 구성. 레거시 레코드는 `row.items` fallback.

### 미포함
- MO 담당자 자동 할당은 Step C 에서 PO 등록 시 "생산 담당자" 지정 필드로 해결됨(PR #435). 추가 백엔드 변경 불필요.

## 🔗 관련 이슈
- closes #436

## ✅ 체크리스트
- [x] 정상 동작 확인 — vite build 6.99s, gradle build 성공
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 다음 단계
- Step D(문서 품목 단가 표시 정합성 + PI/PO 폼 편집 정책) 가 마지막 남은 큰 작업. 별도 PR.