### PR TITLE
fix(#474): PO clientId=0 블로커 진짜 뿌리 + 동명이인 식별 + seal CORS

### DIFF
--- a/src/components/domain/document/CIDocumentTemplate.vue
+++ b/src/components/domain/document/CIDocumentTemplate.vue
@@ -170,7 +170,6 @@ const companySealUrl = computed(() => company.value?.companySealImageUrl || '')
           :src="companySealUrl"
           alt="Company Seal"
           class="company-seal"
-          crossorigin="anonymous"
         />
       </div>
     </div>

--- a/src/components/domain/document/PIDocumentTemplate.vue
+++ b/src/components/domain/document/PIDocumentTemplate.vue
@@ -149,7 +149,6 @@ function resolveItemQuantity(item) {
             :src="companySealUrl"
             alt="Company Seal"
             class="company-seal"
-            crossorigin="anonymous"
           />
         </div>
       </div>

--- a/src/components/domain/document/PLDocumentTemplate.vue
+++ b/src/components/domain/document/PLDocumentTemplate.vue
@@ -170,7 +170,6 @@ const companySealUrl = computed(() => company.value?.companySealImageUrl || '')
           :src="companySealUrl"
           alt="Company Seal"
           class="company-seal"
-          crossorigin="anonymous"
         />
       </div>
     </div>

--- a/src/components/domain/document/PODocumentTemplate.vue
+++ b/src/components/domain/document/PODocumentTemplate.vue
@@ -165,7 +165,6 @@ function resolveUom(raw) {
           :src="companySealUrl"
           alt="Company Seal"
           class="company-seal"
-          crossorigin="anonymous"
         />
       </div>
     </div>

--- a/src/composables/useSearchModalLookups.js
+++ b/src/composables/useSearchModalLookups.js
@@ -21,6 +21,13 @@ export function useSearchModalLookups() {
 
       clientRowsSource.value = clientsData.map((client) => ({
         id: String(client.clientId),
+        // 소비자(POPage 등)가 numeric clientId 를 기대. id 를 문자열로 쓰는 코드와
+        // 공존시키기 위해 clientId 를 별도 필드로도 보존. 이 매핑이 clientId 를 버려서
+        // PO 생성 payload 의 clientId 가 null → 백엔드 0 fallback → 하류 CI/PL/활동-PO
+        // 매칭 전부 깨지던 블로커 (시연 2026-04-21 재현). email 필드도 CI/PL 메일 모달
+        // default-recipient-email 로 쓰므로 포함.
+        clientId: client.clientId ?? null,
+        clientEmail: client.clientEmail ?? '',
         code: client.clientCode ?? '-',
         name: client.clientName ?? '-',
         country: client.countryName ?? '-',
@@ -30,12 +37,14 @@ export function useSearchModalLookups() {
 
       productRowsSource.value = itemsData.map((item) => ({
         id: String(item.itemId),
+        itemId: item.itemId ?? null,
         code: item.itemCode ?? '-',
         name: item.itemName ?? '-',
         nameKr: item.itemNameKr ?? '-',
         spec: item.itemSpec ?? '-',
         unit: item.itemUnit ?? '-',
         unitPrice: item.itemUnitPrice ?? 0,
+        weight: item.itemWeight ?? 0,
         category: item.itemCategory ?? '-',
         status: item.itemStatus ?? '-',
       }))

--- a/src/views/activity/ActivityCreatePage.vue
+++ b/src/views/activity/ActivityCreatePage.vue
@@ -51,7 +51,13 @@ const clientOptions = ref([])
 onMounted(async () => {
   try {
     const data = await fetchClients()
-    clientOptions.value = data.map((c) => ({ label: `${c.clientName} (${c.clientNameKr})`, value: c.clientId }))
+    // clientCode 를 라벨에 포함해 동명이인 거래처 식별 가능. 비활성은 제외.
+    clientOptions.value = data
+      .filter((c) => String(c.clientStatus ?? 'active').toLowerCase() !== 'inactive')
+      .map((c) => ({
+        label: `[${c.clientCode}] ${c.clientName}${c.clientNameKr ? ` (${c.clientNameKr})` : ''}`,
+        value: c.clientId,
+      }))
   } catch (e) {
     console.error('거래처 목록 로드 실패', e)
     error('거래처 목록을 불러오지 못했습니다. 페이지를 새로고침해주세요.')


### PR DESCRIPTION
## 📋 작업 내용

이전 PR #471/#473 만으로 해결 안 된 시연 블로커 재조사 결과 발견한 **진짜 뿌리**.

### Bug 1 (Critical) — POPage matchedClient.clientId 소실
- \`useSearchModalLookups\` 의 client 매핑이 API 응답을 \`{ id, code, name, country, city, status }\` 로 재구성하며 **\`clientId\` 필드를 drop**
- POPage.vue L433: \`matchedClient.clientId\` → \`undefined\` → payload \`clientId: null\` → 백엔드 \`request.clientId() == null ? 0\` → **PO260015 clientId=0** → CI260014/PL260014 까지 inherit
- 결과: 메일 발송 모달 경고, 활동-PO 검색 0건, 패키지 생성 불가 전부 이 뿌리 한 줄에서 파생.
- 수정: 매핑 결과에 \`clientId\` / \`clientEmail\` / \`itemId\` / \`weight\` 필드 보존.

### Bug 2 — 동명이인 거래처 식별 불가 (Phase 5.1 블로커)
- \`ActivityCreatePage.vue\` 드롭다운 라벨이 \`"Chung Corp (청 코퍼레이션)"\` 로 같으면 구분 불가
- 수정: 라벨을 \`[CLI006] Chung Corp (청 코퍼레이션)\` 로. 비활성 거래처 제외.

### Bug 3 — PDF 직인 미리보기 naturalWidth=0
- 4개 문서 템플릿의 \`<img crossorigin=\"anonymous\">\` 가 S3 CORS 없이 로드 실패
- 수정: crossorigin 속성 제거. S3 team2-files-prod 에 CORS 정책은 인프라 측에서 별도 설정.

## 🔗 관련 이슈

- closes #474

## 📸 스크린샷 (선택)

N/A — 실제 데이터 흐름 정상화가 핵심.

## ✅ 체크리스트

- [x] 정상 동작 확인 (POPage / ActivityCreatePage / 4 문서 템플릿 로컬 빌드 OK)
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

- 머지 후 **신규 생성되는 PO 부터 clientId 정상**. 기존 PO260015 등은 0 그대로 — 재시연에선 새 PO 만들어야 함.
- 거래처 도장(clientSealImageUrl) 지원은 DDL/Entity/DTO/Form 다층 변경이라 별건 이슈로 분리 예정.