### PR TITLE
fix(#488): 결재 요청 스냅샷을 대시보드에 반영

### DIFF
--- a/src/stores/approvalRequests.js
+++ b/src/stores/approvalRequests.js
@@ -5,6 +5,20 @@ import { useAuthStore } from './auth'
 const approvalRequests = ref([])
 let loading = null
 
+function parseJsonSafe(value, fallback = null) {
+  if (typeof value !== 'string') return value ?? fallback
+  try { return JSON.parse(value) } catch { return fallback }
+}
+
+function normalizeApprovalRequest(row) {
+  const reviewSnapshot = parseJsonSafe(row?.reviewSnapshot ?? row?.approvalReview, null)
+  return {
+    ...row,
+    reviewSnapshot,
+    approvalReview: reviewSnapshot,
+  }
+}
+
 /**
  * 결재 요청 원본 리스트 로드.
  * piDocuments/poDocuments 가 각 문서에 결재자/반려사유를 병합할 때 참조하고,
@@ -13,7 +27,7 @@ let loading = null
 export async function loadApprovalRequests() {
   try {
     const list = await fetchApprovalRequests()
-    approvalRequests.value = Array.isArray(list) ? list : []
+    approvalRequests.value = Array.isArray(list) ? list.map(normalizeApprovalRequest) : []
   } catch (e) {
     console.error('Failed to load approval requests:', e)
     approvalRequests.value = []

--- a/src/stores/piDocuments.js
+++ b/src/stores/piDocuments.js
@@ -100,6 +100,7 @@ function attachApprovalInfo(row) {
     approvalRequestId: req.approvalRequestId ?? row.approvalRequestId ?? null,
     approverId: req.approverId ?? row.approverId ?? null,
     approverName: req.approverName ?? row.approverName ?? null,
+    approvalReview: req.approvalReview ?? req.reviewSnapshot ?? row.approvalReview ?? null,
     approvalRejectReason:
       statusLower === 'rejected' ? (req.reason ?? row.approvalRejectReason ?? null) : (row.approvalRejectReason ?? null),
   }

--- a/src/stores/poDocuments.js
+++ b/src/stores/poDocuments.js
@@ -110,6 +110,7 @@ function attachApprovalInfo(row) {
     approvalRequestId: req.approvalRequestId ?? row.approvalRequestId ?? null,
     approverId: req.approverId ?? row.approverId ?? null,
     approverName: req.approverName ?? row.approverName ?? null,
+    approvalReview: req.approvalReview ?? req.reviewSnapshot ?? row.approvalReview ?? null,
     approvalRejectReason:
       statusLower === 'rejected' ? (req.reason ?? row.approvalRejectReason ?? null) : (row.approvalRejectReason ?? null),
   }


### PR DESCRIPTION
## 📋 작업 내용

- approval request의 reviewSnapshot을 approvalReview로 정규화했습니다.
- PI/PO store가 최신 pending approval request의 검토 스냅샷을 문서 row에 병합하도록 수정했습니다.
- 대시보드 결재 모달이 현재 문서 fallback 대신 수정요청 시점의 변경 후 품목 스냅샷을 표시하도록 했습니다.

## 🔗 관련 이슈

- closes #488

## 📸 스크린샷 (선택)

N/A

## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

검증: `npx vite build --outDir dist-check --emptyOutDir false`

빌드 경고는 기존 dynamic/static import 중복 및 chunk size 경고만 발생했습니다.