### PR TITLE
fix(#454): QA 워크플로 3종 (STAFF 결재요청·메일 제목·수금완료일)

### DIFF
--- a/src/api/emails.js
+++ b/src/api/emails.js
@@ -9,6 +9,22 @@ function normalizeEmailStatus(raw) {
   return String(raw)
 }
 
+/**
+ * LocalDateTime ISO 문자열 ("2025-04-10T14:00:00") 또는 LocalDate ("2025-04-10")
+ * 을 사용자 표시용 "2025/04/10 14:00" / "2025/04/10" 로 변환 (Issue #16).
+ * 잘못된 값은 원본 그대로 반환해 표시 누락을 피한다.
+ */
+function formatEmailSentAt(value) {
+  if (!value) return ''
+  const str = String(value)
+  if (str.includes('T')) {
+    const [datePart, timePart = ''] = str.split('T')
+    const hhmm = timePart.substring(0, 5)
+    return hhmm ? `${datePart.replaceAll('-', '/')} ${hhmm}` : datePart.replaceAll('-', '/')
+  }
+  return str.replaceAll('-', '/')
+}
+
 export async function fetchActivityEmails() {
   const { data } = await api.get('/email-logs')
   // 백엔드 응답은 { clientName, types: [{emailLogTypeId, emailDocType}], status: 'failed'|'sent', ... } 형태.
@@ -22,7 +38,7 @@ export async function fetchActivityEmails() {
     recipient: row.recipient ?? row.recipientName ?? row.emailRecipientName ?? '',
     email: row.email ?? row.recipientEmail ?? row.emailRecipientEmail ?? '',
     sender: row.sender ?? row.senderName ?? '-',
-    sentAt: row.sentAt ?? row.sentDate ?? row.emailSentAt ?? '',
+    sentAt: formatEmailSentAt(row.sentAt ?? row.sentDate ?? row.emailSentAt ?? ''),
     status: normalizeEmailStatus(row.status),
   }))
 }

