### PR TITLE
fix(#444): 팀장 PI/PO 즉시 수정 + PO 생성 재시도 idempotency

### DIFF
--- a/src/views/documents/PIDetailPage.vue
+++ b/src/views/documents/PIDetailPage.vue
@@ -17,6 +17,7 @@ import {
   requestPiDeletion,
   requestPiModification,
   deleteProformaInvoiceDraft,
+  updateProformaInvoiceDraft,
   cancelProformaInvoiceApproval,
   updateApprovalRequest,
 } from '@/api/documents'
@@ -691,11 +692,53 @@ function handleSave(formValue) {
   pendingEditRequest.value = {
     id: sourceRow.value.id,
     approver: formValue.approver || sourceRow.value.approver || '',
+    // formValue 를 보존해 confirmEditApprovalRequest 단계에서 팀장 직접 수정 PUT
+    // payload 를 만들 수 있게 한다 (G3+G4 프론트 반영).
+    formValue,
     nextRow,
     revisedSnapshot,
     changeRows,
   }
   editConfirmOpen.value = true
+}
+
+// 팀장 직접 수정용 PUT payload 빌더. ProformaInvoiceCreateRequest 구조에 맞춤.
+// PI 상세의 sourceRow 는 clientId/currencyId 같은 FK 를 보존하지 않으므로 가능
+// 한 범위 내에서 resolve 하고 나머지는 null 로 둬 백엔드 updateDraft 가 기존
+// 값을 유지하도록 한다.
+function buildManagerUpdatePayload(formValue) {
+  const matchedClient = clientRowsSource.value.find((c) => c.name === formValue.clientName)
+  const currencyCode = formValue.currency || sourceRow.value?.currency || 'USD'
+  const items = (formValue.items ?? []).map((item) => ({
+    itemId: null,
+    itemName: item.name ?? '',
+    quantity: Number(item.qty ?? item.quantity ?? 0) || 0,
+    unit: item.unit ?? '',
+    unitPrice: Number(item.unitPrice ?? 0) || 0,
+    amount: Number(item.amount ?? 0) || 0,
+    remark: item.remark ?? '',
+  }))
+  const totalAmount = items.reduce((sum, item) => sum + (Number(item.amount) || 0), 0)
+  return {
+    piId: null,
+    issueDate: (formValue.issueDate ?? '').replaceAll('/', '-'),
+    clientId: matchedClient?.clientId ?? null,
+    currencyId: null,
+    managerId: sourceRow.value?.managerId ?? authStore.currentUser?.userId ?? null,
+    deliveryDate: (formValue.deliveryDate ?? '').replaceAll('/', '-') || null,
+    incotermsCode: formValue.incoterms || 'FOB',
+    namedPlace: formValue.namedPlace || '',
+    totalAmount,
+    clientName: formValue.clientName || '',
+    clientAddress: formValue.clientAddress || matchedClient?.address || sourceRow.value?.clientAddress || '',
+    country: matchedClient?.country || sourceRow.value?.country || '',
+    currencyCode,
+    exchangeRate: null,
+    managerName: sourceRow.value?.manager || authStore.currentUser?.userName || '',
+    userId: authStore.currentUser?.userId ?? null,
+    remarks: formValue.reason ?? sourceRow.value?.remarks ?? '',
+    items,
+  }
 }
 
 function openClientSearch() {
@@ -747,15 +790,25 @@ async function confirmEditApprovalRequest() {
   if (!pendingEditRequest.value) return
   try {
     const userId = authStore.currentUser?.userId
-    await requestPiModification({ piId: pendingEditRequest.value.id, userId })
+    if (isTeamLeader.value) {
+      // 팀장/ADMIN: 결재 요청 경로를 건너뛰고 PUT /proforma-invoices/{id} 로 즉시
+      // 필드 반영. 백엔드 updateDraft 가 MANAGER 모드에서 CONFIRMED 도 허용하도록
+      // 확장됨 (docs 98bc5d4). 상태는 그대로 유지.
+      const payload = buildManagerUpdatePayload(pendingEditRequest.value.formValue)
+      await updateProformaInvoiceDraft(pendingEditRequest.value.id, payload)
+    } else {
+      await requestPiModification({ piId: pendingEditRequest.value.id, userId })
+    }
     await loadPiDocuments()
 
     editApprovalRequestOpen.value = false
     pendingEditRequest.value = null
     formOpen.value = false
-    success(`${sourceRow.value?.id} 수정 결재 요청이 전송되었습니다.`)
+    success(isTeamLeader.value
+      ? `${sourceRow.value?.id} 수정 내용이 즉시 반영되었습니다.`
+      : `${sourceRow.value?.id} 수정 결재 요청이 전송되었습니다.`)
   } catch (e) {
-    error(e.response?.data?.message || '수정 결재 요청 중 오류가 발생했습니다.')
+    error(e.response?.data?.message || '수정 처리 중 오류가 발생했습니다.')
   }
 }
 

--- a/src/views/documents/PODetailPage.vue
+++ b/src/views/documents/PODetailPage.vue
@@ -15,6 +15,7 @@ import POFormModal from '@/components/domain/document/POFormModal.vue'
 import ProductionOrderIssueModal from '@/components/domain/document/ProductionOrderIssueModal.vue'
 import {
   requestPoModification,
+  updatePurchaseOrderDraft,
   validatePoDeletable,
   requestPoDeletion,
   deletePurchaseOrderDraft,
@@ -668,11 +669,52 @@ function handleSave(formValue) {
   pendingEditRequest.value = {
     id: sourceRow.value.id,
     approver: formValue.approver || sourceRow.value.approver || '',
+    formValue,
     nextRow,
     revisedSnapshot,
     changeRows,
   }
   editConfirmOpen.value = true
+}
+
+// 팀장 직접 수정용 PO PUT payload. PurchaseOrderCreateRequest 구조.
+function buildManagerUpdatePoPayload(formValue) {
+  const items = Array.isArray(formValue.items) ? formValue.items : (sourceRow.value?.items ?? [])
+  const mappedItems = items.map((item) => ({
+    itemId: null,
+    itemName: item.name ?? item.itemName ?? '',
+    quantity: Number(item.qty ?? item.quantity ?? 0) || 0,
+    unit: item.unit ?? '',
+    unitPrice: Number(item.unitPrice ?? 0) || 0,
+    amount: Number(item.amount ?? 0) || 0,
+    remark: item.remark ?? '',
+  }))
+  const totalAmount = mappedItems.reduce((sum, item) => sum + (Number(item.amount) || 0), 0)
+  return {
+    poId: null,
+    piId: formValue.linkedPiId || sourceRow.value?.piId || null,
+    issueDate: (sourceRow.value?.issueDate ?? '').replaceAll('/', '-') || null,
+    clientId: null,
+    currencyId: null,
+    managerId: sourceRow.value?.managerId ?? authStore.currentUser?.userId ?? null,
+    deliveryDate: (formValue.deliveryDate ?? sourceRow.value?.deliveryDate ?? '').replaceAll('/', '-') || null,
+    incotermsCode: sourceRow.value?.incoterms || 'FOB',
+    namedPlace: sourceRow.value?.namedPlace || '',
+    sourceDeliveryDate: (sourceRow.value?.sourceDeliveryDate ?? sourceRow.value?.deliveryDate ?? '').replaceAll('/', '-') || null,
+    deliveryDateOverride: Boolean(sourceRow.value?.deliveryDateOverride),
+    totalAmount,
+    clientName: formValue.clientName || sourceRow.value?.clientName || '',
+    clientAddress: sourceRow.value?.clientAddress || '',
+    country: sourceRow.value?.country || '',
+    currencyCode: formValue.currency || sourceRow.value?.currency || 'USD',
+    managerName: sourceRow.value?.manager || authStore.currentUser?.userName || '',
+    userId: authStore.currentUser?.userId ?? null,
+    remarks: formValue.reason ?? sourceRow.value?.remarks ?? '',
+    productionRoute: formValue.productionRoute ?? sourceRow.value?.productionRoute ?? 'DIRECT',
+    productionAssigneeId: formValue.productionAssigneeId ?? sourceRow.value?.productionAssigneeId ?? null,
+    shippingAssigneeId: formValue.shippingAssigneeId ?? sourceRow.value?.shippingAssigneeId ?? null,
+    items: mappedItems,
+  }
 }
 
 function openPiSearch() {
@@ -814,15 +856,24 @@ async function confirmEditApprovalRequest() {
 
   try {
     const userId = authStore.currentUser?.userId
-    await requestPoModification({ poId: pendingEditRequest.value.id, userId })
+    if (isTeamLeader.value) {
+      // 팀장: 결재 경로 건너뛰고 PUT /purchase-orders/{id} 로 즉시 필드 반영.
+      // 백엔드 updateDraft 가 MANAGER 모드에서 CONFIRMED 도 허용 (docs 98bc5d4).
+      const payload = buildManagerUpdatePoPayload(pendingEditRequest.value.formValue)
+      await updatePurchaseOrderDraft(pendingEditRequest.value.id, payload)
+    } else {
+      await requestPoModification({ poId: pendingEditRequest.value.id, userId })
+    }
     await loadPoDocuments()
 
     editApprovalRequestOpen.value = false
     pendingEditRequest.value = null
     formOpen.value = false
-    success(`${sourceRow.value?.id ?? ''} 수정 결재 요청이 전송되었습니다.`)
+    success(isTeamLeader.value
+      ? `${sourceRow.value?.id ?? ''} 수정 내용이 즉시 반영되었습니다.`
+      : `${sourceRow.value?.id ?? ''} 수정 결재 요청이 전송되었습니다.`)
   } catch (e) {
-    error(e.response?.data?.message || 'PO 수정 결재 요청 중 오류가 발생했습니다.')
+    error(e.response?.data?.message || 'PO 수정 처리 중 오류가 발생했습니다.')
   }
 }
 

--- a/src/views/documents/POPage.vue
+++ b/src/views/documents/POPage.vue
@@ -85,6 +85,12 @@ const productSearchOpen = ref(false)
 const productSearchKeyword = ref('')
 const clientSearchContext = ref('filter')
 const pendingCreateFormValue = ref(null)
+// G5: createPurchaseOrder 성공 후 requestPoRegistration 가 실패하면 DRAFT PO 가
+// 서버에 남는다. 같은 buildCreatePayload 결과로 재시도하면 또 다른 DRAFT 가
+// 생겨버려 초안 중복이 쌓이던 문제를 방지하기 위해, 생성된 poId 를 보관하고
+// 다음 시도에서는 create 를 건너뛰고 request-registration 만 재시도한다.
+const pendingDraftPoId = ref(null)
+const createSaving = ref(false)
 const pendingEditRequest = ref(null)
 const ciDocuments = useCiDocuments()
 const piRowsSource = usePiDocuments()
@@ -839,24 +845,39 @@ const deleteApprovalItemSummaryRows = computed(() => {
 })
 
 async function confirmCreateApprovalRequest() {
-  if (!pendingCreateFormValue.value) return
+  if (!pendingCreateFormValue.value || createSaving.value) return
 
+  createSaving.value = true
   try {
-    const payload = buildCreatePayload(pendingCreateFormValue.value)
-    const { poId } = await createPurchaseOrder(payload)
     const userId = authStore.currentUser?.userId
     const approverId = pendingCreateFormValue.value.approverId ?? null
+
+    // Idempotency: 직전 시도에서 DRAFT 는 만들어졌지만 requestPoRegistration 이
+    // 실패했을 경우 pendingDraftPoId 가 살아있다. 이번엔 create 를 스킵하고
+    // requestPoRegistration 만 재시도.
+    let poId = pendingDraftPoId.value
+    if (!poId) {
+      const payload = buildCreatePayload(pendingCreateFormValue.value)
+      const created = await createPurchaseOrder(payload)
+      poId = created.poId
+      pendingDraftPoId.value = poId
+    }
     await requestPoRegistration({ poId, userId, approverId })
     await loadPoDocuments()
 
     createApprovalRequestOpen.value = false
     pendingCreateFormValue.value = null
+    pendingDraftPoId.value = null
     formOpen.value = false
     selectedPi.value = null
     selectedClient.value = null
     success('PO 등록 결재 요청이 전송되었습니다.')
   } catch (e) {
     error(e.response?.data?.message || 'PO 등록 결재 요청 중 오류가 발생했습니다.')
+    // DRAFT 는 남겨둠 (pendingDraftPoId 유지). 모달이 열려 있으면 재시도 시 위
+    // if(!poId) 분기가 create 를 스킵하고 request-registration 만 재시도한다.
+  } finally {
+    createSaving.value = false
   }
 }
 


### PR DESCRIPTION
## 📋 작업 내용
4차 QA 사용자 추가 리포트의 G3+G4+G5 한 묶음.

### 백엔드 (main 푸시 완료)
- team2-backend-documents [`98bc5d4`](https://github.com/hanhwa-swcamp-22th-final/team2-backend-documents/commit/98bc5d4)
- `Proforma/PurchaseOrderModificationRequestService` MANAGER 분기 수정: 상태 변경 없이 revision history 만. 취소 버튼 미노출 → 404 미발생.
- `Proforma/PurchaseOrderCreationService.updateDraft`: MANAGER 면 CONFIRMED 도 허용 (UserPositionRepository 주입).

### 프론트 (이 PR)
- **G3+G4**: `PIDetailPage`·`PODetailPage` 의 `confirmEditApprovalRequest` 에 `isTeamLeader` 분기 추가.
  팀장이면 `updateProformaInvoiceDraft`/`updatePurchaseOrderDraft` 로 즉시 필드 반영. `buildManagerUpdatePayload` / `buildManagerUpdatePoPayload` 헬퍼로 sourceRow + formValue 기반 PUT payload 생성. `pendingEditRequest` 에 `formValue` 보존.
- **G5**: `POPage` 에 `pendingDraftPoId`·`createSaving` ref 추가. `createPurchaseOrder` 성공 후 poId 보관, `requestPoRegistration` 실패 시 유지. 재시도 시 create 스킵하고 request 만 재호출.

## 🔗 관련 이슈
- closes #444

## ✅ 체크리스트
- [x] vite build 5.72s 성공
- [x] documents gradle build 성공

## 💬 남은 후속
- **Step D** 단가 표시 역변환 (PI/PO/CI/PL/Shipment/Collection 6개 문서 표시 레이어) 은 스코프가 커서 별도 PR.
- **Step D** 품목 편집 정책 (수량·단가만 편집, 나머지 readonly) 도 별도 PR.