### PR TITLE
fix(#482): 팀장 PI/PO 수정·삭제 버튼 '요청' 라벨 제거

### DIFF
--- a/src/views/documents/PIDetailPage.vue
+++ b/src/views/documents/PIDetailPage.vue
@@ -927,13 +927,13 @@ async function confirmReject() {
             <template #leading>
               <i class="fas fa-edit text-xs" aria-hidden="true"></i>
             </template>
-            {{ ['확정','confirmed','CONFIRMED'].includes(detail.status) ? '수정요청' : '수정' }}
+            {{ isTeamLeader || !['확정','confirmed','CONFIRMED'].includes(detail.status) ? '수정' : '수정요청' }}
           </BaseButton>
           <BaseButton v-if="canMutate && !shipmentLockInfo.locked && !['결재대기','pending_approval','APPROVAL_PENDING'].includes(detail.status)" variant="secondary" size="sm" @click="handleDelete">
             <template #leading>
               <i class="fas fa-trash text-xs" aria-hidden="true"></i>
             </template>
-            {{ ['확정','confirmed','CONFIRMED'].includes(detail.status) ? '삭제요청' : '삭제' }}
+            {{ isTeamLeader || !['확정','confirmed','CONFIRMED'].includes(detail.status) ? '삭제' : '삭제요청' }}
           </BaseButton>
           <BaseButton
             v-if="canReviewAsApprover"

--- a/src/views/documents/PODetailPage.vue
+++ b/src/views/documents/PODetailPage.vue
@@ -1002,13 +1002,13 @@ async function confirmReject() {
             <template #leading>
               <i class="fas fa-edit text-xs" aria-hidden="true"></i>
             </template>
-            {{ ['확정','confirmed','CONFIRMED'].includes(detail.status) ? '수정요청' : '수정' }}
+            {{ isTeamLeader || !['확정','confirmed','CONFIRMED'].includes(detail.status) ? '수정' : '수정요청' }}
           </BaseButton>
           <BaseButton v-if="canMutate && !shipmentLockInfo.locked && !collectionLockInfo.locked && !['결재대기','pending_approval','APPROVAL_PENDING'].includes(detail.status)" variant="secondary" size="sm" @click="handleDelete">
             <template #leading>
               <i class="fas fa-trash text-xs" aria-hidden="true"></i>
             </template>
-            {{ ['확정','confirmed','CONFIRMED'].includes(detail.status) ? '삭제요청' : '삭제' }}
+            {{ isTeamLeader || !['확정','confirmed','CONFIRMED'].includes(detail.status) ? '삭제' : '삭제요청' }}
           </BaseButton>
           <BaseButton
             v-if="canReviewAsApprover"


### PR DESCRIPTION
## 📋 작업 내용

시연 피드백: 이영업(팀장) 으로 PI/PO 수정·삭제 시 "수정요청"/"삭제요청" 버튼이 떠서 결재 플로우 타야 하는 것처럼 보임. 실제 내부는 이미 \`isTeamLeader\` 분기로 PUT/DELETE 직접 호출 중 — 라벨만 misleading.

### 변경
- \`PIDetailPage.vue\` / \`PODetailPage.vue\` 액션 버튼 라벨: \`isTeamLeader\` 또는 비확정일 때 "수정"/"삭제", 스태프 + 확정일 때만 "수정요청"/"삭제요청"
- 내부 동작(confirmEditApprovalRequest / handleDelete) 은 이미 팀장 bypass 이므로 그대로

## 🔗 관련 이슈
- closes #482

## ✅ 체크리스트
- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료