### PR TITLE
fix(#479): 품목 등록/수정 — 포장단위 필수화

### DIFF
--- a/src/components/domain/master/ItemFormModal.vue
+++ b/src/components/domain/master/ItemFormModal.vue
@@ -127,6 +127,10 @@ function validate() {
     e.unit = '단위를 선택하세요.'
   }
 
+  if (!form.value.packUnit) {
+    e.packUnit = '포장단위를 선택하세요.'
+  }
+
   if (form.value.unitPrice === '' || form.value.unitPrice === null || form.value.unitPrice === undefined) {
     e.unitPrice = '단가를 입력하세요.'
   } else {
@@ -253,8 +257,9 @@ function handleSave() {
             <BaseSelect v-model="form.unit" :options="unitOptions" placeholder="단위를 선택하세요" />
             <p v-if="errors.unit" class="mt-1 text-xs text-red-500">{{ errors.unit }}</p>
           </FormField>
-          <FormField label="포장단위">
+          <FormField label="포장단위" required>
             <BaseSelect v-model="form.packUnit" :options="packUnitOptions" placeholder="포장단위를 선택하세요" />
+            <p v-if="errors.packUnit" class="mt-1 text-xs text-red-500">{{ errors.packUnit }}</p>
           </FormField>
         </div>
       </div>


### PR DESCRIPTION
## 📋 작업 내용

시연 피드백: "품목 등록/수정 때 포장단위도 필수로"

- \`ItemFormModal.vue\` \`validate()\` 에 \`form.packUnit\` null/공란 체크 추가
- \`FormField\` 에 \`required\` 배지 + \`errors.packUnit\` 인라인 에러 메시지

기존 품목은 packUnit null 이라도 저장돼 있을 수 있음 — 수정 모달 열면 에러로 노출되므로 업데이트 시 재선택 필요. 기존 데이터는 그대로 유지 (backfill 없음).

## ✅ 체크리스트
- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료