### PR TITLE
fix(#440): 거래처 팀 default·바이어 컨택 sync·활동 패키지 에러 노출

### DIFF
--- a/src/views/master/ClientListPage.vue
+++ b/src/views/master/ClientListPage.vue
@@ -388,7 +388,7 @@ function goToDetail(row) {
       :payment-terms="paymentTerms"
       :departments="departments"
       :teams="teams"
-      :default-team-id="currentUser?.teamId ?? null"
+      :default-team-id="isAdmin ? null : (currentUser?.teamId ?? null)"
       :lock-team="!isAdmin"
       :all-clients="clients"
       :saving="saving"

--- a/src/views/package/ActivityPackagePage.vue
+++ b/src/views/package/ActivityPackagePage.vue
@@ -389,13 +389,17 @@ async function savePackage() {
       await updatePackage(editId.value, payload)
       success('패키지가 수정되었습니다.')
     } else {
-      payload.id = `PKG${String(Date.now()).slice(-6)}`
+      // 이전엔 클라이언트가 "PKG..." prefix id 를 추가로 보냈는데, 백엔드
+      // ActivityPackageCreateRequest 레코드엔 해당 필드가 없고 PK 는 DB auto.
+      // Jackson strict 설정에서 이 알 수 없는 필드가 400 을 유발해 저장이 실패하던
+      // 문제(G6). id 를 보내지 않도록 정리.
       await createPackage(payload)
       success('패키지가 저장되었습니다.')
     }
     router.push('/')
-  } catch {
-    error('패키지 저장에 실패했습니다.')
+  } catch (e) {
+    // 서버 400/403 메시지를 토스트에 그대로 노출해 디버깅 가능.
+    error(e?.response?.data?.message || '패키지 저장에 실패했습니다.')
   } finally {
     isSaving.value = false
   }


### PR DESCRIPTION
## 📋 작업 내용
4차 QA 사용자 추가 리포트의 비교적 빠르게 해결 가능한 3건 묶음.

### G1 거래처 팀 default (최관리 자동주입 제거)
- `ClientListPage` 의 `:default-team-id` 를 `isAdmin ? null : currentUser.teamId` 로 조건 분기.
- ADMIN 은 이제 팀 선택 필수. `ClientFormModal.validate` 의 기존 "담당 팀을 선택하세요" 가드가 작동.

### G2 바이어 → Contact 동기화에 ADMIN 포함 (백엔드)
- `team2-backend-master` [`0e158ef`](https://github.com/hanhwa-swcamp-22th-final/team2-backend-master/commit/0e158ef) 에서 `BuyerCommandService.syncToActivityContacts` 대상 집합을 `sales + admin` 으로 확장.

### G6 활동기록 패키지 생성 실패
- `ActivityPackagePage.savePackage` 의 payload 에서 임의 `id` 주입 제거. 백엔드 record DTO 에 없는 필드라 Jackson strict 환경에서 400 가능.
- `catch {}` → `catch(e)` 로 변경해 서버 메시지 노출. 앞으로 비슷한 경로도 원인 추적 가능.

## 🔗 관련 이슈
- closes #440

## ✅ 체크리스트
- [x] vite build 성공
- [x] master gradle build 성공
- [x] 불필요한 코드/주석 제거

## 💬 남은 후속 (사용자 리포트 중 미포함)
- **G3+G4** 팀장이 수정요청 보내면 대시보드 미노출 + 취소 오류: 백엔드 `ProformaInvoiceModificationRequestService` 가 MANAGER 분기에서 ApprovalRequest 를 생성하지 않는 구조. 팀장 직접 수정 엔드포인트 신설 필요 — 별도 PR.
- **G5** PO 생성 초안 재시도: `POPage.handleSave` 의 create → request-registration 2-step 사이 실패 복구 — 별도 PR.
- **G7** 기록 등록 시 PO 조회 안 됨 — 조사 중.
- **G8** PI 생성 후 메일 발송 — `DocumentAutoMailService` 측 조사 중.
- **G10** 생산팀 로그인 시 진행중 MO 완료 처리 불가 — 권한/상태 비교 조사 중.