### PR TITLE
fix(#472): Inactive 필터 + 상태 컬럼 숨김 + PDF 직인 렌더링

### DIFF
--- a/src/components/domain/auth/UserFormModal.vue
+++ b/src/components/domain/auth/UserFormModal.vue
@@ -220,9 +220,8 @@ const currentTeamName = computed(() => {
       </div>
 
       <template v-if="mode === 'edit'">
-        <FormField label="상태">
-          <BaseSelect v-model="form.status" :options="statusOptions" />
-        </FormField>
+        <!-- 상태 필드는 UI 에서 숨김 — 신규 = active, "삭제" 버튼이 퇴직 처리 담당.
+             form.status 는 submit 시 기존 값 그대로 유지됨 (undefined 방지). -->
 
         <div class="space-y-2 rounded-xl border border-slate-200 bg-slate-50/50 p-4">
           <p class="text-xs text-slate-500">

--- a/src/components/domain/auth/UserListTab.vue
+++ b/src/components/domain/auth/UserListTab.vue
@@ -80,7 +80,10 @@ const deleting = ref(false)
 
 // department → team → users 트리 구성
 const tree = computed(() => {
-  let filtered = users.value
+  // 퇴직(retired) 사용자는 트리에서 자동 제외. 복직은 별도 API 로 status 'active' 복구.
+  let filtered = users.value.filter(
+    (u) => String(u.userStatus ?? 'active').toLowerCase() !== 'retired',
+  )
   if (searchKeyword.value) {
     const kw = searchKeyword.value.toLowerCase()
     filtered = filtered.filter(
@@ -171,7 +174,7 @@ const userColumns = [
   { key: 'employeeNo', label: '사번', width: '120px' },
   { key: 'userName', label: '이름', width: '200px' },
   { key: 'userEmail', label: '이메일' },
-  { key: 'status', label: '상태', width: '100px', align: 'center' },
+  // 상태(status) 컬럼 숨김 — 퇴직자는 tree 에서 자동 제외, 재직자만 노출.
   { key: 'actions', label: '', width: '140px', align: 'center', sortable: false },
 ]
 
@@ -324,12 +327,6 @@ defineExpose({ openCreateModal })
                       <p class="text-xs text-slate-400">{{ row.positionName || positionMap[row.positionId] || '' }}</p>
                     </div>
                   </div>
-                </template>
-                <template #cell-status="{ row }">
-                  <StatusBadge
-                    :value="label(USER_STATUS_LABEL, row.userStatus)"
-                    :variant="row.userStatus === 'active' ? 'active' : 'inactive'"
-                  />
                 </template>
                 <template #cell-actions="{ row }">
                   <TableActions

--- a/src/components/domain/document/CIDocumentTemplate.vue
+++ b/src/components/domain/document/CIDocumentTemplate.vue
@@ -8,6 +8,7 @@ import {
   resolveShipperAddress,
   resolveShipperName,
 } from '@/utils/ciplTemplate'
+import { useCompany } from '@/stores/company'
 
 const props = defineProps({
   document: {
@@ -20,6 +21,11 @@ const invoiceItems = computed(() => normalizeCIItems(props.document?.items))
 const itemCount = computed(() => invoiceItems.value.length)
 const consigneeAttention = computed(() => resolveConsigneeAttention(props.document))
 const currencyCode = computed(() => props.document?.currency || 'USD')
+
+// 자사 도장 이미지 — 발행 문서의 서명란 우측에 합성. 자사정보 탭에서 업로드된
+// companySealImageUrl 을 그대로 사용 (CloudFront cdn URL).
+const company = useCompany()
+const companySealUrl = computed(() => company.value?.companySealImageUrl || '')
 </script>
 
 <template>
@@ -159,6 +165,13 @@ const currencyCode = computed(() => props.document?.currency || 'USD')
       <div class="signature-line-row">
         <span class="signed-label">Signed by</span>
         <span class="signed-line"></span>
+        <img
+          v-if="companySealUrl"
+          :src="companySealUrl"
+          alt="Company Seal"
+          class="company-seal"
+          crossorigin="anonymous"
+        />
       </div>
     </div>
   </div>
@@ -380,6 +393,18 @@ const currencyCode = computed(() => props.document?.currency || 'USD')
   display: inline-block;
   width: 230px;
   border-bottom: 1px solid #000;
+}
+
+/* 자사 도장 — 서명란 우측 상단에 겹쳐 반투명 합성. 40% opacity 로 실인장 느낌. */
+.company-seal {
+  position: relative;
+  width: 68px;
+  height: 68px;
+  object-fit: contain;
+  margin-left: -80px;
+  margin-bottom: -10px;
+  opacity: 0.7;
+  mix-blend-mode: multiply;
 }
 
 .accent-red,

--- a/src/components/domain/document/PIDocumentTemplate.vue
+++ b/src/components/domain/document/PIDocumentTemplate.vue
@@ -6,8 +6,10 @@
  * 구조: From(수출자) / To(수입자) + 문서 메타 + 배송조건 + 품목 테이블 + 합계
  */
 import DocumentPrintLayout from './DocumentPrintLayout.vue'
+import { computed } from 'vue'
 import { resolveConsigneeAddress } from '@/utils/ciplTemplate'
 import { normalizeIncoterms } from '@/utils/incoterms'
+import { useCompany } from '@/stores/company'
 
 defineProps({
   // 문서 전체 데이터 객체
@@ -16,6 +18,9 @@ defineProps({
     required: true,
   },
 })
+
+const company = useCompany()
+const companySealUrl = computed(() => company.value?.companySealImageUrl || '')
 
 function extractIncotermCode(value, namedPlace) {
   return normalizeIncoterms(value, namedPlace).code || '-'
@@ -139,6 +144,13 @@ function resolveItemQuantity(item) {
         <div class="signature-box">
           <div class="signature-line"></div>
           <p>Authorized Signature</p>
+          <img
+            v-if="companySealUrl"
+            :src="companySealUrl"
+            alt="Company Seal"
+            class="company-seal"
+            crossorigin="anonymous"
+          />
         </div>
       </div>
     </template>
@@ -252,6 +264,7 @@ function resolveItemQuantity(item) {
 .signature-box {
   text-align: center;
   width: 220px;
+  position: relative;
 }
 .signature-line {
   border-bottom: 1px solid #0f172a;
@@ -263,5 +276,16 @@ function resolveItemQuantity(item) {
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: #64748b;
+}
+.company-seal {
+  position: absolute;
+  right: 10px;
+  top: 4px;
+  width: 72px;
+  height: 72px;
+  object-fit: contain;
+  opacity: 0.7;
+  mix-blend-mode: multiply;
+  pointer-events: none;
 }
 </style>

--- a/src/components/domain/document/PLDocumentTemplate.vue
+++ b/src/components/domain/document/PLDocumentTemplate.vue
@@ -8,6 +8,7 @@ import {
   resolveShipperAddress,
   resolveShipperName,
 } from '@/utils/ciplTemplate'
+import { useCompany } from '@/stores/company'
 
 const props = defineProps({
   document: {
@@ -19,6 +20,9 @@ const props = defineProps({
 const packingItems = computed(() => normalizePLItems(props.document?.items))
 const itemCount = computed(() => packingItems.value.length)
 const consigneeAttention = computed(() => resolveConsigneeAttention(props.document))
+
+const company = useCompany()
+const companySealUrl = computed(() => company.value?.companySealImageUrl || '')
 </script>
 
 <template>
@@ -161,6 +165,13 @@ const consigneeAttention = computed(() => resolveConsigneeAttention(props.docume
       <div class="signature-line-row">
         <span class="signed-label">Signed by</span>
         <span class="signed-line"></span>
+        <img
+          v-if="companySealUrl"
+          :src="companySealUrl"
+          alt="Company Seal"
+          class="company-seal"
+          crossorigin="anonymous"
+        />
       </div>
     </div>
   </div>
@@ -383,6 +394,17 @@ const consigneeAttention = computed(() => resolveConsigneeAttention(props.docume
   display: inline-block;
   width: 230px;
   border-bottom: 1px solid #000;
+}
+
+.company-seal {
+  position: relative;
+  width: 68px;
+  height: 68px;
+  object-fit: contain;
+  margin-left: -80px;
+  margin-bottom: -10px;
+  opacity: 0.7;
+  mix-blend-mode: multiply;
 }
 
 .accent-red,

--- a/src/components/domain/document/PODocumentTemplate.vue
+++ b/src/components/domain/document/PODocumentTemplate.vue
@@ -9,8 +9,10 @@
  *       + 품목 테이블 + Total
  */
 import DocumentPrintLayout from './DocumentPrintLayout.vue'
+import { computed } from 'vue'
 import { resolveConsigneeAddress } from '@/utils/ciplTemplate'
 import { normalizeIncoterms } from '@/utils/incoterms'
+import { useCompany } from '@/stores/company'
 
 defineProps({
   document: {
@@ -18,6 +20,9 @@ defineProps({
     required: true,
   },
 })
+
+const company = useCompany()
+const companySealUrl = computed(() => company.value?.companySealImageUrl || '')
 
 function extractIncotermCode(value, namedPlace) {
   return normalizeIncoterms(value, namedPlace).code || '-'
@@ -149,6 +154,21 @@ function resolveUom(raw) {
         </tr>
       </tfoot>
     </table>
+
+    <!-- ── 서명 / 자사 직인 ── -->
+    <div class="po-signature">
+      <div class="signature-box">
+        <div class="signature-line"></div>
+        <p>Authorized Signature</p>
+        <img
+          v-if="companySealUrl"
+          :src="companySealUrl"
+          alt="Company Seal"
+          class="company-seal"
+          crossorigin="anonymous"
+        />
+      </div>
+    </div>
   </DocumentPrintLayout>
 </template>
 
@@ -240,4 +260,40 @@ function resolveUom(raw) {
 .text-right { text-align: right; }
 .font-semibold { font-weight: 600; }
 .font-bold { font-weight: 700; }
+
+/* ── 서명 / 직인 ── */
+.po-signature {
+  margin-top: 42px;
+  padding-top: 12px;
+  border-top: 1px solid #cbd5e1;
+  display: flex;
+  justify-content: flex-end;
+}
+.signature-box {
+  text-align: center;
+  width: 220px;
+  position: relative;
+}
+.signature-line {
+  border-bottom: 1px solid #0f172a;
+  height: 58px;
+}
+.signature-box p {
+  margin: 8px 0 0;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #64748b;
+}
+.company-seal {
+  position: absolute;
+  right: 10px;
+  top: 4px;
+  width: 72px;
+  height: 72px;
+  object-fit: contain;
+  opacity: 0.7;
+  mix-blend-mode: multiply;
+  pointer-events: none;
+}
 </style>

--- a/src/components/domain/master/ItemFormModal.vue
+++ b/src/components/domain/master/ItemFormModal.vue
@@ -275,9 +275,8 @@ function handleSave() {
             <BaseTextField v-model="form.hsCode" placeholder="HS Code를 입력하세요" />
             <p v-if="errors.hsCode" class="mt-1 text-xs text-red-500">{{ errors.hsCode }}</p>
           </FormField>
-          <FormField label="상태">
-            <BaseSelect v-model="form.status" :options="statusOptions" placeholder="상태를 선택하세요" />
-          </FormField>
+          <!-- 상태 필드는 UI 에서 숨김 — 신규 = active, 삭제 버튼이 soft-delete(inactive) 담당.
+               ADMIN 이 재활성화 필요하면 별도 REST API (PATCH /api/items/{id}/status) 호출. -->
         </div>
       </div>
     </form>

--- a/src/stores/company.js
+++ b/src/stores/company.js
@@ -1,0 +1,40 @@
+// 자사정보(회사명/주소/TEL/도장 이미지 URL) 전역 캐시 store.
+// 문서 템플릿(PI/PO/CI/PL)이 발행 시점에 도장을 합성하려면 companySealImageUrl 이
+// 필요한데, 매 템플릿 마운트마다 /api/company 를 재호출하는 건 낭비라 Pinia 스타일
+// 경량 store 로 한 번만 로드하고 재사용한다. 도장 재업로드 시 refreshCompany() 호출.
+
+import { ref } from 'vue'
+import { fetchCompany as fetchCompanyApi } from '@/api/auth'
+
+const company = ref(null)
+let loadingPromise = null
+
+export async function loadCompany() {
+  if (company.value) return company.value
+  if (loadingPromise) return loadingPromise
+  loadingPromise = (async () => {
+    try {
+      const data = await fetchCompanyApi()
+      company.value = data
+      return data
+    } catch (e) {
+      console.error('Failed to load company info:', e)
+      return null
+    } finally {
+      loadingPromise = null
+    }
+  })()
+  return loadingPromise
+}
+
+export async function refreshCompany() {
+  company.value = null
+  return loadCompany()
+}
+
+export function useCompany() {
+  if (!company.value && !loadingPromise) {
+    loadCompany()
+  }
+  return company
+}

--- a/src/views/master/ClientListPage.vue
+++ b/src/views/master/ClientListPage.vue
@@ -84,7 +84,8 @@ const columns = [
   { key: 'currency', label: '통화', width: '80px', align: 'center' },
   { key: 'clientManager', label: '거래처 담당자', width: '140px' },
   { key: 'teamLabel', label: '담당 팀', width: '130px' },
-  { key: 'clientStatus', label: '상태', width: '80px', align: 'center' },
+  // 상태(clientStatus) 컬럼은 시연/운영 UX 상 숨긴다 — 삭제=비활성화(soft delete) 로
+  // 취급하므로 활성만 목록에 노출되고, 비활성 행은 filteredClients 에서 자동 제외.
   { key: 'actions', label: '', width: '120px', align: 'center', sortable: false },
 ]
 
@@ -122,7 +123,11 @@ function searchRows() {
 }
 
 const filteredClients = computed(() => {
-  let result = enrichedClients.value
+  // 비활성(inactive) 거래처는 그리드에서 자동 제외. 삭제 = status 'inactive' soft-delete 이므로
+  // 삭제된 거래처가 리스트에 계속 보이는 현상을 막는다. ADMIN 이 복구 필요한 경우는 별도 API.
+  let result = enrichedClients.value.filter(
+    (c) => String(c.clientStatus ?? 'active').toLowerCase() !== 'inactive',
+  )
 
   // RBAC: 영업 사용자는 자기 팀 거래처만 표시 (팀→부서는 역참조)
   if (!isAdmin.value && currentUser.value?.role === 'sales') {
@@ -299,14 +304,6 @@ function goToDetail(row) {
           <FormField label="담당자">
             <BaseTextField v-model="filters.manager" placeholder="담당자명..." />
           </FormField>
-
-          <FormField label="상태">
-            <SearchableCombobox
-              v-model="filters.status"
-              :options="statusOptions"
-              placeholder="상태 선택..."
-            />
-          </FormField>
         </div>
 
         <div class="mt-2 flex items-center justify-end gap-2 border-t border-slate-100 pt-3">
@@ -362,10 +359,6 @@ function goToDetail(row) {
 
       <template #cell-currency="{ row }">
         {{ row.currencyCode }}
-      </template>
-
-      <template #cell-clientStatus="{ row }">
-        <StatusBadge :value="label(CLIENT_STATUS_LABEL, row.clientStatus)" />
       </template>
 
       <template #cell-actions="{ row }">

--- a/src/views/master/ItemListPage.vue
+++ b/src/views/master/ItemListPage.vue
@@ -94,7 +94,7 @@ const columns = computed(() => {
     { key: 'itemUnitPrice', label: '단가 (KRW)', width: '140px', align: 'right' },
     { key: 'itemWeight', label: '중량 (kg)', width: '110px', align: 'right' },
     { key: 'itemHsCode', label: 'HS Code', width: '100px', align: 'center' },
-    { key: 'itemStatus', label: '상태', width: '80px', align: 'center' },
+    // 상태 컬럼 숨김 — 삭제=비활성화 soft-delete, 비활성 품목은 filteredItems 에서 자동 제외.
   ]
   if (isItemAdmin.value) {
     base.push({ key: 'actions', label: '', width: '120px', align: 'center', sortable: false })
@@ -103,7 +103,10 @@ const columns = computed(() => {
 })
 
 const filteredItems = computed(() => {
-  let result = items.value
+  // 비활성 품목은 자동 제외 (삭제=soft delete 패턴).
+  let result = items.value.filter(
+    (i) => String(i.itemStatus ?? 'active').toLowerCase() !== 'inactive',
+  )
   const f = appliedFilters.value
 
   if (f.keyword) {
@@ -267,13 +270,6 @@ function goToDetail(row) {
             />
           </FormField>
 
-          <FormField label="상태">
-            <SearchableCombobox
-              v-model="filters.status"
-              :options="statusOptions"
-              placeholder="상태 선택..."
-            />
-          </FormField>
         </div>
 
         <div class="mt-2 flex items-center justify-end gap-2 border-t border-slate-100 pt-3">
@@ -326,10 +322,6 @@ function goToDetail(row) {
 
       <template #cell-itemWeight="{ row }">
         {{ row.itemWeight?.toLocaleString() ?? '-' }}
-      </template>
-
-      <template #cell-itemStatus="{ row }">
-        <StatusBadge :value="label(ITEM_STATUS_LABEL, row.itemStatus)" />
       </template>
 
       <template #cell-actions="{ row }">


### PR DESCRIPTION
## 📋 작업 내용

시연 영상 녹화 전 UX 정리 + 자사 도장 PDF 합성 구현.

### Inactive 필터 + 상태 숨김 (5 파일)
- **ClientListPage.vue / ItemListPage.vue**: 상태 컬럼 제거, 상태 필터 드롭다운 제거, inactive 자동 제외 필터 추가
- **UserListTab.vue**: 상태 컬럼 + cell 템플릿 제거, tree 에 retired 자동 제외
- **ItemFormModal.vue / UserFormModal.vue**: 상태 select 필드 제거 (신규=active 자동, form.status 는 form 바인딩 유지)

삭제 흐름은 그대로 — \"삭제\" 버튼이 \`changeClientStatus / changeItemStatus / changeUserStatus\` 호출해 soft-delete 처리, 다음 tick 에 리스트에서 자동 사라짐.

### PDF 도장 합성 (5 파일)
- **stores/company.js** (신규): \`useCompany()\` 컴포저블. /api/company 1회 fetch 후 companySealImageUrl 공유.
- **PI/PO/CI/PL DocumentTemplate**: 서명란/하단에 \`<img class=\"company-seal\">\` 조건부 렌더. \`opacity: 0.7\` + \`mix-blend-mode: multiply\` 로 도장 실인장 느낌.

## 🔗 관련 이슈

- closes #472

## 📸 스크린샷 (선택)

N/A — 스크린샷은 브라우저 시연 테스트 시 수동 캡쳐.

## ✅ 체크리스트

- [x] 정상 동작 확인 (로컬 dev 서버에서 거래처/품목/사용자 리스트 및 폼, PI/PO/CI/PL 상세 프린트 미리보기)
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

- **검색/필터/페이지네이션은 현재 전부 클라이언트 사이드**. 대량 데이터 환경에선 개선 필요하지만 시연 스코프 밖이라 D+7 쿨다운 후 별건 이슈 예정.
- **거래처 인장 컬럼**은 현재 DDL/Entity 에 없어서 이번 PR 에 미포함. 필요 시 DDL add → Entity → Repo → DTO → Form 순서로 별건 추가.
- **도장 이미지 CORS**: cdn.salesboost-team2.site 에서 서빙되는 이미지를 \`crossorigin=\"anonymous\"\` 로 로드. 브라우저 인쇄 미리보기에선 정상 렌더. html2canvas 기반 PDF 래스터화 시 S3/CloudFront 에서 CORS 헤더가 필요할 수 있어 별도 검증 권장.