### PR TITLE
fix(#462): QA 백로그 B1·B3 (승인모달 통화기호·PDF UOM 화이트리스트)

### DIFF
--- a/src/components/domain/document/PODocumentTemplate.vue
+++ b/src/components/domain/document/PODocumentTemplate.vue
@@ -30,6 +30,15 @@ function extractIncotermPlace(value, namedPlace) {
 function resolvePiReference(linkedDocuments) {
   return linkedDocuments?.find((linkedDocument) => String(linkedDocument.id).startsWith('PI'))?.id || '-'
 }
+
+// B3 — item.unit 에 시드 오타("E121A") 같은 garbage 문자열이 그대로 통과해
+// PDF "UOM" 컬럼에 노출되던 문제. 허용 단위 화이트리스트로 검증, 맞지 않으면 'EA' 폴백.
+const ALLOWED_UOM = new Set(['EA', 'SET', 'PCS', 'BOX', 'PKG', 'KG', 'G', 'L', 'M', 'CM', 'MM'])
+function resolveUom(raw) {
+  const normalized = String(raw ?? '').trim().toUpperCase()
+  if (!normalized) return 'EA'
+  return ALLOWED_UOM.has(normalized) ? normalized : 'EA'
+}
 </script>
 
 <template>
@@ -124,7 +133,7 @@ function resolvePiReference(linkedDocuments) {
           <td class="text-center">{{ String(index + 1).padStart(3, '0') }}</td>
           <td>{{ item.name }}</td>
           <td class="text-center">{{ item.quantity }}</td>
-          <td class="text-center">{{ item.unit || 'EA' }}</td>
+          <td class="text-center">{{ resolveUom(item.unit) }}</td>
           <td class="text-right">{{ item.unitPrice }}</td>
           <td class="text-right font-semibold">{{ item.amount }}</td>
         </tr>

--- a/src/views/documents/PIPage.vue
+++ b/src/views/documents/PIPage.vue
@@ -60,6 +60,7 @@ import { createDocumentClientRows } from '@/utils/documentClientRows'
 import { formatIncotermsLabel, resolveIncotermState } from '@/utils/incoterms'
 import { clientSearchColumns, productSearchColumns } from '@/utils/searchModalColumns'
 import { buildSelectOptionsFromRows } from '@/utils/selectOptions'
+import { formatCurrencyAmount } from '@/utils/currencyFormat'
 
 const router = useRouter()
 const authStore = useAuthStore()
@@ -332,8 +333,10 @@ function parseAmount(value) {
 }
 
 function formatAmount(currency, value) {
-  const symbol = currencySymbolMap[currency] ?? `${currency} `
-  return `${symbol}${value.toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 2 })}`
+  // B1 — 승인 검토 모달 품목 라인에서 통화 기호 누락되던 버그(ss_0288tpb39 PI260024 등)
+  // 해소. 공용 formatCurrencyAmount 로 위임해 빈/누락 currency 도 USD 폴백(Issue #10),
+  // 통화별 소수 자릿수(Issue #2) 자동 적용.
+  return formatCurrencyAmount(value, currency)
 }
 
 function downloadPdf(row) {

--- a/src/views/documents/POPage.vue
+++ b/src/views/documents/POPage.vue
@@ -60,6 +60,7 @@ import {
 import { canMutateDocument } from '@/utils/documentOwnership'
 import { clientSearchColumns, productSearchColumns } from '@/utils/searchModalColumns'
 import { buildSelectOptionsFromRows } from '@/utils/selectOptions'
+import { formatCurrencyAmount } from '@/utils/currencyFormat'
 
 const router = useRouter()
 const authStore = useAuthStore()
@@ -335,9 +336,9 @@ function parseAmount(value) {
 }
 
 function formatAmount(currency, value) {
-  const symbolMap = { USD: '$', EUR: '€', JPY: '¥', KRW: '₩' }
-  const symbol = symbolMap[currency] ?? ''
-  return `${symbol}${Number(value || 0).toLocaleString()}`
+  // B1 — 승인 검토 모달 품목 라인 통화 기호·소수 자릿수 일관화. 공용 formatCurrencyAmount
+  // 로 위임 (Issue #2·#10 공통 픽스 경로).
+  return formatCurrencyAmount(value, currency)
 }
 
 function createComparableItem(item) {


### PR DESCRIPTION
## 📋 작업 내용
저녁 QA wave 의 신규 bug 후보 B1 / B3 정리. B2 (stale 결재 row) 는 루트 레포 일회성 SQL 로 별도 처리.

### B1 PI/PO 승인 검토 모달 품목 통화 기호
`views/documents/PIPage.vue` / `POPage.vue` 로컬 `formatAmount` → 공용 `utils/currencyFormat.js:formatCurrencyAmount` 위임.

### B3 PO PDF UOM garbage
`components/domain/document/PODocumentTemplate.vue` — `resolveUom(raw)` 헬퍼 + ALLOWED_UOM 화이트리스트. "E121A" 같은 시드 오타가 해외 거래처 발송 PDF 에 노출되던 것 차단.

## 연관 루트 레포
`ddl/migration_stale_approval_cleanup.sql` (B2) — 이미 main 푸시. Linux Claude 측에서 `USE team2_docs; SOURCE ...` 로 실행 예정.

## 🔗 관련 이슈
- closes #462

## ✅ 체크리스트
- [x] vite build 489 modules 성공
- [x] main 최신 base

## 💬 리뷰어에게
ALLOWED_UOM 에 누락된 단위(예: ROLL, TON 등) 가 있으면 추가 필요. 현재는 범용 단위 11종으로 커버.