### PR TITLE
feat(#468): AWS S3 + CloudFront 배포 파이프라인

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=/api

--- a/.github/workflows/deploy-s3.yml
+++ b/.github/workflows/deploy-s3.yml
@@ -1,0 +1,52 @@
+name: Deploy frontend to S3 + CloudFront
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-prod-frontend
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::392484366116:role/GHA-Frontend-Deploy
+          aws-region: ap-northeast-2
+
+      - name: Sync immutable assets (1y cache)
+        run: |
+          aws s3 sync ./dist s3://team2-frontend-prod --delete \
+            --cache-control "public,max-age=31536000,immutable" \
+            --exclude "index.html"
+
+      - name: Upload index.html (no-cache)
+        run: |
+          aws s3 cp ./dist/index.html s3://team2-frontend-prod/index.html \
+            --cache-control "no-store,no-cache,must-revalidate" \
+            --content-type "text/html; charset=utf-8"
+
+      - name: Invalidate CloudFront index + root
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id E1NUT5BB6DLB2G \
+            --paths "/index.html" "/"


### PR DESCRIPTION
## 📋 작업 내용

AWS 마이그레이션의 프론트엔드 배포 경로 전환. k3s nginx Deployment 대신 S3 + CloudFront 로 SPA 서빙.

- `.env.production` 에 `VITE_API_BASE_URL=/api` 명시 (CloudFront same-origin)
- `.github/workflows/deploy-s3.yml` — OIDC AssumeRole → `aws s3 sync` → CloudFront invalidation
- 불변 에셋은 1년 immutable, `index.html` 은 no-cache (청크 불일치 방지)
- invalidation 은 `/index.html` + `/` 두 경로만 (해시 파일명은 불필요)

## 🔗 관련 이슈

- closes #468

## 📸 스크린샷 (선택)

N/A — 인프라 파이프라인 변경.

## ✅ 체크리스트

- [x] 정상 동작 확인 (merge 후 actions 가 최초 배포, CloudFront → S3 origin 로 index.html 서빙 검증)
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

- OIDC Trust 조건: `repo:hanhwa-swcamp-22th-final/team2-frontend:ref:refs/heads/main` → **main 직접 푸시 시에만** Role 사용 가능. PR 브랜치 머지 후 main 푸시로 자동 트리거.
- CloudFront `/api/*` behavior 는 Console 팀이 ALB origin 추가 후 설정 예정. 이 PR merge 전이라도 S3 origin 만으로 정적 서빙은 동작.
- Role ARN, S3 bucket, Dist ID 는 모두 workflow 파일에 하드코딩 — 스코프가 단일 프로젝트 단일 환경이라 환경변수화 불필요.