### PR TITLE
feat(#480): 전역 로딩 오버레이 — fallback 상태에서 action 제한

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,8 +1,10 @@
 <script setup>
+import GlobalLoadingOverlay from '@/components/common/GlobalLoadingOverlay.vue'
 import ToastContainer from '@/components/common/ToastContainer.vue'
 </script>
 
 <template>
   <RouterView />
+  <GlobalLoadingOverlay />
   <ToastContainer />
 </template>

--- a/src/components/common/GlobalLoadingOverlay.vue
+++ b/src/components/common/GlobalLoadingOverlay.vue
@@ -1,0 +1,69 @@
+<script setup>
+import { isLoading } from '@/stores/loading'
+</script>
+
+<template>
+  <!--
+    전역 로딩 오버레이 — lib/api.js 의 axios 인터셉터가 관리하는 pending 카운터가 0 이 아니면 노출.
+    pointer-events: auto 로 하위 UI 클릭/폼 입력을 완전 차단해 fallback 중 action 을 막는다.
+    시각적으론 반투명 흰 배경 + 중앙 스피너. 60ms 정도의 짧은 요청은 보이지 않도록
+    transition delay 를 줘서 flicker 회피.
+  -->
+  <Transition name="overlay-fade">
+    <div v-if="isLoading" class="global-loading-overlay" role="status" aria-live="polite" aria-busy="true">
+      <div class="spinner" aria-hidden="true"></div>
+      <span class="visually-hidden">로딩 중</span>
+    </div>
+  </Transition>
+</template>
+
+<style scoped>
+.global-loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(248, 250, 252, 0.55);
+  backdrop-filter: blur(1px);
+  cursor: wait;
+}
+
+.spinner {
+  width: 42px;
+  height: 42px;
+  border: 4px solid #cbd5e1;
+  border-top-color: #0f172a;
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.overlay-fade-enter-active,
+.overlay-fade-leave-active {
+  transition: opacity 140ms ease;
+}
+.overlay-fade-enter-active {
+  transition-delay: 80ms;  /* 매우 빠른 요청은 아예 안 보임 (flicker 방지) */
+}
+.overlay-fade-enter-from,
+.overlay-fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,4 +1,5 @@
 import axios from 'axios'
+import { startLoading, stopLoading } from '@/stores/loading'
 
 export const api = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL ?? '/api',
@@ -28,6 +29,12 @@ export function setRouter(router) {
 api.interceptors.request.use((config) => {
   if (_authStore?.accessToken) {
     config.headers.Authorization = `Bearer ${_authStore.accessToken}`
+  }
+
+  // 전역 로딩 오버레이 on. config.meta.silent=true 면 카운터 증가 생략 (폴링/백그라운드).
+  if (!config?.meta?.silent) {
+    startLoading()
+    config._loadingTracked = true
   }
 
   return config
@@ -61,9 +68,17 @@ let isRefreshing = false
 let pendingRequests = []
 
 api.interceptors.response.use(
-  (response) => response,
+  (response) => {
+    if (response?.config?._loadingTracked) stopLoading()
+    return response
+  },
   async (error) => {
     const originalRequest = error.config
+
+    if (originalRequest?._loadingTracked) {
+      stopLoading()
+      originalRequest._loadingTracked = false
+    }
 
     // /auth/refresh, /auth/login 의 401 은 인터셉터에서 제외 — 데드락/오류 가림 방지.
     // refresh 401 을 또 refresh 로 보내면 큐 대기 무한루프, login 401 을 refresh 로 가리면

--- a/src/stores/loading.js
+++ b/src/stores/loading.js
@@ -1,0 +1,29 @@
+// 전역 in-flight HTTP 요청 카운터.
+// lib/api.js 의 axios 인터셉터가 request 시 inc / response·error 시 dec.
+// GlobalLoadingOverlay 가 이 ref 를 watch 하여 카운터 > 0 이면 스피너 + pointer-events 차단 overlay 렌더.
+//
+// 배경: 리스트/폼이 API 응답 오기 전부터 렌더되면서 fallback/빈 데이터 상태에서 사용자가
+// 버튼 클릭 → 중간 상태 insert → 정합성 깨지는 현상이 시연 중 관찰됨. 요청이 돌 때
+// 전역적으로 잠그는 게 가장 작은 변경으로 해결.
+//
+// 특정 요청을 silent 처리하려면 axios config 에 { meta: { silent: true } } 전달.
+// (예: 폴링, 토큰 refresh, 활동 로그 저장 등 백그라운드 요청)
+
+import { ref, computed } from 'vue'
+
+const pending = ref(0)
+
+export function startLoading() {
+  pending.value += 1
+}
+
+export function stopLoading() {
+  if (pending.value > 0) pending.value -= 1
+}
+
+export function resetLoading() {
+  pending.value = 0
+}
+
+export const isLoading = computed(() => pending.value > 0)
+export const pendingCount = computed(() => pending.value)


### PR DESCRIPTION
## 📋 작업 내용

시연 피드백: "등록/로딩해서 폴백이었다가 데이터 생기는 경우가 많은데, 좀 액션 제한하게 로딩 스피너 전역적으로 적용"

### 구성
- **\`stores/loading.js\`** — in-flight HTTP 요청 카운터 + computed \`isLoading\`
- **\`lib/api.js\`** axios 인터셉터
  - request: \`config.meta.silent\` 가 아닐 때 \`startLoading()\`, \`_loadingTracked\` 플래그 부착
  - response + error: \`_loadingTracked\` 확인 후 \`stopLoading()\`
- **\`components/common/GlobalLoadingOverlay.vue\`** — 고정 overlay, backdrop-blur, 42px 스피너, \`pointer-events: auto\` 로 전체 UI 차단, \`transition-delay: 80ms\` 로 짧은 요청은 렌더 skip (flicker 방지)
- **\`App.vue\`** 에 ToastContainer 옆 마운트

### opt-out 패턴
폴링/토큰 refresh 같은 백그라운드 요청:
\`\`\`js
api.get('/something', { meta: { silent: true } })
\`\`\`

## 🔗 관련 이슈

- closes #480

## ✅ 체크리스트

- [x] 정상 동작 확인 (여러 페이지 리로드 + 폼 저장 시 overlay 노출 · 80ms 미만 요청은 overlay 안 뜨는 것 확인)
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

- 모든 axios 요청에 적용되므로, 사용자에게 보여줄 필요 없는 요청(예: 앞으로 추가될 notification polling)은 \`meta.silent\` 로 제외.
- 현재 backend-documents 한 번 재기동 필요한 상황이라 배포 후 실 시연 재확인 권장.