### PR TITLE
feat(#456): PI/PO buyerName 승계 — 결재모달·PDF 바이어 노출

### DIFF
--- a/src/views/documents/PIDetailPage.vue
+++ b/src/views/documents/PIDetailPage.vue
@@ -741,6 +741,8 @@ function buildManagerUpdatePayload(formValue) {
     managerName: sourceRow.value?.manager || authStore.currentUser?.userName || '',
     userId: authStore.currentUser?.userId ?? null,
     remarks: formValue.reason ?? sourceRow.value?.remarks ?? '',
+    // Issue C — 팀장 즉시 수정 경로도 buyerName 을 pass-through.
+    buyerName: formValue.buyerName ?? sourceRow.value?.buyerName ?? '',
     items,
   }
 }

--- a/src/views/documents/PIPage.vue
+++ b/src/views/documents/PIPage.vue
@@ -612,6 +612,9 @@ function buildCreatePayload(formValue) {
     userId: authStore.currentUser?.userId ?? null,
     // 특기사항 (N4): 폼의 reason 필드를 백엔드 remarks 컬럼으로 매핑.
     remarks: formValue.reason ?? '',
+    // 바이어 이름 (Issue C): PIFormModal 의 바이어 드롭다운 선택값을 그대로 전달.
+    // PI 에 저장된 뒤 PO 생성 시 승계되고, CI/PL 로도 전이된다.
+    buyerName: formValue.buyerName ?? '',
     items,
   }
 }

--- a/src/views/documents/PODetailPage.vue
+++ b/src/views/documents/PODetailPage.vue
@@ -714,6 +714,8 @@ function buildManagerUpdatePoPayload(formValue) {
     managerName: sourceRow.value?.manager || authStore.currentUser?.userName || '',
     userId: authStore.currentUser?.userId ?? null,
     remarks: formValue.reason ?? sourceRow.value?.remarks ?? '',
+    // Issue C — 팀장 즉시 수정 경로도 buyerName 을 pass-through.
+    buyerName: formValue.buyerName ?? sourceRow.value?.buyerName ?? '',
     productionRoute: formValue.productionRoute ?? sourceRow.value?.productionRoute ?? 'DIRECT',
     productionAssigneeId: formValue.productionAssigneeId ?? sourceRow.value?.productionAssigneeId ?? null,
     shippingAssigneeId: formValue.shippingAssigneeId ?? sourceRow.value?.shippingAssigneeId ?? null,

--- a/src/views/documents/POPage.vue
+++ b/src/views/documents/POPage.vue
@@ -531,6 +531,9 @@ function buildCreatePayload(formValue) {
     userId: authStore.currentUser?.userId ?? null,
     // 특기사항 (N4): POFormModal 은 폼에 reason 필드가 없어도 미래 대비 pass-through.
     remarks: formValue.reason ?? '',
+    // 바이어 이름 (Issue C): 연결 PI 에 저장된 buyerName 을 그대로 승계.
+    // PO 저장 시 함께 보관되어 CI.ci_buyer / PL.pl_buyer 로 전이되고, PDF·결재 모달에 노출.
+    buyerName: linkedPi?.buyerName || formValue.buyerName || '',
     // Step C — 후속 흐름 분기 + 담당자. 백엔드가 미전달 시 DIRECT 기본.
     productionRoute: formValue.productionRoute ?? 'DIRECT',
     productionAssigneeId: formValue.productionAssigneeId ?? null,


### PR DESCRIPTION
## 📋 작업 내용

QA Issue C / 과거 #14 의 완결. PI/PO 테이블에 buyer 컬럼을 추가하고 PI→PO→CI/PL 체인으로 전이시켜 결재 모달과 PDF 에 바이어가 정상 표시되도록 수정.

## 관련 커밋
- **Backend** team2-backend-documents @ 38a73c6 — PI/PO 엔티티·DTO·서비스·쿼리·response 전 범위 반영, CI/PL createFromPurchaseOrder SQL 에 buyer 전이.
- **DDL** root @ ee67fca — document_service.sql / integrated_ddl.sql 컬럼 추가 + migration_pi_po_buyer_backfill.sql 작성.
- **Frontend** 이 PR — 프론트 payload 경로 4곳에 buyerName 전달.

## 🔗 관련 이슈
- closes #456
- refs #14

## ✅ 체크리스트
- [x] vite build 489 modules 성공
- [x] gradle build 성공 (test 제외)
- [x] main 최신

## 💬 운영 단계
1. PR 머지 + 백엔드 rollout 대기
2. 운영 DB 에 \`ddl/migration_pi_po_buyer_backfill.sql\` 실행 (ALTER + 백필)
3. 브라우저에서 결재 모달 / PO PDF 확인