### PR TITLE
fix(#450): 통화 표시·입력 정합성 4종 일괄 (QA #1 #2 #9 + 백엔드 #3 #5 연계)

### DIFF
--- a/src/components/domain/document/PIFormModal.vue
+++ b/src/components/domain/document/PIFormModal.vue
@@ -432,7 +432,11 @@ function findProductByName(name) {
 
 function formatUnitPriceValue(value) {
   if (!Number.isFinite(value)) return '0'
-  return String(Math.max(0, Math.round(value)))
+  // 소수점 2자리까지 보존 (USD / EUR 등 외화는 센트 단위가 의미있음).
+  // KRW 는 센트 개념이 없지만 "1000.00" 식 표기가 해되지는 않으므로 단일 포맷 유지.
+  const clamped = Math.max(0, value)
+  const rounded = Math.round(clamped * 100) / 100
+  return String(rounded)
 }
 
 function convertKrwPriceToCurrency(basePrice, currency) {
@@ -459,6 +463,34 @@ function sanitizeNonNegativeInteger(value, fallback = '0') {
   return String(Math.max(0, Math.round(numericValue)))
 }
 
+/**
+ * 소수점 보존 sanitizer.
+ * 입력 중 "." 뒤 자릿수가 아직 없는 상태("250.")를 보존하기 위해 숫자 파싱이
+ * 아니라 문자 단위로 정제한다. 소수점은 첫 하나만 유지, 소수 자리수는 maxDecimals
+ * 로 제한. 통화별 (KRW/JPY = 0, USD/EUR 등 = 2) 로 자릿수를 다르게 주입.
+ */
+function sanitizeNonNegativeDecimal(value, fallback = '0', maxDecimals = 2) {
+  const raw = String(value ?? '').replace(/[^0-9.]/g, '')
+
+  if (raw === '') {
+    return fallback
+  }
+
+  const [head, ...rest] = raw.split('.')
+  if (rest.length === 0) {
+    return head === '' ? fallback : head
+  }
+
+  const tail = rest.join('').slice(0, Math.max(0, maxDecimals))
+  const normalizedHead = head === '' ? '0' : head
+  return maxDecimals === 0 ? normalizedHead : `${normalizedHead}.${tail}`
+}
+
+function unitPriceDecimalsFor(currency) {
+  // KRW 와 JPY 는 소수 단위 없음 (원·엔). 그 외 통화는 2자리까지 허용.
+  return currency === 'KRW' || currency === 'JPY' ? 0 : 2
+}
+
 function handleQuantityChange(item) {
   item.qty = sanitizeNonNegativeInteger(item.qty, '0')
   clearItemError(item.id, 'qty')
@@ -466,7 +498,8 @@ function handleQuantityChange(item) {
 }
 
 function handleUnitPriceChange(item) {
-  item.unitPrice = sanitizeNonNegativeInteger(item.unitPrice, '0')
+  const decimals = unitPriceDecimalsFor(form.value.currency)
+  item.unitPrice = sanitizeNonNegativeDecimal(item.unitPrice, '0', decimals)
   clearItemError(item.id, 'unitPrice')
   updateItemAmount(item)
 }
@@ -603,7 +636,11 @@ function validateForm() {
 
 function formatAmount(value) {
   if (!Number.isFinite(value)) return '0'
-  return Math.max(0, Math.round(value)).toLocaleString('en-US')
+  // 소수점 2자리까지 보존. KRW/JPY 도 동일 포맷이지만 소수 자리 0 으로 입력되면
+  // toLocaleString 이 자연히 정수로 찍음 (100,000).
+  const clamped = Math.max(0, value)
+  const rounded = Math.round(clamped * 100) / 100
+  return rounded.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 2 })
 }
 
 function updateItemAmount(item) {
@@ -622,12 +659,13 @@ function normalizeEditItem(item, index) {
   const normalizedQty = parseNumericInput(item.qty ?? item.quantity)
   const normalizedUnitPrice = parseNumericInput(item.unitPrice)
   const normalizedAmount = parseNumericInput(item.amount)
+  const toTwoDecimals = (n) => Math.round(n * 100) / 100
   const resolvedUnitPrice = normalizedUnitPrice > 0
-    ? normalizedUnitPrice
-    : (normalizedAmount > 0 && normalizedQty > 0 ? Math.round(normalizedAmount / normalizedQty) : 0)
+    ? toTwoDecimals(normalizedUnitPrice)
+    : (normalizedAmount > 0 && normalizedQty > 0 ? toTwoDecimals(normalizedAmount / normalizedQty) : 0)
   const resolvedAmount = normalizedAmount > 0
-    ? normalizedAmount
-    : normalizedQty * resolvedUnitPrice
+    ? toTwoDecimals(normalizedAmount)
+    : toTwoDecimals(normalizedQty * resolvedUnitPrice)
 
   return {
     id: item.id ?? index + 1,

--- a/src/stores/ciDocuments.js
+++ b/src/stores/ciDocuments.js
@@ -1,6 +1,7 @@
 import { useAuthStore } from './auth'
 import { ref } from 'vue'
 import { fetchCommercialInvoicesPaged } from '@/api/documents'
+import { formatCurrencyAmount } from '@/utils/currencyFormat'
 
 function formatDate(value) {
   return String(value ?? '').replace(/-/g, '/')
@@ -11,12 +12,6 @@ function formatNumber(value, maximumFractionDigits = 0) {
     minimumFractionDigits: maximumFractionDigits,
     maximumFractionDigits,
   })
-}
-
-function formatCurrencyAmount(amount, currencyCode) {
-  const symbols = { USD: '$', EUR: '€', JPY: '¥', GBP: '£', AUD: 'A$', CAD: 'C$', SGD: 'S$', AED: 'د.إ', CNY: '¥', MYR: 'RM', THB: '฿', VND: '₫', IDR: 'Rp', INR: '₹', SAR: '﷼', BRL: 'R$', SEK: 'kr', CHF: 'CHF', KRW: '₩' }
-  const symbol = symbols[currencyCode] ?? ''
-  return `${symbol}${formatNumber(amount, 0)}`
 }
 
 function parseJsonSafe(value, fallback = []) {

--- a/src/stores/piDocuments.js
+++ b/src/stores/piDocuments.js
@@ -2,6 +2,7 @@ import { useAuthStore } from './auth'
 import { ref } from 'vue'
 import { fetchProformaInvoicesPaged } from '@/api/documents'
 import { loadApprovalRequests, pickLatestRequestFor } from './approvalRequests'
+import { formatCurrencyAmount } from '@/utils/currencyFormat'
 
 function tryParseJson(value, fallback = null) {
   if (typeof value !== 'string') return value ?? fallback
@@ -20,12 +21,6 @@ function formatTimestamp(value) {
 
 function formatDate(value) {
   return String(value ?? '').replace(/-/g, '/')
-}
-
-function formatCurrencyAmount(amount, currencyCode) {
-  const symbols = { USD: '$', EUR: '€', JPY: '¥', GBP: '£', AUD: 'A$', CAD: 'C$', SGD: 'S$', AED: 'د.إ', CNY: '¥', MYR: 'RM', THB: '฿', VND: '₫', IDR: 'Rp', INR: '₹', SAR: '﷼', BRL: 'R$', SEK: 'kr', CHF: 'CHF', KRW: '₩' }
-  const symbol = symbols[currencyCode] ?? ''
-  return `${symbol}${Number(amount || 0).toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`
 }
 
 function mapPiResponse(row) {

--- a/src/stores/poDocuments.js
+++ b/src/stores/poDocuments.js
@@ -2,15 +2,10 @@ import { useAuthStore } from './auth'
 import { ref } from 'vue'
 import { fetchPurchaseOrdersPaged } from '@/api/documents'
 import { loadApprovalRequests, pickLatestRequestFor } from './approvalRequests'
+import { formatCurrencyAmount } from '@/utils/currencyFormat'
 
 function formatDate(value) {
   return String(value ?? '').replace(/-/g, '/')
-}
-
-function formatCurrencyAmount(amount, currencyCode) {
-  const symbols = { USD: '$', EUR: '€', JPY: '¥', GBP: '£', AUD: 'A$', CAD: 'C$', SGD: 'S$', AED: 'د.إ', CNY: '¥', MYR: 'RM', THB: '฿', VND: '₫', IDR: 'Rp', INR: '₹', SAR: '﷼', BRL: 'R$', SEK: 'kr', CHF: 'CHF', KRW: '₩' }
-  const symbol = symbols[currencyCode] ?? ''
-  return `${symbol}${Number(amount || 0).toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`
 }
 
 function formatTimestamp(value) {

--- a/src/utils/currencyFormat.js
+++ b/src/utils/currencyFormat.js
@@ -1,0 +1,36 @@
+const CURRENCY_SYMBOLS = {
+  USD: '$', EUR: '€', JPY: '¥', GBP: '£', AUD: 'A$', CAD: 'C$', SGD: 'S$',
+  AED: 'د.إ', CNY: '¥', MYR: 'RM', THB: '฿', VND: '₫', IDR: 'Rp',
+  INR: '₹', SAR: '﷼', BRL: 'R$', SEK: 'kr', CHF: 'CHF', KRW: '₩',
+}
+
+// 통화별 소수 자릿수.
+// KRW 와 JPY 는 센트 단위가 없으므로 0, 그 외는 2자리.
+const CURRENCY_DECIMALS = {
+  KRW: 0,
+  JPY: 0,
+}
+
+export function getCurrencySymbol(currencyCode) {
+  return CURRENCY_SYMBOLS[currencyCode] ?? ''
+}
+
+export function getCurrencyDecimals(currencyCode) {
+  return CURRENCY_DECIMALS[currencyCode] ?? 2
+}
+
+/**
+ * 통화 기호 + 숫자 포맷팅. 통화별 소수 자릿수 자동 적용.
+ * 이전에는 maximumFractionDigits 를 0 으로 하드코딩해 $3,999.97 → $4,000 같이
+ * 소수점 2자리가 강제 반올림 되는 표시 오류(Issue #2) 가 있었음.
+ */
+export function formatCurrencyAmount(amount, currencyCode) {
+  const symbol = getCurrencySymbol(currencyCode)
+  const decimals = getCurrencyDecimals(currencyCode)
+  const value = Number(amount || 0)
+  const formatted = value.toLocaleString('en-US', {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: decimals,
+  })
+  return `${symbol}${formatted}`
+}

--- a/src/utils/documentActivityEmail.js
+++ b/src/utils/documentActivityEmail.js
@@ -1,6 +1,7 @@
 import { fetchBuyersByClient, fetchClients, fetchCurrencies, fetchItems, fetchPorts } from '@/api/master'
 import { api } from '@/lib/api'
 import { resolveMasterCurrency, resolvePaymentTermLabel, resolvePortLabel } from '@/utils/ciplMaster'
+import { formatCurrencyAmount } from '@/utils/currencyFormat'
 import { resolveIncotermState } from '@/utils/incoterms'
 
 const clientsByName = new Map()
@@ -64,11 +65,6 @@ function formatNumber(value, maximumFractionDigits = 0) {
   })
 }
 
-function formatCurrencyAmount(amount, currencyCode) {
-  const symbolMap = { KRW: '₩', USD: '$', EUR: '€', JPY: '¥' }
-  const symbol = symbolMap[currencyCode] ?? ''
-  return `${symbol}${formatNumber(amount, 0)}`
-}
 
 function getClientByName(clientName) {
   return clientsByName.get(clientName) ?? null

--- a/src/utils/exchangeRate.js
+++ b/src/utils/exchangeRate.js
@@ -1,3 +1,5 @@
+import { getKrwRate } from '@/stores/exchangeRates'
+
 export function createExchangeRateHint(currency) {
   if (!currency || currency === 'KRW') {
     return '원화(KRW) 거래입니다.'
@@ -5,6 +7,13 @@ export function createExchangeRateHint(currency) {
   return `${currency} → KRW 환율은 백엔드에서 실시간 적용됩니다.`
 }
 
+/**
+ * 외화 금액을 현재 환율로 KRW 환산.
+ * 호출자는 @/stores/exchangeRates 의 loadExchangeRates() 를 사전에 호출해 rate 가
+ * 메모리에 로드돼 있어야 한다. rate 미로드 시 getKrwRate 는 null 을 반환하므로
+ * 이 경우 원금 그대로 반환하지 말고 0 을 반환해 "집계 불가" 임을 명확히 드러낸다
+ * (이전엔 외화값을 1:1 로 KRW 로 찍어 수억원을 수십만으로 오표시 → Issue #1).
+ */
 export function convertCurrencyAmountToKrw(amount, currency) {
   const numericAmount = Number(amount)
 
@@ -16,5 +25,12 @@ export function convertCurrencyAmountToKrw(amount, currency) {
     return Math.round(numericAmount)
   }
 
-  return Math.round(numericAmount)
+  const rate = getKrwRate(currency)
+  if (!rate || rate === 1) {
+    // rate 로드 실패 또는 1 은 환율 데이터가 없음을 뜻함. 0 반환하여 UI 가 "-" 로
+    // 표시하거나 집계에서 제외하도록 한다.
+    return 0
+  }
+
+  return Math.round(numericAmount * rate)
 }

--- a/src/views/documents/CollectionsPage.vue
+++ b/src/views/documents/CollectionsPage.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, ref } from 'vue'
+import { computed, onMounted, onUnmounted, ref } from 'vue'
 
 import BaseButton from '@/components/common/BaseButton.vue'
 import BasePagination from '@/components/common/BasePagination.vue'
@@ -18,6 +18,7 @@ import { useSearchModalLookups } from '@/composables/useSearchModalLookups'
 import { useToast } from '@/composables/useToast'
 import { updateCollection } from '@/api/documents'
 import { useSalesCollectionDocuments, loadSalesCollectionDocuments, normalizeSalesCollectionRow } from '@/stores/salesCollectionDocuments'
+import { loadExchangeRates, clearExchangeRates } from '@/stores/exchangeRates'
 import { openTableOutput } from '@/utils/documentOutput'
 import { convertCurrencyAmountToKrw } from '@/utils/exchangeRate'
 import { clientSearchColumns } from '@/utils/searchModalColumns'
@@ -51,6 +52,14 @@ const columns = [
 
 const rowsData = useSalesCollectionDocuments()
 const statusOptions = computed(() => buildSelectOptionsFromRows(rowsData.value, 'status'))
+
+// 환산매출액(KRW) 컬럼·원화환산 총계는 convertCurrencyAmountToKrw 가 getKrwRate 로
+// 실시간 환율을 참조한다. 페이지 진입 시 rate 가 메모리에 없으면 모든 외화 금액이
+// 0 으로 계산돼 수억대 집계가 0 또는 1:1 수치로 깨진다. 페이지 onMount 에서 강제 로드.
+onMounted(() => {
+  loadExchangeRates()
+})
+onUnmounted(clearExchangeRates)
 
 function createOptionList(values) {
   return [...new Set(values.filter(Boolean))]

--- a/src/views/documents/PIDetailPage.vue
+++ b/src/views/documents/PIDetailPage.vue
@@ -176,8 +176,12 @@ function parseNumericValue(value) {
 }
 
 function formatCurrencyValue(currency, value) {
-  const symbol = currencySymbolMap[currency] ?? `${currency} `
-  return `${symbol}${Math.round(value).toLocaleString('en-US')}`
+  // 통화별 소수 자릿수 자동 적용 (KRW/JPY=0, USD/EUR 등=2). 이전 Math.round 강제
+  // 정수화로 $3,999.97 → $4,000 로 표시되던 버그(Issue #2) 해소.
+  const numeric = Number(value || 0)
+  const decimals = currency === 'KRW' || currency === 'JPY' ? 0 : 2
+  const symbol = currencySymbolMap[currency] ?? `${currency || ''} `
+  return `${symbol}${numeric.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: decimals })}`
 }
 
 function formatSlashDate(value) {

--- a/src/views/documents/PODetailPage.vue
+++ b/src/views/documents/PODetailPage.vue
@@ -143,9 +143,13 @@ function parseNumericValue(value) {
 }
 
 function formatCurrencyValue(currency, value) {
-  const symbolMap = { KRW: '₩', USD: '$', EUR: '€', JPY: '¥' }
-  const symbol = symbolMap[currency] ?? `${currency} `
-  return `${symbol}${Math.round(value).toLocaleString('en-US')}`
+  // 통화별 소수 자릿수 자동 적용 (KRW/JPY=0, USD/EUR 등=2). 이전 Math.round 강제
+  // 정수화로 $3,999.97 → $4,000 로 표시되던 버그(Issue #2) 해소.
+  const numeric = Number(value || 0)
+  const decimals = currency === 'KRW' || currency === 'JPY' ? 0 : 2
+  const symbolMap = { KRW: '₩', USD: '$', EUR: '€', JPY: '¥', GBP: '£', AUD: 'A$', CAD: 'C$', CNY: '¥', SGD: 'S$', CHF: 'CHF' }
+  const symbol = symbolMap[currency] ?? `${currency || ''} `
+  return `${symbol}${numeric.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: decimals })}`
 }
 
 const totalItemQuantity = computed(() => (


### PR DESCRIPTION
## 📋 작업 내용

2026-04-20 전면 QA 결과의 상위 5개 중대 결함 중 **프론트 3건** 을 통합 수정.
백엔드 2건 (#3 CI/PL 스냅샷, #5 결재 취소 stale) 은 team2-backend-documents 에 같이 main 푸시 완료.

### 변경 요약

- \`src/components/domain/document/PIFormModal.vue\` — **[#9]** 단가 입력 sanitize 를 정수 강제 → 2자리 소수 보존. 통화별 자릿수 분기 (KRW/JPY=0, 그 외=2). 데이터 무결성 리스크 제거.
- \`src/utils/currencyFormat.js\` **(신규)** — 통화 기호/자릿수 shared helper. store 3종 + PI/PO 상세페이지가 동일 로직 공유.
- \`src/stores/{po,pi,ci}Documents.js\` — 로컬 formatCurrencyAmount 제거, shared helper import.
- \`src/utils/documentActivityEmail.js\` — 동일.
- \`src/utils/exchangeRate.js\` — **[#1]** convertCurrencyAmountToKrw 가 환율 곱셈 없이 Math.round 만 하던 stub → getKrwRate 연동.
- \`src/views/documents/CollectionsPage.vue\` — **[#1]** loadExchangeRates onMount 추가. 이전엔 환율 store 자체를 트리거하지 않아 항상 {} 상태.
- \`src/views/documents/{PI,PO}DetailPage.vue\` — **[#2]** 상세 페이지 formatCurrencyValue 도 동일 자릿수 정책 적용.

## 🔗 관련 이슈
- closes #450
- refs QA report 2026-04-20 (P0 / P1 분류)

## ✅ 체크리스트
- [x] 정상 동작 확인 — vite build 489 modules 성공
- [x] 불필요한 코드/주석 제거 — 중복 formatCurrencyAmount 정의 4곳 통합
- [x] 충돌(conflict) 해결 완료 — main 최신 rebase

## 💬 리뷰어에게
1. **#9 는 데이터 오염 방지 최우선** — 운영 사용자 지침: 이 PR rollout 전 단가에 소수 입력했던 PI 는 값 확인 필요.
2. **#1 과 #2 는 표시 레이어** — DB 값은 안전. 마이그레이션 불필요.
3. **#3 / #5 백엔드 변경** (다른 레포 main) 이 같이 rollout 돼야 #5 stale 결재 해소 효과 발현. CI/PL 스냅샷은 **신규 생성분부터 적용**, 기존 CI/PL 의 NULL snapshot 은 별도 backfill SQL 필요 (다음 PR 또는 별도 운영 작업).
4. **Issue #10~#17** 은 severity 낮아 후속 PR 로 분리 예정.