### PR TITLE
fix(#490): 활동패키지 생성 후 목록 반영

### DIFF
--- a/src/api/package.js
+++ b/src/api/package.js
@@ -1,17 +1,36 @@
 import { api } from '@/lib/api'
 import { unwrapCollection } from '@/utils/apiResponse'
 
+function unwrapEntity(data) {
+  if (data?.content && typeof data.content === 'object' && !Array.isArray(data.content)) {
+    return data.content
+  }
+  return data
+}
+
+function normalizeIdList(value, idKey) {
+  if (!Array.isArray(value)) return []
+  return value
+    .map((item) => (item && typeof item === 'object' ? item[idKey] ?? item.id : item))
+    .filter((item) => item != null)
+}
+
 function normalizePackage(pkg) {
-  if (!pkg) return pkg
+  const source = unwrapEntity(pkg)
+  if (!source) return source
   return {
-    ...pkg,
-    id: pkg.id ?? pkg.packageId,
-    title: pkg.title ?? pkg.packageTitle,
+    ...source,
+    id: source.id ?? source.packageId,
+    title: source.title ?? source.packageTitle,
+    activityIds: source.activityIds ?? normalizeIdList(source.items, 'activityId'),
+    viewerIds: source.viewerIds ?? normalizeIdList(source.viewers, 'userId'),
   }
 }
 
 export function fetchPackages() {
-  return api.get('/activity-packages').then((r) => unwrapCollection(r.data).map(normalizePackage))
+  return api
+    .get('/activity-packages', { params: { size: 1000, _ts: Date.now() } })
+    .then((r) => unwrapCollection(r.data).map(normalizePackage))
 }
 
 export function fetchPackageById(id) {
@@ -19,11 +38,11 @@ export function fetchPackageById(id) {
 }
 
 export function createPackage(data) {
-  return api.post('/activity-packages', data).then((r) => normalizePackage(r.data?.content ?? r.data))
+  return api.post('/activity-packages', data).then((r) => normalizePackage(r.data))
 }
 
 export function updatePackage(id, data) {
-  return api.put(`/activity-packages/${id}`, data).then((r) => normalizePackage(r.data?.content ?? r.data))
+  return api.put(`/activity-packages/${id}`, data).then((r) => normalizePackage(r.data))
 }
 
 export function deletePackage(id) {

--- a/src/views/DashboardPage.vue
+++ b/src/views/DashboardPage.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { computed, onMounted, ref } from 'vue'
-import { RouterLink, useRouter } from 'vue-router'
+import { RouterLink, useRoute, useRouter } from 'vue-router'
 import ApprovalReviewModal from '@/components/common/ApprovalReviewModal.vue'
 import BaseCard from '@/components/common/BaseCard.vue'
 import ConfirmModal from '@/components/common/ConfirmModal.vue'
@@ -14,7 +14,7 @@ import { useProductionOrderDocuments, loadProductionOrderDocuments } from '@/sto
 import { useShipmentStatusDocuments, loadShipmentStatusDocuments } from '@/stores/shipmentStatusDocuments'
 import { fetchActivities } from '@/api/activity'
 import { fetchClients } from '@/api/master'
-import { fetchPackages, deletePackage as deletePackageApi } from '@/api/package'
+import { fetchPackageById, fetchPackages, deletePackage as deletePackageApi } from '@/api/package'
 import { updateApprovalRequest } from '@/api/documents'
 import { loadApprovalRequests } from '@/stores/approvalRequests'
 import { label as enumLabel, PI_PO_STATUS_LABEL } from '@/utils/enumLabels'
@@ -22,6 +22,7 @@ import { useToast } from '@/composables/useToast'
 import PackageDetailModal from '@/components/domain/activity/PackageDetailModal.vue'
 
 const router = useRouter()
+const route = useRoute()
 const authStore = useAuthStore()
 const { success, error: toastError } = useToast()
 const ciDocuments = useCiDocuments()
@@ -66,6 +67,10 @@ onMounted(async () => {
     loadProductionOrderDocuments(),
     loadShipmentStatusDocuments(),
   ])
+
+  if (canFetchPackages) {
+    await ensureCreatedPackageVisible()
+  }
 })
 
 const currentUser = computed(() => authStore.currentUser ?? null)
@@ -85,6 +90,44 @@ const requestSectionTitle = computed(() => {
 function parseSlashDate(value) {
   if (!value) return 0
   return new Date(String(value).replace(/\./g, '-').replace(/\//g, '-')).getTime() || 0
+}
+
+function packageIdOf(pkg) {
+  return pkg?.packageId ?? pkg?.id
+}
+
+function packageViewerIds(pkg) {
+  return (pkg?.viewerIds ?? pkg?.viewers ?? [])
+    .map((viewer) => (viewer && typeof viewer === 'object' ? viewer.userId ?? viewer.id : viewer))
+    .filter((viewer) => viewer != null)
+}
+
+function upsertPackage(pkg) {
+  const packageId = packageIdOf(pkg)
+  if (!packageId) return
+  const exists = packagesData.value.some((row) => String(packageIdOf(row)) === String(packageId))
+  packagesData.value = exists
+    ? packagesData.value.map((row) => String(packageIdOf(row)) === String(packageId) ? pkg : row)
+    : [pkg, ...packagesData.value]
+}
+
+async function ensureCreatedPackageVisible() {
+  const rawId = Array.isArray(route.query.createdPackageId)
+    ? route.query.createdPackageId[0]
+    : route.query.createdPackageId
+  if (!rawId) return
+  const existing = packagesData.value.find((pkg) => String(packageIdOf(pkg)) === String(rawId))
+  if (existing) {
+    selectedPackage.value = existing
+    return
+  }
+  try {
+    const pkg = await fetchPackageById(rawId)
+    upsertPackage(pkg)
+    selectedPackage.value = pkg
+  } catch (e) {
+    console.error('생성 패키지 상세 로드 실패', e)
+  }
 }
 
 function findLatestRow(rows, dateField) {
@@ -535,7 +578,7 @@ const visiblePackages = computed(() => {
   }
   const uid = currentUserId.value
   return [...packagesData.value]
-    .filter((pkg) => String(pkg.creatorId) === uid || (pkg.viewers ?? []).map(String).includes(uid))
+    .filter((pkg) => String(pkg.creatorId) === uid || packageViewerIds(pkg).map(String).includes(uid))
     .sort((a, b) => parseSlashDate(b.createdAt) - parseSlashDate(a.createdAt))
     .slice(0, 5)
 })

--- a/src/views/package/ActivityPackagePage.vue
+++ b/src/views/package/ActivityPackagePage.vue
@@ -418,6 +418,7 @@ async function savePackage() {
   }
 
   try {
+    let nextRoute = '/'
     if (isEditMode.value) {
       delete payload.createdAt
       await updatePackage(editId.value, payload)
@@ -427,10 +428,14 @@ async function savePackage() {
       // ActivityPackageCreateRequest 레코드엔 해당 필드가 없고 PK 는 DB auto.
       // Jackson strict 설정에서 이 알 수 없는 필드가 400 을 유발해 저장이 실패하던
       // 문제(G6). id 를 보내지 않도록 정리.
-      await createPackage(payload)
+      const savedPackage = await createPackage(payload)
+      const savedPackageId = savedPackage?.packageId ?? savedPackage?.id
+      if (savedPackageId) {
+        nextRoute = { path: '/', query: { createdPackageId: String(savedPackageId) } }
+      }
       success('패키지가 저장되었습니다.')
     }
-    router.push('/')
+    router.push(nextRoute)
   } catch (e) {
     // 서버 400/403 메시지를 토스트에 그대로 노출해 디버깅 가능.
     error(e?.response?.data?.message || '패키지 저장에 실패했습니다.')


### PR DESCRIPTION
## 📋 작업 내용

- 활동패키지 API wrapper가 EntityModel 응답과 ID 목록을 일관되게 정규화하도록 보강했습니다.
- 패키지 목록 조회 시 운영 데이터 증가와 캐시 영향에 대비해 size=1000 및 cache-busting query를 적용했습니다.
- 패키지 생성 후 대시보드로 이동할 때 생성된 packageId를 전달하고, 대시보드에서 상세 조회 후 목록에 병합하도록 수정했습니다.
- 대시보드 공유 패키지 필터가 존재하지 않는 viewers 대신 백엔드 응답 필드 viewerIds를 사용하도록 수정했습니다.
- 생성 직후 대시보드에서 생성된 패키지 상세 모달을 열어 저장 결과를 바로 확인할 수 있게 했습니다.

## 🔗 관련 이슈

- closes #490

## 📸 스크린샷 (선택)

N/A

## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

검증: `npx vite build --outDir dist-check --emptyOutDir false`

빌드 경고는 기존 dynamic/static import 중복 및 chunk size 경고만 발생했습니다.