### PR TITLE
fix(#460): QA 저녁 wave 잔여 5종 (버이어·포맷·PI 수정 리셋)

### DIFF
--- a/src/components/domain/document/PIFormModal.vue
+++ b/src/components/domain/document/PIFormModal.vue
@@ -831,10 +831,20 @@ watch(
   },
 )
 
+// 수정 모드 초기 진입 시 refreshAutoPricedItems 가 catalog 의 KRW 기준 master price
+// 에 현재 환율을 곱해 기존 저장 unitPrice (외화) 를 덮어쓰는 데이터 손실 버그(B4) 를
+// 일으켰다. 즉 PI260021 을 편집 모달로 열기만 해도 $999.99 가 (KRW_master × 현재_rate)
+// 로 재계산돼 폼에 찍히고, 저장 시 DB 가 덮어씀. edit 모드 초기 실행은 건너뛰고 이후
+// 사용자가 통화/발행일을 명시적으로 바꿀 때만 refresh.
+let currencyDateWatchReady = props.mode !== 'edit'
 watch(
   () => [form.value.currency, form.value.issueDate],
   ([currency, issueDate]) => {
     exchangeRateHint.value = createExchangeRateHint(currency || 'USD', issueDate)
+    if (!currencyDateWatchReady) {
+      currencyDateWatchReady = true
+      return
+    }
     refreshAutoPricedItems()
   },
   { immediate: true },

--- a/src/stores/ciDocuments.js
+++ b/src/stores/ciDocuments.js
@@ -1,7 +1,7 @@
 import { useAuthStore } from './auth'
 import { ref } from 'vue'
 import { fetchCommercialInvoicesPaged } from '@/api/documents'
-import { formatCurrencyAmount } from '@/utils/currencyFormat'
+import { formatCurrencyAmount, getCurrencyDecimals } from '@/utils/currencyFormat'
 
 function formatDate(value) {
   return String(value ?? '').replace(/-/g, '/')
@@ -42,12 +42,15 @@ function normalizeDocStatus(raw, fallback = '발행대기') {
 
 function mapCiResponse(row) {
   const rawItems = row.items?.length ? row.items : parseJsonSafe(row.itemsSnapshot)
+  // F4 — 품목 라인 셀의 소수 자릿수를 통화별로 결정. KRW/JPY=0, 그 외=2.
+  // 이전엔 2자리 고정이라 CI260011(KRW) 도 "12,000.00" 처럼 찍혀 이상했음.
+  const itemDecimals = getCurrencyDecimals(row.currencyCode)
   const items = rawItems.map((item) => ({
     name: item.itemName ?? item.name ?? '-',
     hsCode: item.hsCode ?? '-',
     quantity: String(item.quantity ?? 1),
-    unitPrice: formatNumber(Number(item.unitPrice ?? 0), 2),
-    amount: formatNumber(Number(item.amount ?? 0), 2),
+    unitPrice: formatNumber(Number(item.unitPrice ?? 0), itemDecimals),
+    amount: formatNumber(Number(item.amount ?? 0), itemDecimals),
     remark: item.remark ?? '',
   }))
 
@@ -59,7 +62,9 @@ function mapCiResponse(row) {
     clientName: row.clientName ?? '-',
     clientEmail: row.clientEmail ?? row.client_email ?? '',
     clientAddress: row.clientAddress ?? '-',
-    buyer: row.buyerName ?? '-',
+    // 백엔드 CommercialInvoiceResponse.buyer 필드명이므로 row.buyer 로 읽는다.
+    // 이전 row.buyerName 은 undefined → 항상 '-' 로 떨어져 CI 상세 "바이어" 비어보였음 (F1).
+    buyer: row.buyer ?? row.buyerName ?? '-',
     country: row.country ?? '-',
     // row.currencyCode 가 빈 문자열 ("") 이어도 fallback 이 동작하도록 || 사용.
     // 기존 ?? 는 "" 를 그대로 사용해 통화 기호가 누락됐음 (Issue #10).

--- a/src/stores/plDocuments.js
+++ b/src/stores/plDocuments.js
@@ -62,7 +62,8 @@ function mapPlResponse(row) {
     clientName: row.clientName ?? '-',
     clientEmail: row.clientEmail ?? row.client_email ?? '',
     clientAddress: row.clientAddress ?? '-',
-    buyer: row.buyerName ?? '-',
+    // 백엔드 PackingListResponse.buyer 필드명 기준. F1 (CI 와 동일 패턴).
+    buyer: row.buyer ?? row.buyerName ?? '-',
     country: row.country ?? '-',
     itemName: items[0]?.name
       ?? row.itemName

--- a/src/utils/currencyFormat.js
+++ b/src/utils/currencyFormat.js
@@ -36,8 +36,10 @@ export function formatCurrencyAmount(amount, currencyCode) {
   const symbol = getCurrencySymbol(resolved)
   const decimals = getCurrencyDecimals(resolved)
   const value = Number(amount || 0)
+  // min = max = decimals 로 통일해 trailing zero 유지. USD $139,998.90 가 $139,998.9
+  // 로 잘려 보이던 F3 해소. KRW/JPY 는 decimals=0 이므로 자연히 정수만 노출.
   const formatted = value.toLocaleString('en-US', {
-    minimumFractionDigits: 0,
+    minimumFractionDigits: decimals,
     maximumFractionDigits: decimals,
   })
   return `${symbol}${formatted}`

--- a/src/views/documents/PIDetailPage.vue
+++ b/src/views/documents/PIDetailPage.vue
@@ -129,6 +129,9 @@ const summaryRows = computed(() => {
 
   return [
     { label: '거래처', value: detail.value.clientName },
+    // F2 — PI 상세 summary 에 바이어 라인 추가. 데이터(detail.value.buyerName) 는 이미
+    // poDocuments 와 동일하게 piDocuments 가 매핑해 주지만 템플릿에 필드가 없어 노출되지 않음.
+    { label: '바이어', value: detail.value.buyerName || detail.value.buyer || '-' },
     { label: '영업담당자', value: detail.value.manager || '-' },
     { label: '통화 / 총액', value: `${detail.value.currency} / ${detail.value.totalAmount}` },
     { label: '납기일', value: detail.value.deliveryDate || '-' },

--- a/src/views/documents/PODetailPage.vue
+++ b/src/views/documents/PODetailPage.vue
@@ -526,6 +526,9 @@ const summaryRows = computed(() => {
 
   return [
     { label: '거래처', value: detail.value.clientName },
+    // F2 — PO 상세에도 바이어 라인 추가. detail.value.buyer 는 이미 mapPoResponse 가
+    // PI 에서 승계된 값을 전달. 템플릿이 렌더링만 안 하고 있어 "-" 로 보이던 것.
+    { label: '바이어', value: detail.value.buyer || detail.value.buyerName || '-' },
     { label: '영업담당자', value: detail.value.manager || '-' },
     { label: '통화 / 총액', value: `${detail.value.currency} / ${detail.value.totalAmount}` },
     { label: '납기일', value: detail.value.deliveryDate || '-' },


### PR DESCRIPTION
## 📋 작업 내용

2026-04-20 저녁 브라우저 Claude QA 에서 찍어준 상위 FAIL 5건 일괄 수정.

| ID | severity | 파일 | 요약 |
|----|----------|------|------|
| F1 | P0 | stores/{ci,pl}Documents.js | backend `buyer` 필드 매핑 수정 |
| F2 | P0 | views/documents/{PI,PO}DetailPage.vue | summaryRows 에 바이어 라인 추가 |
| F3 | P1 | utils/currencyFormat.js | `$139,998.90` trailing zero 유지 |
| F4 | P1 | stores/ciDocuments.js | KRW 품목 라인 소수 자리수 currency-aware |
| **B4** | **P0 데이터 손실** | components/.../PIFormModal.vue | edit 모드 초기 진입 시 refreshAutoPricedItems 실행되어 stored 외화 unitPrice 가 (KRW master × 현재 환율) 로 덮여 저장 시 DB 오염. flag 로 초기 fire 스킵. |

## 연관 백엔드
- team2-backend-activity @ f7ff77d — **F5** email_logs.sentAt NULL 해소 (자동 PI 메일 수신 시각 기록).

## 🔗 관련 이슈
- closes #460

## ✅ 체크리스트
- [x] vite build 489 modules 성공
- [x] activity backend gradle compileJava 성공
- [x] main 최신 base

## 💬 리뷰어에게 / 운영 후속
1. **B4 는 데이터 손실 리스크 최우선** — 이 PR rollout 전 팀장 계정으로 외화 PI 를 "수정" 모달만 열고 닫은 적 있으면 저장까지 안 눌렀어도 이미 우려는 없음 (watch 는 저장 시 DB 쓰지 않고 폼 state 만 바꿈). 다만 rollout 후에도 같은 PI 를 실제로 "저장" 한 이력이 있으면 단가가 KRW master × 현재환율로 덮여있을 수 있어 Linux Claude 측 revision_history 에서 최근 "DRAFT_UPDATE" PI 후보 스캔 권장.
2. **백로그 별건 3종**: B1(PI 승인 검토 모달 품목 통화기호), B2(stale 미지정 결재 row SQL cleanup), B3(PO PDF UOM "E121A" 화이트리스트) — 다음 PR 묶음 대상.
3. **여전히 대기**: Issue D (item weight + PL 총중량) — 비즈니스 정책 결정 필요.