### PR TITLE
fix(#442): 기록등록 PO 에러 메시지 + 팀장 PI 메일 + 생산완료 상태 비교

### DIFF
--- a/src/views/activity/ActivityCreatePage.vue
+++ b/src/views/activity/ActivityCreatePage.vue
@@ -202,12 +202,18 @@ async function openPoSearch() {
     return
   }
   try {
-    poList.value = await fetchPOsByClient(formClient.value)
+    const list = await fetchPOsByClient(formClient.value)
+    poList.value = Array.isArray(list) ? list : []
     poKeyword.value = ''
     isPoSearchOpen.value = true
+    // 클라이언트에는 확정된 PO 가 아직 없는 정상 상태. 빈 목록을 열어 안내.
+    if (poList.value.length === 0) {
+      warning('해당 거래처의 PO 가 아직 없습니다.')
+    }
   } catch (e) {
     console.error('PO 목록 로드 실패', e)
-    error('PO 목록을 불러오지 못했습니다. 다시 시도해주세요.')
+    // 서버 응답 메시지를 그대로 노출 (403/500 등 원인 추적 가능).
+    error(e?.response?.data?.message || 'PO 목록을 불러오지 못했습니다. 다시 시도해주세요.')
   }
 }
 

--- a/src/views/documents/ProductionOrderDetailPage.vue
+++ b/src/views/documents/ProductionOrderDetailPage.vue
@@ -55,9 +55,13 @@ const isAssignee = computed(() => {
   return uid != null && Number(detail.value.managerId) === Number(uid)
 })
 const canShowCompleteButton = computed(() => isProductionUser.value || isAdminUser.value)
+// G10: 이전엔 '진행중' 한글 리터럴만 허용했으나 백엔드가 상황따라 DB enum
+// 'in_progress' 를 그대로 반환하는 경우가 있어 버튼이 영원히 disabled.
+// 한영 양쪽 값을 모두 수용.
+const IN_PROGRESS_STATES = new Set(['진행중', 'in_progress', 'IN_PROGRESS'])
 const canCompleteProduction = computed(() => (
   canShowCompleteButton.value
-  && detail.value?.status === '진행중'
+  && IN_PROGRESS_STATES.has(String(detail.value?.status ?? '').trim())
   && (isAdminUser.value || isAssignee.value)
 ))
 const totalQuantity = computed(() => (


### PR DESCRIPTION
## 📋 작업 내용
4차 QA 사용자 추가 리포트 중 G7·G8·G10 세 건.

### G7 기록등록 PO 조회 오류 진단 강화 (이 PR)
- `ActivityCreatePage.openPoSearch` 에 서버 메시지 노출 + 빈 결과 warning.
- 기존 generic "PO 목록을 불러오지 못했습니다" 는 403/500/빈응답이 모두 같은 표시라 사용자가 원인 구분 못 했음.

### G8 팀장 셀프 PI 자동 메일 (백엔드 main)
- `ProformaInvoiceService.requestRegistration` 의 MANAGER 즉시 확정 분기에 `sendApprovedPiToBuyer` 호출 추가.
- team2-backend-documents [`149befd`](https://github.com/hanhwa-swcamp-22th-final/team2-backend-documents/commit/149befd) main 푸시 완료.

### G10 생산완료 버튼 상태 비교 (이 PR)
- `ProductionOrderDetailPage.canCompleteProduction` 을 `IN_PROGRESS_STATES` Set 기반 ('진행중'·'in_progress'·'IN_PROGRESS') 으로 변경.
- A-8 (Shipment MO 상태) 과 동일한 한영 불일치 패턴. 해당 수정은 `documentShipmentLock.getPoProductionGate` 에서 이미 완료.

## 🔗 관련 이슈
- closes #442

## ✅ 체크리스트
- [x] vite build 10.53s 성공
- [x] documents gradle build 성공
- [x] 불필요한 코드/주석 제거

## 💬 남은 후속
- **G3+G4** 팀장 수정 요청 / 취소 오류 — 백엔드 `ProformaInvoiceModificationRequestService` 가 MANAGER 분기에서 ApprovalRequest 미생성. 팀장 직접 수정 엔드포인트 신설이 필요 (DRAFT 외 CONFIRMED 허용). 별도 큰 PR.
- **G5** PO 생성 초안 재시도 — `POPage.handleSave` 의 2-step (createPurchaseOrder → requestPoRegistration) 사이 실패 복구. 별도 PR.