### PR TITLE
fix(#486): CRUD 등록 반영 및 활동패키지 PDF 오류 수정

### DIFF
--- a/src/api/package.js
+++ b/src/api/package.js
@@ -1,24 +1,37 @@
 import { api } from '@/lib/api'
 import { unwrapCollection } from '@/utils/apiResponse'
 
+function normalizePackage(pkg) {
+  if (!pkg) return pkg
+  return {
+    ...pkg,
+    id: pkg.id ?? pkg.packageId,
+    title: pkg.title ?? pkg.packageTitle,
+  }
+}
+
 export function fetchPackages() {
-  return api.get('/activity-packages').then((r) => unwrapCollection(r.data))
+  return api.get('/activity-packages').then((r) => unwrapCollection(r.data).map(normalizePackage))
 }
 
 export function fetchPackageById(id) {
-  return api.get(`/activity-packages/${id}`).then((r) => r.data)
+  return api.get(`/activity-packages/${id}`).then((r) => normalizePackage(r.data))
 }
 
 export function createPackage(data) {
-  return api.post('/activity-packages', data).then((r) => r.data)
+  return api.post('/activity-packages', data).then((r) => normalizePackage(r.data?.content ?? r.data))
 }
 
 export function updatePackage(id, data) {
-  return api.put(`/activity-packages/${id}`, data).then((r) => r.data)
+  return api.put(`/activity-packages/${id}`, data).then((r) => normalizePackage(r.data?.content ?? r.data))
 }
 
 export function deletePackage(id) {
   return api.delete(`/activity-packages/${id}`)
+}
+
+export function downloadPackageReport(id) {
+  return api.get(`/activity-packages/${id}/report`, { responseType: 'blob' }).then((r) => r.data)
 }
 
 export async function fetchAllUsers() {

--- a/src/components/domain/activity/ActivityDetailModal.vue
+++ b/src/components/domain/activity/ActivityDetailModal.vue
@@ -17,10 +17,16 @@ const props = defineProps({
 
 defineEmits(['close'])
 
+const isScheduleActivity = computed(() =>
+  ['schedule', '일정'].includes(props.activity.type ?? props.activity.activityType),
+)
+const scheduleFrom = computed(() => props.activity.scheduleFrom ?? props.activity.activityScheduleFrom)
+const scheduleTo = computed(() => props.activity.scheduleTo ?? props.activity.activityScheduleTo)
+
 const modalTitle = computed(() => {
-  const title = props.activity.title || '활동 상세'
-  if (props.activity.type === '일정' && props.activity.scheduleFrom && props.activity.scheduleTo) {
-    return `${title}(${props.activity.scheduleFrom}~${props.activity.scheduleTo})`
+  const title = props.activity.title ?? props.activity.activityTitle ?? '활동 상세'
+  if (isScheduleActivity.value && scheduleFrom.value && scheduleTo.value) {
+    return `${title}(${scheduleFrom.value}~${scheduleTo.value})`
   }
   return title
 })
@@ -62,11 +68,11 @@ const modalTitle = computed(() => {
         <p class="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">내용</p>
         <div class="rounded-lg border border-slate-100 bg-slate-50 px-4 py-3">
           <p class="whitespace-pre-wrap text-sm text-slate-700">
-            {{ activity.type === '일정'
-              ? (activity.scheduleFrom && activity.scheduleTo
-                  ? `${activity.scheduleFrom} ~ ${activity.scheduleTo} ${activity.title || ''}`.trim()
-                  : (activity.title || '-'))
-              : (activity.content || '-') }}
+            {{ isScheduleActivity
+              ? (scheduleFrom && scheduleTo
+                  ? `${scheduleFrom} ~ ${scheduleTo} ${activity.title ?? activity.activityTitle ?? ''}`.trim()
+                  : (activity.title ?? activity.activityTitle ?? '-'))
+              : (activity.content ?? activity.activityContent ?? '-') }}
           </p>
         </div>
       </div>

--- a/src/components/domain/activity/ActivityEditModal.vue
+++ b/src/components/domain/activity/ActivityEditModal.vue
@@ -25,7 +25,7 @@ const emit = defineEmits(['close', 'save'])
 const { warning } = useToast()
 
 const priorityOptions = [
-  { label: '보통', value: 'medium' },
+  { label: '보통', value: 'normal' },
   { label: '높음', value: 'high' },
 ]
 
@@ -126,7 +126,7 @@ function initForm(val) {
   formDate.value         = (val?.date         ?? '').replaceAll('/', '-')
   formTitle.value        = val?.title        ?? ''
   formContent.value      = val?.content      ?? ''
-  formPriority.value     = val?.priority     ?? val?.activityPriority ?? 'medium'
+  formPriority.value     = val?.priority     ?? val?.activityPriority ?? 'normal'
   formScheduleFrom.value = (val?.scheduleFrom ?? val?.activityScheduleFrom ?? '').replaceAll('/', '-')
   formScheduleTo.value   = (val?.scheduleTo   ?? val?.activityScheduleTo   ?? '').replaceAll('/', '-')
   errors.value           = {}

--- a/src/components/domain/activity/PackageDetailModal.vue
+++ b/src/components/domain/activity/PackageDetailModal.vue
@@ -1,10 +1,11 @@
 <script setup>
 import { computed, ref } from 'vue'
-import { jsPDF } from 'jspdf'
+import { downloadPackageReport } from '@/api/package'
 import ActivityDetailModal from '@/components/domain/activity/ActivityDetailModal.vue'
 import ActivityTypeBadge from '@/components/domain/activity/ActivityTypeBadge.vue'
 import BaseButton from '@/components/common/BaseButton.vue'
 import BaseModal from '@/components/common/BaseModal.vue'
+import { useToast } from '@/composables/useToast'
 
 const props = defineProps({
   open: {
@@ -26,8 +27,10 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['close', 'edit', 'delete'])
+const { error } = useToast()
 
 const selectedActivity = ref(null)
+const downloading = ref(false)
 
 function openActivityDetail(act) {
   selectedActivity.value = act
@@ -39,7 +42,8 @@ function closeActivityDetail() {
 
 const packageActivities = computed(() => {
   if (!props.pkg?.activityIds?.length) return []
-  return props.activities.filter((a) => props.pkg.activityIds.includes(String(a.id)) || props.pkg.activityIds.includes(a.id))
+  const ids = new Set(props.pkg.activityIds.map((id) => String(id)))
+  return props.activities.filter((a) => ids.has(String(a.id ?? a.activityId)))
 })
 
 const infoRows = computed(() => {
@@ -53,134 +57,20 @@ const infoRows = computed(() => {
   ]
 })
 
-function generatePdf() {
-  if (!props.pkg) return
-
-  const doc = new jsPDF({ orientation: 'portrait', unit: 'mm', format: 'a4' })
-  const pageW = doc.internal.pageSize.getWidth()
-  const margin = 20
-  let y = 20
-
-  // ── 헤더
-  doc.setFontSize(20)
-  doc.setFont('helvetica', 'bold')
-  doc.text('Activity Record Package', pageW / 2, y, { align: 'center' })
-  y += 8
-
-  doc.setFontSize(10)
-  doc.setFont('helvetica', 'normal')
-  doc.setTextColor(100)
-  doc.text(`Generated: ${new Date().toLocaleDateString('ko-KR')}`, pageW / 2, y, { align: 'center' })
-  y += 4
-
-  if (props.pkg.poId) {
-    doc.text(`PO: ${props.pkg.poId}`, pageW / 2, y, { align: 'center' })
-    y += 4
+async function generatePdf() {
+  const packageId = props.pkg?.packageId ?? props.pkg?.id
+  if (!packageId || downloading.value) return
+  downloading.value = true
+  try {
+    const blob = await downloadPackageReport(packageId)
+    const url = URL.createObjectURL(blob)
+    window.open(url, '_blank')
+    setTimeout(() => URL.revokeObjectURL(url), 10000)
+  } catch (e) {
+    error(e?.response?.data?.message || 'PDF 생성에 실패했습니다.')
+  } finally {
+    downloading.value = false
   }
-  doc.text(`Period: ${props.pkg.dateFrom || '-'} ~ ${props.pkg.dateTo || '-'}`, pageW / 2, y, { align: 'center' })
-  y += 8
-
-  // 구분선
-  doc.setDrawColor(200)
-  doc.line(margin, y, pageW - margin, y)
-  y += 8
-
-  // ── 선택된 활동기록 목록
-  const selected = packageActivities.value
-
-  doc.setFontSize(13)
-  doc.setFont('helvetica', 'bold')
-  doc.setTextColor(0)
-  doc.text(`Activity Records (${selected.length})`, margin, y)
-  y += 7
-
-  if (selected.length === 0) {
-    doc.setFontSize(10)
-    doc.setFont('helvetica', 'normal')
-    doc.setTextColor(150)
-    doc.text('No records selected.', margin, y)
-    y += 6
-  } else {
-    const cols = [
-      { label: 'No',     x: margin,      w: 12  },
-      { label: 'Date',   x: margin + 12, w: 25  },
-      { label: 'Type',   x: margin + 37, w: 28  },
-      { label: 'Title',  x: margin + 65, w: 70  },
-      { label: 'Author', x: margin + 135, w: 30 },
-    ]
-
-    doc.setFillColor(240, 244, 255)
-    doc.rect(margin, y - 4, pageW - margin * 2, 7, 'F')
-    doc.setFontSize(9)
-    doc.setFont('helvetica', 'bold')
-    doc.setTextColor(50)
-    cols.forEach((c) => doc.text(c.label, c.x + 1, y))
-    y += 5
-
-    doc.setFont('helvetica', 'normal')
-    doc.setTextColor(30)
-
-    selected.forEach((a, i) => {
-      if (y > 270) {
-        doc.addPage()
-        y = 20
-      }
-      const bg = i % 2 === 0 ? [255, 255, 255] : [248, 250, 252]
-      doc.setFillColor(...bg)
-      doc.rect(margin, y - 4, pageW - margin * 2, 6, 'F')
-
-      doc.setFontSize(8.5)
-      doc.text(String(i + 1), cols[0].x + 1, y)
-      doc.text(a.date ?? '-',  cols[1].x + 1, y)
-      doc.text(a.type ?? '-',  cols[2].x + 1, y)
-
-      const title = doc.splitTextToSize(a.title ?? '-', cols[3].w - 2)[0]
-      doc.text(title, cols[3].x + 1, y)
-      doc.text(a.author ?? '-', cols[4].x + 1, y)
-      y += 6
-    })
-  }
-
-  y += 6
-  doc.setDrawColor(200)
-  doc.line(margin, y, pageW - margin, y)
-  y += 6
-
-  // ── 포함 항목 요약
-  const includedTypes = [...new Set(selected.map((a) => a.type))]
-  doc.setFontSize(13)
-  doc.setFont('helvetica', 'bold')
-  doc.setTextColor(0)
-  doc.text('Include Options', margin, y)
-  y += 7
-
-  doc.setFontSize(9)
-  doc.setFont('helvetica', 'normal')
-  doc.setTextColor(60)
-  if (includedTypes.length === 0) {
-    doc.text('No items selected', margin + 4, y)
-    y += 5
-  } else {
-    includedTypes.forEach((type) => {
-      doc.text(`- ${type}`, margin + 4, y)
-      y += 5
-    })
-  }
-
-  // ── 푸터
-  const totalPages = doc.internal.pages.length - 1
-  for (let p = 1; p <= totalPages; p++) {
-    doc.setPage(p)
-    doc.setFontSize(8)
-    doc.setTextColor(160)
-    doc.text(`Page ${p} / ${totalPages}`, pageW / 2, 290, { align: 'center' })
-    doc.text('SalesBoost - Activity Package', margin, 290)
-  }
-
-  const blob = doc.output('blob')
-  const url = URL.createObjectURL(blob)
-  window.open(url, '_blank')
-  setTimeout(() => URL.revokeObjectURL(url), 10000)
 }
 </script>
 
@@ -262,11 +152,11 @@ function generatePdf() {
 
     <template #footer>
       <template v-if="isOwner">
-        <BaseButton variant="secondary" @click="generatePdf">
+        <BaseButton variant="secondary" :disabled="downloading" @click="generatePdf">
           <template #leading>
             <i class="fas fa-file-pdf text-xs" />
           </template>
-          PDF 다운로드
+          {{ downloading ? 'PDF 생성 중...' : 'PDF 다운로드' }}
         </BaseButton>
         <BaseButton variant="secondary" @click="emit('edit')">
           <template #leading>
@@ -282,11 +172,11 @@ function generatePdf() {
         </BaseButton>
       </template>
       <template v-else>
-        <BaseButton variant="secondary" @click="generatePdf">
+        <BaseButton variant="secondary" :disabled="downloading" @click="generatePdf">
           <template #leading>
             <i class="fas fa-file-pdf text-xs" />
           </template>
-          PDF 다운로드
+          {{ downloading ? 'PDF 생성 중...' : 'PDF 다운로드' }}
         </BaseButton>
         <BaseButton variant="secondary" @click="emit('close')">닫기</BaseButton>
       </template>

--- a/src/views/DashboardPage.vue
+++ b/src/views/DashboardPage.vue
@@ -207,12 +207,20 @@ const shipmentItems = computed(() => {
     }))
 })
 
-const clientNameById = computed(() => new Map(clientsData.value.map((client) => [Number(client.id), client.name])))
+const clientNameById = computed(() => new Map(
+  clientsData.value
+    .map((client) => [
+      Number(client.clientId ?? client.id),
+      client.clientName ?? client.name ?? '-',
+    ])
+    .filter(([id]) => Number.isFinite(id)),
+))
 
 function resolveActivityIcon(type) {
-  if (type === '미팅/협의') return 'fa-users'
-  if (type === '이슈') return 'fa-flag'
-  if (type === '메모/노트') return 'fa-sticky-note'
+  if (type === 'meeting' || type === '미팅/협의') return 'fa-users'
+  if (type === 'issue' || type === '이슈') return 'fa-flag'
+  if (type === 'memo' || type === '메모/노트') return 'fa-sticky-note'
+  if (type === 'schedule' || type === '일정') return 'fa-calendar'
   return 'fa-comment'
 }
 
@@ -547,7 +555,9 @@ function closePackageDetail() {
 
 function handlePackageEdit() {
   if (!selectedPackage.value) return
-  router.push({ path: '/package', query: { edit: selectedPackage.value.id } })
+  const packageId = selectedPackage.value.packageId ?? selectedPackage.value.id
+  if (!packageId) return
+  router.push({ path: '/package', query: { edit: packageId } })
   closePackageDetail()
 }
 
@@ -561,9 +571,11 @@ function closeDeleteConfirm() {
 
 async function confirmPackageDelete() {
   if (!selectedPackage.value) return
+  const packageId = selectedPackage.value.packageId ?? selectedPackage.value.id
+  if (!packageId) return
   try {
-    await deletePackageApi(selectedPackage.value.id)
-    packagesData.value = packagesData.value.filter((p) => p.id !== selectedPackage.value.id)
+    await deletePackageApi(packageId)
+    packagesData.value = packagesData.value.filter((p) => (p.packageId ?? p.id) !== packageId)
     success('패키지가 삭제되었습니다.')
     closeDeleteConfirm()
     closePackageDetail()

--- a/src/views/activity/ActivityCreatePage.vue
+++ b/src/views/activity/ActivityCreatePage.vue
@@ -27,7 +27,7 @@ const formType = ref('')
 const formPoDisplay = ref('')
 const formPoId = ref('')
 const formDate = ref(new Date().toISOString().slice(0, 10))
-const formPriority = ref('medium')
+const formPriority = ref('normal')
 const formTitle = ref('')
 const formContent = ref('')
 const formAuthor = ref(authStore.currentUser?.userName ?? '')
@@ -72,7 +72,7 @@ const typeOptions = [
 ]
 
 const priorityOptions = [
-  { label: '보통', value: 'medium' },
+  { label: '보통', value: 'normal' },
   { label: '높음', value: 'high' },
 ]
 

--- a/src/views/activity/ActivityListPage.vue
+++ b/src/views/activity/ActivityListPage.vue
@@ -104,18 +104,23 @@ const clientMap = computed(() =>
   Object.fromEntries(clients.value.map((c) => [c.clientId, c])),
 )
 
+function normalizeDate(value) {
+  return value ? String(value).slice(0, 10).replaceAll('/', '-') : ''
+}
+
 const filteredActivities = computed(() => {
   return activities.value.filter((a) => {
     const client = clientMap.value[a.clientId]
     const matchType   = !applied.value.type   || a.type === applied.value.type
-    const matchTitle  = !applied.value.title  || a.title.includes(applied.value.title)
-      || client?.clientName.includes(applied.value.title) || client?.clientNameKr.includes(applied.value.title)
+    const matchTitle  = !applied.value.title  || (a.title ?? '').includes(applied.value.title)
+      || (client?.clientName ?? '').includes(applied.value.title) || (client?.clientNameKr ?? '').includes(applied.value.title)
     const matchAuthor = !applied.value.author || a.author === applied.value.author
     const matchPo     = !applied.value.po     || (a.poId ?? '').includes(applied.value.po)
-    const dateFrom = applied.value.dateFrom.replaceAll('-', '/')
-    const dateTo   = applied.value.dateTo.replaceAll('-', '/')
-    const matchFrom   = !dateFrom || a.date >= dateFrom
-    const matchTo     = !dateTo   || a.date <= dateTo
+    const dateFrom = normalizeDate(applied.value.dateFrom)
+    const dateTo   = normalizeDate(applied.value.dateTo)
+    const activityDate = normalizeDate(a.date ?? a.activityDate)
+    const matchFrom   = !dateFrom || activityDate >= dateFrom
+    const matchTo     = !dateTo   || activityDate <= dateTo
     return matchType && matchTitle && matchAuthor && matchPo && matchFrom && matchTo
   })
 })

--- a/src/views/master/ClientDetailPage.vue
+++ b/src/views/master/ClientDetailPage.vue
@@ -143,8 +143,8 @@ async function loadData() {
 
     allClients.value = clientsData
     buyers.value = buyersData
-  } catch {
-    error('데이터를 불러오는 중 오류가 발생했습니다.')
+  } catch (e) {
+    error(e?.response?.data?.message || '데이터를 불러오는 중 오류가 발생했습니다.')
   } finally {
     loading.value = false
   }
@@ -153,8 +153,8 @@ async function loadData() {
 async function reloadBuyers() {
   try {
     buyers.value = await fetchBuyersByClient(route.params.id)
-  } catch {
-    error('바이어 목록을 다시 불러오지 못했습니다.')
+  } catch (e) {
+    error(e?.response?.data?.message || '바이어 목록을 다시 불러오지 못했습니다.')
   }
 }
 
@@ -172,8 +172,8 @@ async function handleSave(formData) {
     success('거래처 정보가 수정되었습니다.')
     showFormModal.value = false
     await loadData()
-  } catch {
-    error('수정 중 오류가 발생했습니다.')
+  } catch (e) {
+    error(e?.response?.data?.message || '수정 중 오류가 발생했습니다.')
   } finally {
     saving.value = false
   }
@@ -189,8 +189,8 @@ async function handleDelete() {
     await changeClientStatus(client.value.id ?? client.value.clientId, 'inactive')
     success(`${name} 거래처가 비활성화되었습니다.`)
     router.push({ name: 'client-list' })
-  } catch {
-    error('삭제 중 오류가 발생했습니다.')
+  } catch (e) {
+    error(e?.response?.data?.message || '삭제 중 오류가 발생했습니다.')
   } finally {
     showConfirmModal.value = false
     deleting.value = false
@@ -276,8 +276,8 @@ async function handleBuyerDelete() {
     showBuyerDeleteModal.value = false
     buyerToDelete.value = null
     await reloadBuyers()
-  } catch {
-    error('삭제 중 오류가 발생했습니다.')
+  } catch (e) {
+    error(e?.response?.data?.message || '삭제 중 오류가 발생했습니다.')
   }
 }
 

--- a/src/views/master/ClientListPage.vue
+++ b/src/views/master/ClientListPage.vue
@@ -193,8 +193,8 @@ async function loadData() {
     clients.value = clientsData ?? []
     departments.value = deptsData ?? []
     teams.value = teamsData ?? []
-  } catch {
-    error('데이터를 불러오는 중 오류가 발생했습니다.')
+  } catch (e) {
+    error(e?.response?.data?.message || '데이터를 불러오는 중 오류가 발생했습니다.')
   } finally {
     loading.value = false
   }
@@ -233,7 +233,7 @@ async function handleDelete() {
     await loadData()
   } catch (e) {
     console.error('거래처 삭제 실패', e)
-    error('삭제 중 오류가 발생했습니다.')
+    error(e?.response?.data?.message || '삭제 중 오류가 발생했습니다.')
   } finally {
     showConfirmModal.value = false
     clientToDelete.value = null
@@ -255,8 +255,8 @@ async function handleSave(formData) {
     }
     showFormModal.value = false
     await loadData()
-  } catch {
-    error('저장 중 오류가 발생했습니다.')
+  } catch (e) {
+    error(e?.response?.data?.message || '저장 중 오류가 발생했습니다.')
   } finally {
     saving.value = false
   }

--- a/src/views/master/ItemDetailPage.vue
+++ b/src/views/master/ItemDetailPage.vue
@@ -20,6 +20,7 @@ const authStore = useAuthStore()
 const isItemAdmin = computed(() => canManageItems(authStore.currentUser?.role))
 
 const item = ref(null)
+const itemId = computed(() => item.value?.itemId ?? item.value?.id)
 const allItems = ref([]) // used for code uniqueness check in edit modal
 const loading = ref(false)
 const saving = ref(false)
@@ -81,8 +82,8 @@ async function loadData() {
     }
     item.value = itemData
     allItems.value = itemsData
-  } catch {
-    error('데이터를 불러오는 중 오류가 발생했습니다.')
+  } catch (e) {
+    error(e?.response?.data?.message || '데이터를 불러오는 중 오류가 발생했습니다.')
   } finally {
     loading.value = false
   }
@@ -98,12 +99,12 @@ async function handleSave(formData) {
   if (saving.value) return
   saving.value = true
   try {
-    await updateItem(item.value.id, formData)
+    await updateItem(itemId.value, formData)
     success('품목 정보가 수정되었습니다.')
     showFormModal.value = false
     await loadData()
-  } catch {
-    error('수정 중 오류가 발생했습니다.')
+  } catch (e) {
+    error(e?.response?.data?.message || '수정 중 오류가 발생했습니다.')
   } finally {
     saving.value = false
   }
@@ -116,11 +117,11 @@ async function handleDelete() {
   deleting.value = true
   const name = item.value.itemName
   try {
-    await changeItemStatus(item.value.id, 'inactive')
+    await changeItemStatus(itemId.value, 'inactive')
     success(`${name} 품목이 비활성화되었습니다.`)
     router.push({ name: 'item-list' })
-  } catch {
-    error('삭제 중 오류가 발생했습니다.')
+  } catch (e) {
+    error(e?.response?.data?.message || '삭제 중 오류가 발생했습니다.')
   } finally {
     showConfirmModal.value = false
     deleting.value = false
@@ -164,13 +165,13 @@ function goBack() {
       <!-- 관련 문서 링크 -->
       <BaseCard title="관련 문서 바로가기" subtitle="이 품목의 관련 문서를 조회합니다.">
         <div class="flex flex-wrap gap-2">
-          <DocumentLinkButton :to="{ path: '/po', query: { itemId: item.id } }">
+          <DocumentLinkButton :to="{ path: '/po', query: { itemId } }">
             PO 조회
           </DocumentLinkButton>
-          <DocumentLinkButton :to="{ path: '/pi', query: { itemId: item.id } }">
+          <DocumentLinkButton :to="{ path: '/pi', query: { itemId } }">
             PI 조회
           </DocumentLinkButton>
-          <DocumentLinkButton :to="{ path: '/production', query: { itemId: item.id } }">
+          <DocumentLinkButton :to="{ path: '/production', query: { itemId } }">
             생산 조회
           </DocumentLinkButton>
         </div>

--- a/src/views/master/ItemListPage.vue
+++ b/src/views/master/ItemListPage.vue
@@ -154,8 +154,8 @@ async function loadData() {
   loading.value = true
   try {
     items.value = await fetchItems()
-  } catch {
-    error('데이터를 불러오는 중 오류가 발생했습니다.')
+  } catch (e) {
+    error(e?.response?.data?.message || '데이터를 불러오는 중 오류가 발생했습니다.')
   } finally {
     loading.value = false
   }
@@ -182,13 +182,18 @@ function confirmDelete(item) {
 
 async function handleDelete() {
   if (!itemToDelete.value || deleting.value) return
+  const id = itemToDelete.value.itemId ?? itemToDelete.value.id
+  if (!id) {
+    error('품목 ID가 없습니다.')
+    return
+  }
   deleting.value = true
   try {
-    await changeItemStatus(itemToDelete.value.id, 'inactive')
+    await changeItemStatus(id, 'inactive')
     success(`${itemToDelete.value.itemName} 품목이 비활성화되었습니다.`)
     await loadData()
-  } catch {
-    error('삭제 중 오류가 발생했습니다.')
+  } catch (e) {
+    error(e?.response?.data?.message || '삭제 중 오류가 발생했습니다.')
   } finally {
     showConfirmModal.value = false
     itemToDelete.value = null
@@ -208,23 +213,24 @@ async function handleSave(formData) {
       // PUT 의 UpdateItemRequest DTO 에는 itemStatus 필드가 없어 포함시켜도 무시된다.
       // 따라서 상태가 변경된 경우에는 PATCH 를 별도로 호출해야 실제 반영됨.
       const statusChanged = formData.itemStatus !== selectedItem.value.itemStatus
-      await updateItem(selectedItem.value.id, formData)
+      const id = selectedItem.value.itemId ?? selectedItem.value.id
+      await updateItem(id, formData)
       if (statusChanged) {
-        await changeItemStatus(selectedItem.value.id, formData.itemStatus)
+        await changeItemStatus(id, formData.itemStatus)
       }
       success('품목 정보가 수정되었습니다.')
     }
     showFormModal.value = false
     await loadData()
-  } catch {
-    error('저장 중 오류가 발생했습니다.')
+  } catch (e) {
+    error(e?.response?.data?.message || '저장 중 오류가 발생했습니다.')
   } finally {
     saving.value = false
   }
 }
 
 function goToDetail(row) {
-  router.push({ name: 'item-detail', params: { id: row.id } })
+  router.push({ name: 'item-detail', params: { id: row.itemId ?? row.id } })
 }
 </script>
 

--- a/src/views/package/ActivityPackagePage.vue
+++ b/src/views/package/ActivityPackagePage.vue
@@ -101,8 +101,8 @@ async function loadPackageForEdit() {
     dateTo.value = pkg.dateTo || ''
     selectedActivityIds.value = [...(pkg.activityIds || [])]
     selectedViewerIds.value = [...(pkg.viewerIds || [])]
-  } catch {
-    error('패키지 정보를 불러오지 못했습니다.')
+  } catch (e) {
+    error(e?.response?.data?.message || '패키지 정보를 불러오지 못했습니다.')
   }
 }
 
@@ -155,7 +155,7 @@ const packageDescription = ref('')
 const keyword     = ref('')
 const poDisplay   = ref('')
 const dateFrom    = ref('')
-const dateTo      = ref(todayKr())
+const dateTo      = ref('')
 
 // ── 열람 권한 ──────────────────────────────────────────────
 const selectedViewerIds = ref([])
@@ -276,39 +276,57 @@ const activeTypeTab = ref('전체')
 
 const typeTabs = [
   { key: '전체',     label: '전체'     },
-  { key: '미팅/협의', label: '미팅/협의' },
-  { key: '이슈',     label: '이슈'     },
-  { key: '메모/노트', label: '메모/노트' },
-  { key: '일정',     label: '일정'     },
+  { key: 'meeting',  label: '미팅/협의' },
+  { key: 'issue',    label: '이슈'     },
+  { key: 'memo',     label: '메모/노트' },
+  { key: 'schedule', label: '일정'     },
 ]
 
 const selectedActivityIds = ref([])
 
+function normalizeDate(value) {
+  return value ? String(value).slice(0, 10).replaceAll('/', '-') : ''
+}
+
+function activityRowId(activity) {
+  return activity?.id ?? activity?.activityId
+}
+
+function activityTypeOf(activity) {
+  return activity?.type ?? activity?.activityType
+}
+
+function isActivitySelected(id) {
+  return selectedActivityIds.value.some((selectedId) => String(selectedId) === String(id))
+}
+
 // 탭/필터와 무관하게 실제 선택된 활동기록 전체
-const selectedActivities = computed(() =>
-  activities.value.filter((a) => selectedActivityIds.value.includes(a.id)),
-)
+const selectedActivities = computed(() => {
+  const ids = new Set(selectedActivityIds.value.map((id) => String(id)))
+  return activities.value.filter((a) => ids.has(String(activityRowId(a))))
+})
 
 const includedTypes = computed(() =>
-  [...new Set(selectedActivities.value.map((a) => a.type))],
+  [...new Set(selectedActivities.value.map(activityTypeOf).filter(Boolean))],
 )
 
 const filteredActivities = computed(() => {
   if (!selectedPoId.value) return []
   let list = activities.value.filter((a) => a.poId === selectedPoId.value)
   if (activeTypeTab.value !== '전체') {
-    list = list.filter((a) => a.type === activeTypeTab.value)
+    list = list.filter((a) => activityTypeOf(a) === activeTypeTab.value)
   }
   if (keyword.value.trim()) {
     const q = keyword.value.trim().toLowerCase()
     list = list.filter((a) =>
-      a.title.toLowerCase().includes(q) || (a.content ?? '').toLowerCase().includes(q),
+      (a.title ?? a.activityTitle ?? '').toLowerCase().includes(q) ||
+      (a.content ?? a.activityContent ?? '').toLowerCase().includes(q),
     )
   }
-  const aFrom = actDateFrom.value.replaceAll('-', '/')
-  const aTo   = actDateTo.value.replaceAll('-', '/')
-  if (aFrom) list = list.filter((a) => a.date >= aFrom)
-  if (aTo)   list = list.filter((a) => a.date <= aTo)
+  const aFrom = normalizeDate(actDateFrom.value)
+  const aTo   = normalizeDate(actDateTo.value)
+  if (aFrom) list = list.filter((a) => normalizeDate(a.date ?? a.activityDate) >= aFrom)
+  if (aTo)   list = list.filter((a) => normalizeDate(a.date ?? a.activityDate) <= aTo)
   return list
 })
 
@@ -321,7 +339,7 @@ watch([actDateFrom, actDateTo], async () => {
     return
   }
   await nextTick()
-  selectedActivityIds.value = filteredActivities.value.map((a) => a.id)
+  selectedActivityIds.value = filteredActivities.value.map(activityRowId).filter((id) => id != null)
 })
 
 // PO 변경 시 전체 선택으로 리셋 (편집 모드 초기 로드 제외)
@@ -333,26 +351,27 @@ watch(selectedPoId, async () => {
     return
   }
   await nextTick()
-  selectedActivityIds.value = filteredActivities.value.map((a) => a.id)
+  selectedActivityIds.value = filteredActivities.value.map(activityRowId).filter((id) => id != null)
 })
 
 const isAllSelected = computed(() =>
   filteredActivities.value.length > 0 &&
-  filteredActivities.value.every((a) => selectedActivityIds.value.includes(a.id)),
+  filteredActivities.value.every((a) => isActivitySelected(activityRowId(a))),
 )
 
 function toggleAll(checked) {
-  const ids = filteredActivities.value.map((a) => a.id)
+  const ids = filteredActivities.value.map(activityRowId).filter((id) => id != null)
   if (checked) {
     selectedActivityIds.value = [...new Set([...selectedActivityIds.value, ...ids])]
   } else {
-    selectedActivityIds.value = selectedActivityIds.value.filter((id) => !ids.includes(id))
+    const visibleIds = new Set(ids.map((id) => String(id)))
+    selectedActivityIds.value = selectedActivityIds.value.filter((id) => !visibleIds.has(String(id)))
   }
 }
 
 function toggleActivity(id) {
-  if (selectedActivityIds.value.includes(id)) {
-    selectedActivityIds.value = selectedActivityIds.value.filter((v) => v !== id)
+  if (isActivitySelected(id)) {
+    selectedActivityIds.value = selectedActivityIds.value.filter((v) => String(v) !== String(id))
   } else {
     selectedActivityIds.value = [...selectedActivityIds.value, id]
   }
@@ -362,7 +381,9 @@ function toggleActivity(id) {
 const summaryText = computed(() => {
   if (selectedActivities.value.length === 0) return '활동기록 목록에서 항목을 선택하면 포함 건수가 표시됩니다.'
   const countByType = selectedActivities.value.reduce((acc, a) => {
-    acc[a.type] = (acc[a.type] ?? 0) + 1
+    const type = activityTypeOf(a)
+    if (!type) return acc
+    acc[type] = (acc[type] ?? 0) + 1
     return acc
   }, {})
   const parts = Object.entries(countByType).map(([type, count]) => `${type} ${count}건`)
@@ -390,10 +411,10 @@ async function savePackage() {
     packageTitle: packageTitle.value.trim(),
     packageDescription: packageDescription.value.trim(),
     poId: selectedPoId.value,
-    dateFrom: dateFrom.value,
-    dateTo: dateTo.value,
-    activityIds: [...selectedActivityIds.value],
-    viewerIds: [...selectedViewerIds.value],
+    dateFrom: dateFrom.value || null,
+    dateTo: dateTo.value || null,
+    activityIds: selectedActivityIds.value.map(Number).filter(Number.isFinite),
+    viewerIds: selectedViewerIds.value.map(Number).filter(Number.isFinite),
   }
 
   try {
@@ -681,21 +702,21 @@ async function savePackage() {
             </div>
             <div
               v-for="activity in filteredActivities"
-              :key="activity.id"
+              :key="activityRowId(activity)"
               class="flex items-center gap-3 rounded-lg border border-slate-100 bg-slate-50 p-3 transition hover:bg-slate-100"
             >
               <input
                 type="checkbox"
                 class="rounded border-slate-300 text-brand-500"
-                :checked="selectedActivityIds.includes(activity.id)"
-                @change="toggleActivity(activity.id)"
+                :checked="isActivitySelected(activityRowId(activity))"
+                @change="toggleActivity(activityRowId(activity))"
               />
               <div class="min-w-0 flex-1">
                 <div class="flex items-center gap-2">
-                  <ActivityTypeBadge :value="activity.type" />
-                  <span class="truncate text-sm font-medium text-slate-700">{{ activity.title }}</span>
+                  <ActivityTypeBadge :value="activityTypeOf(activity)" />
+                  <span class="truncate text-sm font-medium text-slate-700">{{ activity.title ?? activity.activityTitle }}</span>
                 </div>
-                <p class="mt-0.5 text-xs text-slate-400">{{ activity.date }} · {{ activity.author }}</p>
+                <p class="mt-0.5 text-xs text-slate-400">{{ activity.date ?? activity.activityDate }} · {{ activity.author ?? activity.authorName }}</p>
               </div>
             </div>
           </div>
@@ -730,7 +751,7 @@ async function savePackage() {
             <DateField v-model="dateTo" />
           </div>
           <div class="flex justify-end">
-            <BaseButton variant="secondary" size="sm" @click="dateFrom = ''; dateTo = todayKr()">기간 초기화</BaseButton>
+            <BaseButton variant="secondary" size="sm" @click="dateFrom = ''; dateTo = ''">기간 초기화</BaseButton>
           </div>
         </div>
       </template>


### PR DESCRIPTION
## 📋 작업 내용

- 활동패키지 등록 시 종료일 기본값 때문에 시작일 누락 토스트가 뜨던 검증 오류를 수정했습니다.
- 활동패키지 PDF 생성을 프론트 jsPDF에서 백엔드 report endpoint(blob) 호출로 전환해 한글 깨짐을 방지했습니다.
- 패키지 id/title, 활동 id/type/date, 마스터 clientId/itemId 필드 불일치 구간을 정규화했습니다.
- 거래처/품목 저장·삭제 실패 시 백엔드 오류 메시지를 토스트로 노출하도록 보강했습니다.
- 활동 우선순위 값을 백엔드 enum에 맞춰 medium 대신 normal로 통일했습니다.

## 🔗 관련 이슈

- closes #486

## 📸 스크린샷 (선택)

N/A

## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

검증: `npx vite build --outDir dist-check --emptyOutDir false`

빌드 경고는 기존 dynamic/static import 중복 및 chunk size 경고만 발생했습니다.