### PR TITLE
fix(#438): CRUD 중복 제출 가드·로딩 스피너 + 활동 기록 수정 후 refresh

### DIFF
--- a/src/components/common/BaseButton.vue
+++ b/src/components/common/BaseButton.vue
@@ -18,11 +18,19 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  // 제출 중일 때 연타 방지 + 스피너 노출. :disabled 를 따로 묶지 않아도
+  // loading=true 면 자동으로 비활성화됨.
+  loading: {
+    type: Boolean,
+    default: false,
+  },
   block: {
     type: Boolean,
     default: false,
   },
 })
+
+const isDisabled = computed(() => props.disabled || props.loading)
 
 const variantClasses = {
   primary: 'border-brand bg-brand text-white shadow-sm hover:border-brand-600 hover:bg-brand-600 focus-visible:ring-brand/30',
@@ -48,10 +56,14 @@ const buttonClasses = computed(() => [
 <template>
   <button
     :type="type"
-    :disabled="disabled"
+    :disabled="isDisabled"
     :class="buttonClasses"
+    :aria-busy="loading || null"
   >
-    <slot name="leading" />
+    <span v-if="loading" class="inline-flex h-3.5 w-3.5 animate-spin items-center justify-center" aria-hidden="true">
+      <i class="fas fa-spinner text-[11px]"></i>
+    </span>
+    <slot v-else name="leading" />
     <slot />
     <slot name="trailing" />
   </button>

--- a/src/components/common/ConfirmModal.vue
+++ b/src/components/common/ConfirmModal.vue
@@ -47,6 +47,11 @@ const props = defineProps({
     type: String,
     default: 'primary',
   },
+  // 확인 버튼을 처리 중 상태로 표시. 스피너 + disabled 자동. 연타 가드 용도.
+  loading: {
+    type: Boolean,
+    default: false,
+  },
   helperText: {
     type: String,
     default: '이 작업은 되돌릴 수 없습니다.',
@@ -177,8 +182,8 @@ const emit = defineEmits(['confirm', 'cancel'])
     </div>
 
     <template #footer>
-      <BaseButton variant="secondary" @click="emit('cancel')">{{ cancelLabel }}</BaseButton>
-      <BaseButton :variant="confirmVariant" @click="emit('confirm')">{{ confirmLabel }}</BaseButton>
+      <BaseButton variant="secondary" :disabled="loading" @click="emit('cancel')">{{ cancelLabel }}</BaseButton>
+      <BaseButton :variant="confirmVariant" :loading="loading" @click="emit('confirm')">{{ confirmLabel }}</BaseButton>
     </template>
   </BaseModal>
 </template>

--- a/src/views/DashboardPage.vue
+++ b/src/views/DashboardPage.vue
@@ -32,6 +32,7 @@ const productionOrderDocuments = useProductionOrderDocuments()
 const shipmentStatusDocuments = useShipmentStatusDocuments()
 const selectedRequest = ref(null)
 const decisionConfirmOpen = ref(false)
+const decisionSaving = ref(false)
 const pendingDecision = ref('')
 const rejectReason = ref('')
 const clientsData = ref([])
@@ -382,7 +383,7 @@ function openRejectConfirm() {
 }
 
 async function confirmDecision() {
-  if (!selectedRequest.value || !pendingDecision.value) return
+  if (!selectedRequest.value || !pendingDecision.value || decisionSaving.value) return
 
   const item = selectedRequest.value
   const approvalRequestId = item.approvalRequestId
@@ -393,6 +394,7 @@ async function confirmDecision() {
     return
   }
 
+  decisionSaving.value = true
   try {
     if (pendingDecision.value === 'approve') {
       await updateApprovalRequest(approvalRequestId, { status: 'APPROVED' })
@@ -412,6 +414,7 @@ async function confirmDecision() {
   } catch (e) {
     toastError(e?.response?.data?.message || '결재 처리 중 오류가 발생했습니다.')
   } finally {
+    decisionSaving.value = false
     closeDecisionConfirm()
     closeRequestReview()
   }
@@ -756,6 +759,7 @@ async function confirmPackageDelete() {
       helper-text="처리 후 요청 상태와 문서 상태가 즉시 갱신됩니다."
       width="max-w-2xl"
       :z-index="90"
+      :loading="decisionSaving"
       @confirm="confirmDecision"
       @cancel="closeDecisionConfirm"
     >

--- a/src/views/activity/ActivityListPage.vue
+++ b/src/views/activity/ActivityListPage.vue
@@ -76,6 +76,15 @@ function resetFilters() {
 const activities = ref([])
 const clients = ref([])
 
+async function loadActivities() {
+  try {
+    activities.value = await fetchActivities()
+  } catch (e) {
+    console.error('기록 목록 로드 실패', e)
+    error('기록 목록을 불러오지 못했습니다.')
+  }
+}
+
 onMounted(async () => {
   try {
     const [activityData, clientData] = await Promise.all([
@@ -165,12 +174,13 @@ async function handleSave(updated) {
   isSaving.value = true
   try {
     await updateActivity(activityId, updated)
-    const idx = activities.value.findIndex((a) => a.id === activityId)
-    if (idx !== -1) activities.value[idx] = { ...activities.value[idx], ...updated }
+    // 이전엔 폼 payload 를 로컬 row 에 spread 해서 type/author 등 서버 가공값이
+    // 덮이지 않아 목록이 stale 로 보임. 서버 응답을 신뢰하기 위해 목록 재fetch.
+    await loadActivities()
     closeEdit()
   } catch (e) {
     console.error('기록 수정 실패', e)
-    error('기록 수정에 실패했습니다. 다시 시도해주세요.')
+    error(e?.response?.data?.message || '기록 수정에 실패했습니다. 다시 시도해주세요.')
   } finally {
     isSaving.value = false
   }
@@ -370,6 +380,7 @@ const columns = [
       :detail="deleteTarget?.title"
       confirm-label="삭제"
       confirm-variant="danger"
+      :loading="isDeleting"
       @confirm="handleDelete"
       @cancel="closeDelete"
     />

--- a/src/views/documents/CollectionsPage.vue
+++ b/src/views/documents/CollectionsPage.vue
@@ -34,6 +34,7 @@ const appliedCurrencyFilter = ref('')
 const { warning, success, error: toastError } = useToast()
 const statusConfirmOpen = ref(false)
 const pendingStatusChange = ref(null)
+const statusSaving = ref(false)
 
 const columns = [
   { key: 'poId', label: 'PO 번호', align: 'center', width: '140px' },
@@ -288,7 +289,7 @@ function toIsoDate(slashDate) {
 }
 
 async function confirmStatusChange() {
-  if (!pendingStatusChange.value) return
+  if (!pendingStatusChange.value || statusSaving.value) return
 
   const pending = pendingStatusChange.value
   // 백엔드 complete(id, status, date): 1차 re-verification 에서 로컬 뮤테이션만
@@ -300,6 +301,7 @@ async function confirmStatusChange() {
     return
   }
 
+  statusSaving.value = true
   try {
     await updateCollection(pending.collectionId, {
       status: pending.nextStatus, // "수금완료" / "미수금"
@@ -312,6 +314,7 @@ async function confirmStatusChange() {
   } catch (e) {
     toastError(e?.response?.data?.message || '수금 상태 변경 중 오류가 발생했습니다.')
   } finally {
+    statusSaving.value = false
     statusConfirmOpen.value = false
     pendingStatusChange.value = null
   }
@@ -676,6 +679,7 @@ function downloadCurrentTablePdf() {
       confirm-label="변경"
       helper-text="수금상태 변경 시 수금일자도 함께 조정됩니다."
       width="max-w-lg"
+      :loading="statusSaving"
       @confirm="confirmStatusChange"
       @cancel="cancelStatusChange"
     />


### PR DESCRIPTION
## 📋 작업 내용
4차 QA 사용자 추가 리포트 3건:
1. CRUD 버튼 연타 시 중복 호출 → 에러 토스트
2. 긴 처리 중 UI 미차단 (재클릭/재이동 가능)
3. 활동 기록 수정 후 목록 stale

## 변경
### 공통 컴포넌트
- `BaseButton`: `loading` prop 추가. true 일 때 자동 `disabled` + 스피너 leading. `aria-busy` 도 세팅.
- `ConfirmModal`: `loading` prop 위임. 확인 버튼 `:loading`, 취소 버튼 `:disabled`.

### Activity 목록 refresh 버그
- `ActivityListPage` 가 수정 후 `activities.value[idx] = {...row, ...updated}` 로 로컬 spread 패치. 폼 payload 가 서버 정규화 필드(type/author/priorityLevel 등)를 덮지 못해 목록이 stale 로 보임.
- `loadActivities()` 독립 함수로 승격. `handleSave` 성공 후 `await loadActivities()` 로 서버 기준 재fetch.
- 삭제 ConfirmModal 에 `:loading=isDeleting` 바인딩.

### 연타 가드
- `CollectionsPage.confirmStatusChange`: `statusSaving` ref + `:loading` 바인딩.
- `DashboardPage.confirmDecision`: `decisionSaving` ref + `:loading` 바인딩.

## 🔗 관련 이슈
- closes #438

## ✅ 체크리스트
- [x] 정상 동작 확인 — vite build 6.06s 성공
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게
- 다른 CRUD 경로(PI/PO Detail 의 승인·반려 모달, 거래처 저장 등) 도 같은 `:loading` 패턴으로 follow-up PR 에서 점진 적용 예정. 이번 PR 은 가장 빈번한 3개 경로(Activity / Collections / Dashboard) 우선.
- `BaseButton` 은 기존 `disabled` prop 동작 그대로 유지. `loading` 은 OR 합산이라 하위 호환.