### PR TITLE
fix(#492): PI 환율 표시와 기록관리 CRUD 반영

### DIFF
--- a/src/api/activity.js
+++ b/src/api/activity.js
@@ -1,6 +1,30 @@
 import { api } from '@/lib/api'
 import { unwrapCollection } from '@/utils/apiResponse'
 
+function unwrapEntity(data) {
+  if (data?.content && typeof data.content === 'object' && !Array.isArray(data.content)) {
+    return data.content
+  }
+  return data
+}
+
+function normalizeActivity(row) {
+  const activity = unwrapEntity(row)
+  if (!activity) return activity
+  return {
+    ...activity,
+    id: activity.id ?? activity.activityId,
+    type: activity.type ?? activity.activityType,
+    title: activity.title ?? activity.activityTitle,
+    date: activity.date ?? activity.activityDate,
+    author: activity.author ?? activity.authorName,
+    content: activity.content ?? activity.activityContent,
+    priority: activity.priority ?? activity.activityPriority,
+    scheduleFrom: activity.scheduleFrom ?? activity.activityScheduleFrom,
+    scheduleTo: activity.scheduleTo ?? activity.activityScheduleTo,
+  }
+}
+
 // ── 거래처 ─────────────────────────────────────────────────
 // master 의 /api/clients/all 은 HATEOAS PagedModel 로 응답한다. unwrapCollection 으로
 // 배열만 꺼내야 호출자(활동기록 드롭다운 등)의 .map 이 정상 동작.
@@ -10,19 +34,26 @@ export async function fetchActivityClients() {
 }
 
 // ── 활동기록 ───────────────────────────────────────────────
-export async function fetchActivities() {
-  const { data } = await api.get('/activities')
-  return unwrapCollection(data)
+export async function fetchActivities(params = {}) {
+  const { data } = await api.get('/activities', {
+    params: { size: 1000, _ts: Date.now(), ...params },
+  })
+  return unwrapCollection(data).map(normalizeActivity)
+}
+
+export async function fetchActivity(id) {
+  const { data } = await api.get(`/activities/${id}`)
+  return normalizeActivity(data)
 }
 
 export async function createActivity(activity) {
   const { data } = await api.post('/activities', activity)
-  return data
+  return normalizeActivity(data)
 }
 
 export async function updateActivity(id, activity) {
   const { data } = await api.put(`/activities/${id}`, activity)
-  return data
+  return normalizeActivity(data)
 }
 
 export async function deleteActivity(id) {

--- a/src/components/domain/document/PIFormModal.vue
+++ b/src/components/domain/document/PIFormModal.vue
@@ -856,6 +856,7 @@ watch(
 // 덮어써지는 데이터 손실이 있어 발동하지 않는다. 수정 시 통화/발행일 변경은 기존 watcher 가 처리.
 watch(exchangeRatesLoaded, (ready) => {
   if (!ready) return
+  exchangeRateHint.value = createExchangeRateHint(form.value.currency || 'USD')
   if (props.mode === 'edit') return
   refreshAutoPricedItems()
 })

--- a/src/views/activity/ActivityCreatePage.vue
+++ b/src/views/activity/ActivityCreatePage.vue
@@ -18,7 +18,7 @@ import SearchModal from '@/components/common/SearchModal.vue'
 
 const router = useRouter()
 const authStore = useAuthStore()
-const { warning, error } = useToast()
+const { success, warning, error } = useToast()
 
 // ── state ──────────────────────────────────────────────────
 const isSubmitting = ref(false)
@@ -253,7 +253,7 @@ async function handleSubmit() {
   }
   isSubmitting.value = true
   try {
-    await createActivity({
+    const savedActivity = await createActivity({
       clientId:             formClient.value,
       activityType:         formType.value,
       activityDate:         formDate.value,
@@ -264,10 +264,14 @@ async function handleSubmit() {
       activityScheduleFrom: isSchedule.value ? formScheduleFrom.value : undefined,
       activityScheduleTo:   isSchedule.value ? formScheduleTo.value : undefined,
     })
-    router.push('/activities')
+    success('기록이 등록되었습니다.')
+    const savedActivityId = savedActivity?.id ?? savedActivity?.activityId
+    router.push(savedActivityId
+      ? { path: '/activities', query: { createdActivityId: String(savedActivityId) } }
+      : '/activities')
   } catch (e) {
     console.error('기록 등록 실패', e)
-    error('기록 등록에 실패했습니다. 다시 시도해주세요.')
+    error(e?.response?.data?.message || '기록 등록에 실패했습니다. 다시 시도해주세요.')
   } finally {
     isSubmitting.value = false
   }

--- a/src/views/activity/ActivityListPage.vue
+++ b/src/views/activity/ActivityListPage.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { computed, onMounted, ref, watch } from 'vue'
-import { useRouter } from 'vue-router'
-import { fetchActivities, deleteActivity, updateActivity } from '@/api/activity'
+import { useRoute, useRouter } from 'vue-router'
+import { fetchActivity, fetchActivities, deleteActivity, updateActivity } from '@/api/activity'
 import { fetchClients } from '@/api/master'
 import { useToast } from '@/composables/useToast'
 import ActivityDetailModal from '@/components/domain/activity/ActivityDetailModal.vue'
@@ -21,7 +21,8 @@ import TableActions from '@/components/common/TableActions.vue'
 import SearchTriggerField from '@/components/common/SearchTriggerField.vue'
 
 const router = useRouter()
-const { error } = useToast()
+const route = useRoute()
+const { success, error } = useToast()
 
 // ── 필터 상태 ──────────────────────────────────────────────
 const isFilterOpen = ref(false)
@@ -76,6 +77,38 @@ function resetFilters() {
 const activities = ref([])
 const clients = ref([])
 
+function activityIdOf(activity) {
+  return activity?.id ?? activity?.activityId
+}
+
+function upsertActivity(activity) {
+  const activityId = activityIdOf(activity)
+  if (!activityId) return
+  const exists = activities.value.some((row) => String(activityIdOf(row)) === String(activityId))
+  activities.value = exists
+    ? activities.value.map((row) => String(activityIdOf(row)) === String(activityId) ? activity : row)
+    : [activity, ...activities.value]
+}
+
+async function ensureCreatedActivityVisible() {
+  const rawId = Array.isArray(route.query.createdActivityId)
+    ? route.query.createdActivityId[0]
+    : route.query.createdActivityId
+  if (!rawId) return
+  const existing = activities.value.find((activity) => String(activityIdOf(activity)) === String(rawId))
+  if (existing) {
+    openDetail(existing)
+    return
+  }
+  try {
+    const activity = await fetchActivity(rawId)
+    upsertActivity(activity)
+    openDetail(activity)
+  } catch (e) {
+    console.error('생성 기록 상세 로드 실패', e)
+  }
+}
+
 async function loadActivities() {
   try {
     activities.value = await fetchActivities()
@@ -93,6 +126,7 @@ onMounted(async () => {
     ])
     activities.value = activityData
     clients.value = clientData
+    await ensureCreatedActivityVisible()
   } catch (e) {
     console.error('데이터 로드 실패', e)
     error('데이터를 불러오지 못했습니다. 페이지를 새로고침해주세요.')
@@ -174,7 +208,7 @@ const isSaving = ref(false)
 
 async function handleSave(updated) {
   if (isSaving.value) return
-  const activityId = editActivity.value?.id
+  const activityId = activityIdOf(editActivity.value)
   if (!activityId) return
   isSaving.value = true
   try {
@@ -182,6 +216,7 @@ async function handleSave(updated) {
     // 이전엔 폼 payload 를 로컬 row 에 spread 해서 type/author 등 서버 가공값이
     // 덮이지 않아 목록이 stale 로 보임. 서버 응답을 신뢰하기 위해 목록 재fetch.
     await loadActivities()
+    success('기록이 수정되었습니다.')
     closeEdit()
   } catch (e) {
     console.error('기록 수정 실패', e)
@@ -209,16 +244,17 @@ const isDeleting = ref(false)
 
 async function handleDelete() {
   if (isDeleting.value) return
-  const targetId = deleteTarget.value?.id
+  const targetId = activityIdOf(deleteTarget.value)
   if (!targetId) return
   isDeleting.value = true
   try {
     await deleteActivity(targetId)
-    activities.value = activities.value.filter((a) => a.id !== targetId)
+    activities.value = activities.value.filter((a) => String(activityIdOf(a)) !== String(targetId))
+    success('기록이 삭제되었습니다.')
     closeDelete()
   } catch (e) {
     console.error('기록 삭제 실패', e)
-    error('기록 삭제에 실패했습니다. 다시 시도해주세요.')
+    error(e?.response?.data?.message || '기록 삭제에 실패했습니다. 다시 시도해주세요.')
   } finally {
     isDeleting.value = false
   }


### PR DESCRIPTION
## 📋 작업 내용

- PI 수정 모달에서 환율 로딩이 늦게 완료되면 환율 힌트가 갱신되지 않던 문제를 수정했습니다.
- 활동기록 API wrapper에서 HATEOAS EntityModel 응답과 activityId/id 필드를 정규화했습니다.
- 기록관리 목록 조회를 size=1000 + cache-busting query로 가져오도록 보강했습니다.
- 기록 등록 후 생성된 기록 ID를 목록으로 전달하고, 목록에서 상세 조회/상세 모달 오픈으로 저장 결과를 즉시 확인하게 했습니다.
- 기록 수정/삭제가 id와 activityId 양쪽을 지원하고 성공 토스트를 표시하도록 수정했습니다.

## 🔗 관련 이슈

- closes #492

## 📸 스크린샷 (선택)

N/A

## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

검증:
- `npx vite build --outDir dist-check --emptyOutDir false`
- 운영 API 이영업 계정으로 활동기록 테스트 생성/즉시 삭제 성공 확인

빌드 경고는 기존 dynamic/static import 중복 및 chunk size 경고만 발생했습니다.