--- a/src/components/domain/document/PODocumentTemplate.vue
+++ b/src/components/domain/document/PODocumentTemplate.vue
@@ -124,7 +124,7 @@ function resolvePiReference(linkedDocuments) {
           <td class="text-center">{{ String(index + 1).padStart(3, '0') }}</td>
           <td>{{ item.name }}</td>
           <td class="text-center">{{ item.quantity }}</td>
-          <td class="text-center">EA</td>
+          <td class="text-center">{{ item.unit || 'EA' }}</td>
           <td class="text-right">{{ item.unitPrice }}</td>
           <td class="text-right font-semibold">{{ item.amount }}</td>
         </tr>

--- a/src/components/domain/document/SendDocumentEmailModal.vue
+++ b/src/components/domain/document/SendDocumentEmailModal.vue
@@ -39,15 +39,25 @@ const canSubmit = computed(
     !!props.clientId,
 )
 
+// 외국 거래처 대상이 기본이므로 제목 템플릿은 영문으로 기본화한다 (Issue F).
+// 사용자는 모달에서 제목을 자유롭게 수정 가능하므로 국내 거래처면 직접 편집.
+const DOC_TYPE_ENGLISH_LABEL = {
+  PI: 'Proforma Invoice',
+  PO: 'Purchase Order',
+  CI: 'Commercial Invoice',
+  PL: 'Packing List',
+}
+
 watch(
   () => props.open,
   (next) => {
     if (next) {
       recipientName.value = props.defaultRecipientName ?? ''
       recipientEmail.value = props.defaultRecipientEmail ?? ''
+      const englishLabel = DOC_TYPE_ENGLISH_LABEL[props.docType] ?? props.docType
       subject.value = props.documentLabel
-        ? `[${props.docType}] ${props.documentLabel} 송부드립니다.`
-        : `[${props.docType}] 문서 송부`
+        ? `${englishLabel} ${props.documentLabel} — Please find attached`
+        : `${englishLabel} — Document enclosed`
     } else {
       submitting.value = false
     }

--- a/src/stores/ciDocuments.js
+++ b/src/stores/ciDocuments.js
@@ -61,8 +61,10 @@ function mapCiResponse(row) {
     clientAddress: row.clientAddress ?? '-',
     buyer: row.buyerName ?? '-',
     country: row.country ?? '-',
-    currencyCode: row.currencyCode ?? 'USD',
-    currency: row.currencyCode ?? 'USD',
+    // row.currencyCode 가 빈 문자열 ("") 이어도 fallback 이 동작하도록 || 사용.
+    // 기존 ?? 는 "" 를 그대로 사용해 통화 기호가 누락됐음 (Issue #10).
+    currencyCode: row.currencyCode || 'USD',
+    currency: row.currencyCode || 'USD',
     itemName: items[0]?.name
       ?? row.itemName
       ?? row.firstItemName

--- a/src/utils/currencyFormat.js
+++ b/src/utils/currencyFormat.js
@@ -19,14 +19,22 @@ export function getCurrencyDecimals(currencyCode) {
   return CURRENCY_DECIMALS[currencyCode] ?? 2
 }
 
+// row.currencyCode 가 null/"" 인 케이스를 USD 로 간주. CI 목록 "1,200,000" 처럼
+// 통화 기호가 통째로 누락되던 증상 방지 (Issue #10).
+function resolveCurrency(currencyCode) {
+  return currencyCode && currencyCode !== '' ? currencyCode : 'USD'
+}
+
 /**
  * 통화 기호 + 숫자 포맷팅. 통화별 소수 자릿수 자동 적용.
  * 이전에는 maximumFractionDigits 를 0 으로 하드코딩해 $3,999.97 → $4,000 같이
  * 소수점 2자리가 강제 반올림 되는 표시 오류(Issue #2) 가 있었음.
+ * currencyCode 가 null/"" 인 경우 USD 로 간주해 기호 누락 방지 (Issue #10).
  */
 export function formatCurrencyAmount(amount, currencyCode) {
-  const symbol = getCurrencySymbol(currencyCode)
-  const decimals = getCurrencyDecimals(currencyCode)
+  const resolved = resolveCurrency(currencyCode)
+  const symbol = getCurrencySymbol(resolved)
+  const decimals = getCurrencyDecimals(resolved)
   const value = Number(amount || 0)
   const formatted = value.toLocaleString('en-US', {
     minimumFractionDigits: 0,

--- a/src/views/DashboardPage.vue
+++ b/src/views/DashboardPage.vue
@@ -316,7 +316,12 @@ const requestItems = computed(() => {
     return allRequestItems.value.filter((item) => item.status === '대기' && canReviewRequest(item))
   }
   if (isSalesMember.value) {
-    return allRequestItems.value.filter((item) => item.requester === currentUser.value?.name)
+    // 백엔드 UserInfo DTO 는 userName 필드로 내려오지만 프론트 다른 곳은
+    // userName 을 우선 사용 → name 폴백. 여기서도 동일 패턴으로 맞춰야 본인이
+    // 요청한 결재가 대시보드 "내 요청 현황" 에 나타난다 (과거 name 하나만 비교해
+    // STAFF 본인 요청이 리스트에서 빠지던 Issue A).
+    const myDisplayName = currentUser.value?.userName || currentUser.value?.name
+    return allRequestItems.value.filter((item) => item.requester === myDisplayName)
   }
   return []
 })

--- a/src/views/documents/CollectionsPage.vue
+++ b/src/views/documents/CollectionsPage.vue
@@ -186,6 +186,10 @@ const poRows = computed(() => {
   return source.filter((row) => [row.poId, row.clientName, row.issueDate].some((value) => String(value).toLowerCase().includes(keyword)))
 })
 
+// 수금완료 처리 시 완료일은 사용자가 모달 내에서 직접 편집 (Issue G).
+// 기본값은 오늘 (YYYY-MM-DD). 미수금 복귀 시 null 처리.
+const editableCollectionDate = ref('')
+
 const statusConfirmRows = computed(() => {
   if (!pendingStatusChange.value) return []
 
@@ -194,7 +198,6 @@ const statusConfirmRows = computed(() => {
     { label: '거래처', value: pendingStatusChange.value.clientName },
     { label: '현재 수금상태', value: pendingStatusChange.value.currentStatus },
     { label: '변경 수금상태', value: pendingStatusChange.value.nextStatus },
-    { label: '수금일자 처리', value: pendingStatusChange.value.collectionDatePolicy, fullWidth: true },
   ]
 })
 
@@ -284,10 +287,11 @@ function openStatusConfirm(row, nextStatusValue) {
     nextStatus,
     nextStatusValue,
     nextCollectionDate,
-    collectionDatePolicy: nextStatus === '수금완료'
-      ? `수금일자가 ${formatCollectionDate(nextCollectionDate)} 로 반영됩니다.`
-      : '수금일자가 초기화되고 화면에는 - 로 표시됩니다.',
   }
+  // 편집 가능한 완료일 초기화 — 수금완료는 기본값 오늘, 미수금 복귀는 빈 값.
+  editableCollectionDate.value = nextStatusValue === 'PAID'
+    ? toIsoDate(nextCollectionDate)
+    : ''
   statusConfirmOpen.value = true
 }
 
@@ -314,8 +318,9 @@ async function confirmStatusChange() {
   try {
     await updateCollection(pending.collectionId, {
       status: pending.nextStatus, // "수금완료" / "미수금"
+      // 사용자가 모달 내 date input 에서 수정한 값 사용. 비워 제출하면 null.
       collectionCompletedDate: pending.nextStatusValue === 'PAID'
-        ? toIsoDate(pending.nextCollectionDate)
+        ? (editableCollectionDate.value || null)
         : null,
     })
     await loadSalesCollectionDocuments()
@@ -686,11 +691,23 @@ function downloadCurrentTablePdf() {
       message="선택한 수금상태를 반영하시겠습니까?"
       :detail-rows="statusConfirmRows"
       confirm-label="변경"
-      helper-text="수금상태 변경 시 수금일자도 함께 조정됩니다."
+      helper-text="수금일자는 기본 오늘 날짜로 채워지며, 필요 시 위 입력에서 수동 조정 가능합니다."
       width="max-w-lg"
       :loading="statusSaving"
       @confirm="confirmStatusChange"
       @cancel="cancelStatusChange"
-    />
+    >
+      <!-- Issue G — 수금완료 전환 시 완료일 input 을 모달 내에서 편집 가능하게. -->
+      <div
+        v-if="pendingStatusChange?.nextStatusValue === 'PAID'"
+        class="rounded-lg border border-slate-200 bg-white px-4 py-3"
+      >
+        <label class="mb-2 block text-xs font-medium text-slate-500">수금 완료일</label>
+        <DateField
+          v-model="editableCollectionDate"
+          :disabled="statusSaving"
+        />
+      </div>
+    </ConfirmModal>
   </div>
 </template>


### PR DESCRIPTION
## 📋 작업 내용

### 프론트 변경
- **Issue A** \`src/views/DashboardPage.vue\` — \`isSalesMember\` 필터의 이름 비교를 \`userName || name\` 폴백으로 변경. STAFF 본인 PI/PO 결재 요청이 대시보드에 노출.
- **Issue F** \`src/components/domain/document/SendDocumentEmailModal.vue\` — 메일 제목 기본 템플릿을 영문 풀네임(PI/PO/CI/PL) 기반으로.
- **Issue G** \`src/views/documents/CollectionsPage.vue\` — ConfirmModal 의 slot 영역에 DateField 추가, 수금완료일을 모달 내에서 수기 편집.

### 연관 백엔드 변경 (별도 커밋 — argoCD 자동 rollout)
- team2-backend-documents @ a46f8ec — **Issue B** DocumentAutoMailService 의 sendApprovedPiToBuyer 에 ActivityFeignClient.createEmailLog 호출 + **Issue F** 영문 제목
- 스킵: **Issue C** PO 바이어 "-" 는 #14 연장선 (pi/po 테이블에 buyer 컬럼 없음, 설계 스프린트 필요)
- 스킵: **Issue D** PL 총중량 — master.items 에 weight 필드 없음, 설계 스프린트 필요
- 스킵: **Issue E** PO 상세 → 메일 모달 거래처 정보 공백 은 #3 (CI/PL 스냅샷 NULL) 과 동일. 신규 CI/PL 부터 정상, 기존 레코드는 backfill SQL 필요

## 🔗 관련 이슈
- closes #454

## ✅ 체크리스트
- [x] vite build 489 modules 성공
- [x] gradle compileJava 통과
- [x] main 최신 base

## 💬 리뷰어에게
- Issue C/D/E 는 데이터 모델 변경이 필요해 별도 이슈로 분리했으면 합니다 (PO 에 buyer 컬럼 추가 + Item 에 weight 컬럼 추가 2건).
- #3 backfill SQL 은 별도 운영 작업으로 실행 예정 (기존 CI260005~011 snapshot 재생성).