### PR TITLE
fix(#470): 시연 블로커 hotfix — CI/PL 메일 발송 + 패키지 validation 토스트

### DIFF
--- a/src/components/domain/document/SendDocumentEmailModal.vue
+++ b/src/components/domain/document/SendDocumentEmailModal.vue
@@ -31,12 +31,15 @@ const recipientEmail = ref('')
 const subject = ref('')
 const submitting = ref(false)
 
+// clientId 가 0/null 이라도 수신자 이메일·제목만 있으면 발송 허용한다.
+// (과거 빌드에서 생성된 PO/CI/PL 은 ClientResponse.id 필드 명명 버그로 clientId=0 로 저장됐는데,
+//  모달이 clientId 존재를 강제하면 그 문서들 메일 발송이 영구 차단됨. 이미 확정된 문서라
+//  이메일 자체는 첨부 PDF·수신자 기준으로 내보낼 수 있어야 한다. 2026-04-21)
 const canSubmit = computed(
   () =>
     !submitting.value &&
     !!recipientEmail.value.trim() &&
-    !!subject.value.trim() &&
-    !!props.clientId,
+    !!subject.value.trim(),
 )
 
 // 외국 거래처 대상이 기본이므로 제목 템플릿은 영문으로 기본화한다 (Issue F).
@@ -71,15 +74,13 @@ function handleClose() {
 
 async function handleSubmit() {
   if (!canSubmit.value) return
-  if (!props.clientId) {
-    toast.error('거래처 정보가 없어 메일을 발송할 수 없습니다.')
-    return
-  }
 
   submitting.value = true
   try {
     const payload = {
-      clientId: Number(props.clientId),
+      // clientId 가 비어있는 과거 문서도 발송 가능하도록 0 으로 fallback.
+      // 백엔드 EmailSendRequest 는 @NotNull 이라 0 은 통과(로그에 clientId=0 기록).
+      clientId: props.clientId ? Number(props.clientId) : 0,
       poId: props.poId || undefined,
       emailTitle: subject.value.trim(),
       emailRecipientName: recipientName.value.trim() || undefined,
@@ -145,8 +146,8 @@ async function handleSubmit() {
 
       <div class="rounded-lg bg-slate-50 p-3 text-xs text-slate-500">
         <p>첨부 파일은 서버에서 자동으로 생성되어 첨부됩니다 ({{ docType }} PDF).</p>
-        <p v-if="!clientId" class="mt-1 text-rose-500">
-          ⚠ 거래처 정보가 없어 발송할 수 없습니다.
+        <p v-if="!clientId" class="mt-1 text-amber-600">
+          ⚠ 거래처 ID 가 문서에 기록되어 있지 않습니다. 메일은 발송되지만 이력에 거래처 연결이 누락될 수 있습니다.
         </p>
       </div>
     </div>

--- a/src/views/package/ActivityPackagePage.vue
+++ b/src/views/package/ActivityPackagePage.vue
@@ -362,7 +362,10 @@ const summaryText = computed(() => {
 // ── 저장 ───────────────────────────────────────────────────
 async function savePackage() {
   if (!validate()) {
-    warning('입력 내용을 확인해주세요.')
+    // 구체적 누락 필드를 토스트에 노출 — "입력 내용을 확인해주세요" 만으로는
+    // 사용자가 뭘 빠뜨렸는지 몰라 재시도가 어려웠음 (2026-04-21 시연 피드백).
+    const messages = Object.values(errors.value).filter(Boolean)
+    warning(messages.length ? messages.join(' / ') : '입력 내용을 확인해주세요.')
     return
   }
 


### PR DESCRIPTION
## 📋 작업 내용

2026-04-21 시연 E2E 테스트 블로커 중 프론트 측 보정.

### 1) SendDocumentEmailModal.vue
- \`canSubmit\` 조건에서 \`!!props.clientId\` 제거. 과거 빌드 버그(백엔드 ClientResponse.id vs 프론트 clientId 불일치)로 CI260013/PL260013 등 이미 저장된 문서의 clientId=0 이라 메일 발송이 영구 차단되던 문제를 해결.
- 발송 자체는 허용하되, clientId 누락 시 경고 문구를 "발송 가능 · 로그에 거래처 연결 누락 가능"으로 톤다운.
- payload clientId 는 \`props.clientId ? Number(props.clientId) : 0\` 으로 fallback. 백엔드 EmailSendRequest 는 \`@NotNull Long\` 이므로 0 은 통과.

### 2) ActivityPackagePage.vue
- \`savePackage()\` 의 validation 실패 토스트 "입력 내용을 확인해주세요" 만 뜨던 것을 \`Object.values(errors).filter(Boolean).join(' / ')\` 로 구체 필드별 메시지 조합. 사용자가 어떤 필드가 잘못됐는지 즉시 파악 가능.

## 🔗 관련 이슈

- closes #470

## 📸 스크린샷 (선택)

N/A — 토스트 메시지 변화 + 발송 버튼 활성화 조건 변경.

## ✅ 체크리스트

- [x] 정상 동작 확인 (로컬 dev 서버에서 기존 E2E 흐름 재현 후 메일 발송 모달 열기/닫기 + 패키지 폼 validation 실패 케이스 검증)
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

- 이 PR 은 **근본 원인 fix 가 아닌 호환성 보정**. 근본 원인은 \`team2-backend-master\` \`813d0f1\` 에서 ClientResponse.getClientId() 별칭 추가로 해결됨. 따라서 신규 생성되는 PO/CI/PL 은 이 프론트 fix 가 없어도 메일 발송이 정상 동작.
- 과거 DB 에 clientId=0 로 저장된 문서는 이 fix 없이는 영구 차단되므로, 데모/운영 데이터 호환성을 위해 포함.
- \`team2-backend-auth\` \`779a5c9\` 에서 AWS STS 의존성 추가로 도장 업로드(S3 PutObject) 403 동시 해결.