### PR TITLE
feat(#484): 대시보드 결재 요청 5개씩 페이지네이션

### DIFF
--- a/src/views/DashboardPage.vue
+++ b/src/views/DashboardPage.vue
@@ -366,6 +366,20 @@ const requestItems = computed(() => {
   return []
 })
 
+const REQUEST_PAGE_STEP = 5
+const requestDisplayLimit = ref(REQUEST_PAGE_STEP)
+const visibleRequestItems = computed(() => requestItems.value.slice(0, requestDisplayLimit.value))
+const hasMoreRequestItems = computed(() => requestItems.value.length > requestDisplayLimit.value)
+function showMoreRequests() {
+  requestDisplayLimit.value = Math.min(
+    requestDisplayLimit.value + REQUEST_PAGE_STEP,
+    requestItems.value.length,
+  )
+}
+function resetRequestPagination() {
+  requestDisplayLimit.value = REQUEST_PAGE_STEP
+}
+
 const selectedRequestReview = computed(() => selectedRequest.value?.review ?? null)
 
 function openRequestReview(item) {
@@ -649,7 +663,7 @@ async function confirmPackageDelete() {
         표시할 결재 요청이 없습니다.
       </div>
       <div
-        v-for="item in requestItems"
+        v-for="item in visibleRequestItems"
         :key="item.id"
         class="flex cursor-pointer flex-col items-start gap-3 px-5 py-3.5 transition hover:bg-slate-50/50 sm:flex-row sm:items-center sm:justify-between"
         :class="item.isNew ? 'bg-amber-50/40 hover:bg-amber-50/60' : ''"
@@ -703,6 +717,24 @@ async function confirmPackageDelete() {
           <i class="fas fa-chevron-right text-xs text-slate-300" />
         </div>
       </div>
+      <button
+        v-if="hasMoreRequestItems"
+        type="button"
+        class="flex w-full items-center justify-center gap-2 px-5 py-3 text-xs font-medium text-slate-500 transition hover:bg-slate-50/70 hover:text-slate-700"
+        @click="showMoreRequests"
+      >
+        <i class="fas fa-chevron-down text-[10px]" />
+        더보기 ({{ visibleRequestItems.length }} / {{ requestItems.length }})
+      </button>
+      <button
+        v-else-if="requestDisplayLimit > REQUEST_PAGE_STEP && requestItems.length > REQUEST_PAGE_STEP"
+        type="button"
+        class="flex w-full items-center justify-center gap-2 px-5 py-3 text-xs font-medium text-slate-400 transition hover:bg-slate-50/70 hover:text-slate-600"
+        @click="resetRequestPagination"
+      >
+        <i class="fas fa-chevron-up text-[10px]" />
+        접기
+      </button>
     </BaseCard>
 
     <!-- 공유 활동기록 패키지 (생산/출하: 요약카드 바로 뒤에 표시됨, 영업: 결재 뒤에 표시) -->


### PR DESCRIPTION
## 📋 작업 내용
대시보드 결재 카드 (`requestItems`) 가 모두 한 번에 렌더링되던 것을 5개씩 페이징하여 노출.

- `requestDisplayLimit` (기본 5) ref 추가 → `visibleRequestItems` 로 슬라이스
- 카드 하단에 "더보기 (current / total)" 버튼 (chevron-down) 추가, 클릭 시 5씩 증가
- 전체 노출 시 "접기" 버튼 (chevron-up) 으로 5개로 복귀
- 헤더의 총 건수 표시 (`{{ requestItems.length }}건`) 는 그대로 유지

함께 적용한 백엔드 perf fix: `team2-backend-documents` `c8372a4` — `UserSnapshotService` 결과 캐싱으로 N+1 (size=1000 호출 시 최대 2000회 Feign) 제거. 둘이 같이 적용되어야 8s timeout 해소됨.

## 🔗 관련 이슈
- closes #484

## ✅ 체크리스트
- [x] 정상 동작 확인 (로컬 — 5건 표시, 더보기로 10/15/... 증가, 접기 정상)
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게
헤더의 "건수" 는 일부러 전체 (filter 후) 카운트 그대로 유지했습니다 — admin 의 경우 한눈에 전체 결재량 파악이 더 중요해서요. 표시된 개수와 헷갈리면 알려주세요.