### PR TITLE
feat(#464): Issue D PL 총중량 자동 + 컨택 전화번호 하이픈 자동

### DIFF
--- a/src/stores/poDocuments.js
+++ b/src/stores/poDocuments.js
@@ -41,6 +41,8 @@ function mapPoResponse(row) {
     unitPrice: String(item.unitPrice ?? 0),
     amount: String(item.amount ?? 0),
     remark: item.remark ?? '',
+    // Issue D — 수정 모달 재제출 시 kg 값 유지. 백엔드 응답에 itemWeight 필드가 포함되면 그대로 pass-through.
+    itemWeight: item.itemWeight ?? null,
   }))
 
   return {

--- a/src/views/contacts/ContactListPage.vue
+++ b/src/views/contacts/ContactListPage.vue
@@ -2,6 +2,7 @@
 import { computed, onMounted, ref } from 'vue'
 import { useToast } from '@/composables/useToast'
 import { fetchContacts, createContact, updateContact, deleteContact } from '@/api/contacts'
+import { applyPhoneMask } from '@/utils/phoneFormat'
 import BaseButton from '@/components/common/BaseButton.vue'
 import FormField from '@/components/common/FormField.vue'
 import BaseModal from '@/components/common/BaseModal.vue'
@@ -92,6 +93,12 @@ function openEdit(contact) {
 
 function closeForm() {
   isFormOpen.value = false
+}
+
+function onContactTelInput(value) {
+  // 숫자만 추출해서 하이픈 포맷 자동 적용. 길이에 따라 3-4-4 (한국 휴대) 또는
+  // 유연하게 ###-####-#### 마스크로 채움. 국가번호는 컨택에 필드가 없어 생략.
+  formTel.value = applyPhoneMask(value, '###-####-####')
 }
 
 function validate() {
@@ -267,7 +274,10 @@ async function handleDelete() {
           <BaseTextField v-model="formEmail" type="email" placeholder="hong@example.com" />
         </FormField>
         <FormField label="전화" :error="formErrors.contactTel">
-          <BaseTextField v-model="formTel" placeholder="010-1234-5678" />
+          <!-- 연락처 입력 편의성: 입력 중 숫자만 추출해 "###-####-####" 포맷으로 하이픈
+               자동 삽입. 컨택은 국가 필드가 없어 국가번호 자동은 생략 (Client/Buyer 폼
+               은 country 기반 prefix 자동). -->
+          <BaseTextField :model-value="formTel" placeholder="010-1234-5678" @update:modelValue="onContactTelInput" />
         </FormField>
       </form>
       <template #footer>

--- a/src/views/documents/PODetailPage.vue
+++ b/src/views/documents/PODetailPage.vue
@@ -695,6 +695,8 @@ function buildManagerUpdatePoPayload(formValue) {
     unitPrice: Number(item.unitPrice ?? 0) || 0,
     amount: Number(item.amount ?? 0) || 0,
     remark: item.remark ?? '',
+    // Issue D — 팀장 수정 시에도 기존 PO 의 itemWeight 를 보존해 PL 재계산이 빗나가지 않게.
+    itemWeight: item.itemWeight != null ? Number(item.itemWeight) : null,
   }))
   const totalAmount = mappedItems.reduce((sum, item) => sum + (Number(item.amount) || 0), 0)
   return {

--- a/src/views/documents/POPage.vue
+++ b/src/views/documents/POPage.vue
@@ -475,6 +475,15 @@ function findItemIdByName(name) {
   return match?.itemId ?? match?.id ?? null
 }
 
+// Issue D — master.items.item_weight(kg) 을 PO 생성 payload 스냅샷에 포함시키기
+// 위해 품목명으로 조회. 스냅샷 후 master 가 바뀌어도 PL 총중량은 PO 시점 값 고정.
+function findItemWeightByName(name) {
+  if (!name) return null
+  const match = itemCatalog.value.find((item) => (item.itemName ?? item.name) === name)
+  const raw = match?.itemWeight ?? match?.weight ?? null
+  return raw == null || raw === '' ? null : Number(raw)
+}
+
 /**
  * POFormModal @save payload 를 백엔드 PurchaseOrderCreateRequest DTO 로 매핑.
  * PO 는 연결 PI 가 이미 거래처 통화로 변환·저장해 둔 외화 단가/금액을 그대로 승계한다.
@@ -502,6 +511,8 @@ function buildCreatePayload(formValue) {
       unitPrice,
       amount,
       remark: item.remark ?? '',
+      // Issue D — master.items.item_weight(kg) 스냅샷. PL 자동생성 총중량 계산에 사용.
+      itemWeight: findItemWeightByName(item.name),
     }
   })
 


### PR DESCRIPTION
## 📋 작업 내용

### 1. Issue D — PL 총중량 자동 산출 (백로그 해결, kg 단위 통일)
- POPage / PODetailPage 의 payload 에 `itemWeight` 포함. master.items 카탈로그에서 name 기반 lookup.
- poDocuments.js items 매핑에 itemWeight pass-through (재제출 시 보존).
- ItemFormModal 의 weight 입력·validation·NUM_RANGE.WEIGHT_MAX 는 **이미 구현돼 있음** 확인.

### 2. 컨택 전화번호 하이픈 자동
- ContactListPage 의 전화 입력에 `applyPhoneMask` 적용 (`###-####-####`).
- Client/Buyer 는 기존 `formatPhoneInput` 으로 국가번호 prefix 자동까지 지원 중.

## 연관 (별도 main 푸시)
- **team2-backend-documents @ 6a09481** — PurchaseOrderItem.po_item_weight, PackingListRepository SUM 서브쿼리, items_snapshot JSON 에 itemWeight.
- **루트 @ 0b3a0d3** — DDL + `migration_po_item_weight.sql` (ALTER + master 백필 + PL 재계산).

## 🔗 관련 이슈
- closes #464

## ✅ 체크리스트
- [x] vite build 489 modules
- [x] gradle build 성공
- [x] main 최신 base

## 💬 운영 후속
1. PR 머지 + 백엔드 rollout (argoCD auto)
2. Linux Claude 측에서 `migration_po_item_weight.sql` 실행 — master 기반 백필 + PL 재계산까지 한 세션.
3. 브라우저 Claude QA — PL 상세 총중량 표시·단위 kg·신규 PI→PO→PL 체인 산출 확인.