### PR TITLE
fix(#494): 날짜 KST 정합성 보정

### DIFF
--- a/src/components/common/BaseTable.vue
+++ b/src/components/common/BaseTable.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { computed, onBeforeUnmount, ref, watch } from 'vue'
+import { parseKstDateValue } from '@/utils/dateTime'
 
 const props = defineProps({
   columns: {
@@ -129,8 +130,8 @@ function parseSortValue(val) {
   if (!Number.isNaN(num) && typeof val !== 'boolean') return num
   // 날짜 패턴 (YYYY/MM/DD, YYYY-MM-DD, YYYY.MM.DD)
   const dateStr = String(val).replace(/\./g, '-').replace(/\//g, '-')
-  const ts = Date.parse(dateStr)
-  if (Number.isFinite(ts)) return ts
+  const ts = parseKstDateValue(dateStr)
+  if (ts > 0) return ts
   // 문자열
   return String(val).toLowerCase()
 }

--- a/src/components/domain/document/PIFormModal.vue
+++ b/src/components/domain/document/PIFormModal.vue
@@ -33,6 +33,7 @@ import {
   getKrwRate,
   useExchangeRates,
 } from '@/stores/exchangeRates'
+import { formatKstDateInput } from '@/utils/dateTime'
 
 const props = defineProps({
   open: { type: Boolean, default: false },
@@ -92,11 +93,7 @@ const currencySymbolMap = {
 }
 
 function getTodayDateInput() {
-  const today = new Date()
-  const year = today.getFullYear()
-  const month = String(today.getMonth() + 1).padStart(2, '0')
-  const day = String(today.getDate()).padStart(2, '0')
-  return `${year}-${month}-${day}`
+  return formatKstDateInput()
 }
 
 function getDefaultApprover() {

--- a/src/composables/useDocumentFilter.js
+++ b/src/composables/useDocumentFilter.js
@@ -1,4 +1,5 @@
 import { computed, ref, watch } from 'vue'
+import { formatKstDateInput, parseKstDateValue } from '@/utils/dateTime'
 
 /**
  * 문서 목록 페이지 공통 필터 composable
@@ -42,15 +43,11 @@ export function useDocumentFilter(rows, options = {}) {
   }
 
   function normalizeDate(value) {
-    return String(value ?? '').replaceAll('/', '-')
+    return formatKstDateInput(value)
   }
 
   function parseSortableDate(value) {
-    const normalized = normalizeDate(value)
-    if (!normalized) return 0
-
-    const timestamp = new Date(normalized).getTime()
-    return Number.isFinite(timestamp) ? timestamp : 0
+    return parseKstDateValue(value)
   }
 
   function resetFilters() {

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -3,7 +3,7 @@ import { startLoading, stopLoading } from '@/stores/loading'
 
 export const api = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL ?? '/api',
-  timeout: 8000,
+  timeout: 20000,
   withCredentials: true, // HttpOnly 쿠키 자동 송수신 (RT)
 })
 

--- a/src/stores/approvalRequests.js
+++ b/src/stores/approvalRequests.js
@@ -1,6 +1,7 @@
 import { ref } from 'vue'
 import { fetchApprovalRequests } from '@/api/documents'
 import { useAuthStore } from './auth'
+import { parseKstDateTimeValue } from '@/utils/dateTime'
 
 const approvalRequests = ref([])
 let loading = null
@@ -62,8 +63,8 @@ export function pickLatestRequestFor(documentType, documentId) {
 }
 
 function byRequestedAtDesc(a, b) {
-  const ta = a?.requestedAt ? new Date(a.requestedAt).getTime() : 0
-  const tb = b?.requestedAt ? new Date(b.requestedAt).getTime() : 0
+  const ta = parseKstDateTimeValue(a?.requestedAt)
+  const tb = parseKstDateTimeValue(b?.requestedAt)
   return tb - ta
 }
 

--- a/src/stores/ciDocuments.js
+++ b/src/stores/ciDocuments.js
@@ -2,9 +2,10 @@ import { useAuthStore } from './auth'
 import { ref } from 'vue'
 import { fetchCommercialInvoicesPaged } from '@/api/documents'
 import { formatCurrencyAmount, getCurrencyDecimals } from '@/utils/currencyFormat'
+import { formatKstSlashDate } from '@/utils/dateTime'
 
 function formatDate(value) {
-  return String(value ?? '').replace(/-/g, '/')
+  return formatKstSlashDate(value)
 }
 
 function formatNumber(value, maximumFractionDigits = 0) {

--- a/src/stores/piDocuments.js
+++ b/src/stores/piDocuments.js
@@ -3,6 +3,7 @@ import { ref } from 'vue'
 import { fetchProformaInvoicesPaged } from '@/api/documents'
 import { loadApprovalRequests, pickLatestRequestFor } from './approvalRequests'
 import { formatCurrencyAmount } from '@/utils/currencyFormat'
+import { formatKstDateTime, formatKstSlashDate } from '@/utils/dateTime'
 
 function tryParseJson(value, fallback = null) {
   if (typeof value !== 'string') return value ?? fallback
@@ -10,17 +11,11 @@ function tryParseJson(value, fallback = null) {
 }
 
 function formatTimestamp(value) {
-  if (!value) return null
-  const str = String(value)
-  if (str.includes('T')) {
-    const [date, time] = str.split('T')
-    return `${date.replace(/-/g, '/')} ${time.substring(0, 5)}`
-  }
-  return str
+  return value ? formatKstDateTime(value) : null
 }
 
 function formatDate(value) {
-  return String(value ?? '').replace(/-/g, '/')
+  return formatKstSlashDate(value)
 }
 
 function mapPiResponse(row) {

--- a/src/stores/plDocuments.js
+++ b/src/stores/plDocuments.js
@@ -1,9 +1,10 @@
 import { useAuthStore } from './auth'
 import { ref } from 'vue'
 import { fetchPackingListsPaged } from '@/api/documents'
+import { formatKstSlashDate } from '@/utils/dateTime'
 
 function formatDate(value) {
-  return String(value ?? '').replace(/-/g, '/')
+  return formatKstSlashDate(value)
 }
 
 function formatNumber(value, maximumFractionDigits = 0) {

--- a/src/stores/poDocuments.js
+++ b/src/stores/poDocuments.js
@@ -3,19 +3,14 @@ import { ref } from 'vue'
 import { fetchPurchaseOrdersPaged } from '@/api/documents'
 import { loadApprovalRequests, pickLatestRequestFor } from './approvalRequests'
 import { formatCurrencyAmount } from '@/utils/currencyFormat'
+import { formatKstDateTime, formatKstSlashDate } from '@/utils/dateTime'
 
 function formatDate(value) {
-  return String(value ?? '').replace(/-/g, '/')
+  return formatKstSlashDate(value)
 }
 
 function formatTimestamp(value) {
-  if (!value) return null
-  const str = String(value)
-  if (str.includes('T')) {
-    const [date, time] = str.split('T')
-    return `${date.replace(/-/g, '/')} ${time.substring(0, 5)}`
-  }
-  return str
+  return value ? formatKstDateTime(value) : null
 }
 
 function parseJsonSafe(value, fallback = null) {

--- a/src/stores/productionOrderDocuments.js
+++ b/src/stores/productionOrderDocuments.js
@@ -1,9 +1,10 @@
 import { useAuthStore } from './auth'
 import { ref } from 'vue'
 import { fetchProductionOrdersPaged } from '@/api/documents'
+import { formatKstSlashDate } from '@/utils/dateTime'
 
 function formatDate(value) {
-  return String(value ?? '').replace(/-/g, '/')
+  return formatKstSlashDate(value)
 }
 
 function parseLinkedDocuments(value) {

--- a/src/stores/shipmentOrderDocuments.js
+++ b/src/stores/shipmentOrderDocuments.js
@@ -1,9 +1,10 @@
 import { useAuthStore } from './auth'
 import { ref } from 'vue'
 import { fetchShipmentOrdersPaged } from '@/api/documents'
+import { formatKstSlashDate } from '@/utils/dateTime'
 
 function formatDate(value) {
-  return String(value ?? '').replace(/-/g, '/')
+  return formatKstSlashDate(value)
 }
 
 function parseLinkedDocuments(value) {

--- a/src/stores/shipmentStatusDocuments.js
+++ b/src/stores/shipmentStatusDocuments.js
@@ -1,9 +1,10 @@
 import { useAuthStore } from './auth'
 import { ref } from 'vue'
 import { fetchShipmentsPaged } from '@/api/documents'
+import { formatKstSlashDate } from '@/utils/dateTime'
 
 function formatDate(value) {
-  return String(value ?? '').replace(/-/g, '/')
+  return formatKstSlashDate(value)
 }
 
 const SHIPMENT_STATUS_LABEL = {

--- a/src/utils/dateTime.js
+++ b/src/utils/dateTime.js
@@ -1,0 +1,122 @@
+export const KST_TIME_ZONE = 'Asia/Seoul'
+
+const EXPLICIT_ZONE_PATTERN = /(?:[zZ]|[+-]\d{2}:?\d{2})$/
+const LOCAL_DATE_TIME_PATTERN = /^(\d{4})[-/.](\d{1,2})[-/.](\d{1,2})(?:[T\s](\d{1,2}):(\d{1,2})(?::(\d{1,2}))?)?/
+
+const kstDateFormatter = new Intl.DateTimeFormat('en-CA', {
+  timeZone: KST_TIME_ZONE,
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+})
+
+const kstDateTimeFormatter = new Intl.DateTimeFormat('en-CA', {
+  timeZone: KST_TIME_ZONE,
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+  hourCycle: 'h23',
+})
+
+function pad(value) {
+  return String(value).padStart(2, '0')
+}
+
+function partsToMap(parts) {
+  return Object.fromEntries(parts.map(({ type, value }) => [type, value]))
+}
+
+function parseLocalDateTime(value) {
+  const match = String(value ?? '').trim().match(LOCAL_DATE_TIME_PATTERN)
+  if (!match) return null
+
+  const [, year, month, day, hour = '0', minute = '0', second = '0'] = match
+  return {
+    year,
+    month: pad(month),
+    day: pad(day),
+    hour: pad(hour),
+    minute: pad(minute),
+    second: pad(second),
+  }
+}
+
+function hasExplicitZone(value) {
+  return EXPLICIT_ZONE_PATTERN.test(String(value ?? '').trim())
+}
+
+export function formatKstDateInput(value) {
+  if (arguments.length === 0) value = new Date()
+  if (value == null || value === '') return ''
+
+  if (typeof value === 'string') {
+    const local = parseLocalDateTime(value)
+    if (local && !hasExplicitZone(value)) {
+      return `${local.year}-${local.month}-${local.day}`
+    }
+  }
+
+  const date = value instanceof Date ? value : new Date(value)
+  if (!Number.isFinite(date.getTime())) return ''
+
+  const parts = partsToMap(kstDateFormatter.formatToParts(date))
+  return `${parts.year}-${parts.month}-${parts.day}`
+}
+
+export function formatKstSlashDate(value) {
+  if (arguments.length === 0) value = new Date()
+  const dateInput = formatKstDateInput(value)
+  return dateInput ? dateInput.replaceAll('-', '/') : ''
+}
+
+export function formatKstDateTime(value) {
+  if (arguments.length === 0) value = new Date()
+  if (value == null || value === '') return ''
+
+  if (typeof value === 'string') {
+    const local = parseLocalDateTime(value)
+    if (local && !hasExplicitZone(value)) {
+      return `${local.year}/${local.month}/${local.day} ${local.hour}:${local.minute}`
+    }
+  }
+
+  const date = value instanceof Date ? value : new Date(value)
+  if (!Number.isFinite(date.getTime())) return String(value)
+
+  const parts = partsToMap(kstDateTimeFormatter.formatToParts(date))
+  return `${parts.year}/${parts.month}/${parts.day} ${parts.hour}:${parts.minute}`
+}
+
+export function parseKstDateValue(value) {
+  const dateInput = formatKstDateInput(value)
+  if (!dateInput) return 0
+
+  const [year, month, day] = dateInput.split('-').map(Number)
+  const timestamp = Date.UTC(year, month - 1, day)
+  return Number.isFinite(timestamp) ? timestamp : 0
+}
+
+export function parseKstDateTimeValue(value) {
+  if (value == null || value === '') return 0
+  if (value instanceof Date) return value.getTime()
+
+  const local = parseLocalDateTime(value)
+  if (local && !hasExplicitZone(value)) {
+    const timestamp = Date.UTC(
+      Number(local.year),
+      Number(local.month) - 1,
+      Number(local.day),
+      Number(local.hour),
+      Number(local.minute),
+      Number(local.second),
+    )
+    return Number.isFinite(timestamp) ? timestamp : 0
+  }
+
+  const timestamp = new Date(value).getTime()
+  if (Number.isFinite(timestamp)) return timestamp
+
+  return parseKstDateValue(value)
+}

--- a/src/utils/documentActivityEmail.js
+++ b/src/utils/documentActivityEmail.js
@@ -2,6 +2,7 @@ import { fetchBuyersByClient, fetchClients, fetchCurrencies, fetchItems, fetchPo
 import { api } from '@/lib/api'
 import { resolveMasterCurrency, resolvePaymentTermLabel, resolvePortLabel } from '@/utils/ciplMaster'
 import { formatCurrencyAmount } from '@/utils/currencyFormat'
+import { formatKstSlashDate } from '@/utils/dateTime'
 import { resolveIncotermState } from '@/utils/incoterms'
 
 const clientsByName = new Map()
@@ -48,14 +49,7 @@ function parseNumericValue(value) {
 }
 
 function formatDateSlash(value = new Date()) {
-  if (value instanceof Date) {
-    const year = value.getFullYear()
-    const month = String(value.getMonth() + 1).padStart(2, '0')
-    const day = String(value.getDate()).padStart(2, '0')
-    return `${year}/${month}/${day}`
-  }
-
-  return String(value ?? '').replace(/-/g, '/')
+  return formatKstSlashDate(value)
 }
 
 function formatNumber(value, maximumFractionDigits = 0) {

--- a/src/views/DashboardPage.vue
+++ b/src/views/DashboardPage.vue
@@ -20,6 +20,7 @@ import { loadApprovalRequests } from '@/stores/approvalRequests'
 import { label as enumLabel, PI_PO_STATUS_LABEL } from '@/utils/enumLabels'
 import { useToast } from '@/composables/useToast'
 import PackageDetailModal from '@/components/domain/activity/PackageDetailModal.vue'
+import { formatKstDateTime, parseKstDateTimeValue, parseKstDateValue } from '@/utils/dateTime'
 
 const router = useRouter()
 const route = useRoute()
@@ -88,8 +89,7 @@ const requestSectionTitle = computed(() => {
 })
 
 function parseSlashDate(value) {
-  if (!value) return 0
-  return new Date(String(value).replace(/\./g, '-').replace(/\//g, '-')).getTime() || 0
+  return parseKstDateValue(value)
 }
 
 function packageIdOf(pkg) {
@@ -281,9 +281,7 @@ const recentActivities = computed(() => {
 })
 
 function parseRequestedAt(value) {
-  const normalized = String(value ?? '').trim()
-  if (!normalized) return 0
-  return new Date(normalized.replace(/\./g, '-')).getTime() || 0
+  return parseKstDateTimeValue(value)
 }
 
 function buildFallbackReview(docType, row) {
@@ -448,13 +446,7 @@ function closeDecisionConfirm() {
 }
 
 function getReviewedAt() {
-  const now = new Date()
-  const year = now.getFullYear()
-  const month = String(now.getMonth() + 1).padStart(2, '0')
-  const day = String(now.getDate()).padStart(2, '0')
-  const hours = String(now.getHours()).padStart(2, '0')
-  const minutes = String(now.getMinutes()).padStart(2, '0')
-  return `${year}/${month}/${day} ${hours}:${minutes}`
+  return formatKstDateTime()
 }
 
 const decisionConfirmTitle = computed(() => (

--- a/src/views/activity/ActivityCreatePage.vue
+++ b/src/views/activity/ActivityCreatePage.vue
@@ -15,6 +15,7 @@ import DateField from '@/components/common/DateField.vue'
 import DocumentPageHeader from '@/components/common/DocumentPageHeader.vue'
 import SearchableCombobox from '@/components/common/SearchableCombobox.vue'
 import SearchModal from '@/components/common/SearchModal.vue'
+import { formatKstDateInput } from '@/utils/dateTime'
 
 const router = useRouter()
 const authStore = useAuthStore()
@@ -26,7 +27,7 @@ const formClient = ref('')
 const formType = ref('')
 const formPoDisplay = ref('')
 const formPoId = ref('')
-const formDate = ref(new Date().toISOString().slice(0, 10))
+const formDate = ref(formatKstDateInput())
 const formPriority = ref('normal')
 const formTitle = ref('')
 const formContent = ref('')
@@ -129,7 +130,7 @@ function nextMonth() {
   else calMonth.value++
 }
 
-const today = toDateStr(new Date())
+const today = formatKstDateInput()
 
 function clickDay(str) {
   if (!str) return

--- a/src/views/documents/CollectionsPage.vue
+++ b/src/views/documents/CollectionsPage.vue
@@ -21,6 +21,7 @@ import { useSalesCollectionDocuments, loadSalesCollectionDocuments, normalizeSal
 import { loadExchangeRates, clearExchangeRates } from '@/stores/exchangeRates'
 import { openTableOutput } from '@/utils/documentOutput'
 import { convertCurrencyAmountToKrw } from '@/utils/exchangeRate'
+import { formatKstSlashDate } from '@/utils/dateTime'
 import { clientSearchColumns } from '@/utils/searchModalColumns'
 import { buildSelectOptionsFromRows } from '@/utils/selectOptions'
 
@@ -224,11 +225,7 @@ function formatCollectionDate(value) {
 }
 
 function getTodaySlashDate() {
-  const today = new Date()
-  const year = today.getFullYear()
-  const month = String(today.getMonth() + 1).padStart(2, '0')
-  const day = String(today.getDate()).padStart(2, '0')
-  return `${year}/${month}/${day}`
+  return formatKstSlashDate()
 }
 
 function resolveNextCollectionDate(row, nextStatusValue) {

--- a/src/views/documents/PIDetailPage.vue
+++ b/src/views/documents/PIDetailPage.vue
@@ -52,6 +52,7 @@ import { formatReferenceDocumentStatus } from '@/utils/referenceDocumentStatus'
 import { formatIncotermsLabel, resolveIncotermState } from '@/utils/incoterms'
 import { clientSearchColumns } from '@/utils/searchModalColumns'
 import { label, PI_PO_STATUS_LABEL } from '@/utils/enumLabels'
+import { formatKstDateTime } from '@/utils/dateTime'
 
 const route = useRoute()
 const router = useRouter()
@@ -239,13 +240,7 @@ function getCurrentRequesterName() {
 }
 
 function getRequestedAt() {
-  const now = new Date()
-  const year = now.getFullYear()
-  const month = String(now.getMonth() + 1).padStart(2, '0')
-  const day = String(now.getDate()).padStart(2, '0')
-  const hours = String(now.getHours()).padStart(2, '0')
-  const minutes = String(now.getMinutes()).padStart(2, '0')
-  return `${year}/${month}/${day} ${hours}:${minutes}`
+  return formatKstDateTime()
 }
 
 function getDefaultDeleteApprover(row) {

--- a/src/views/documents/PIPage.vue
+++ b/src/views/documents/PIPage.vue
@@ -61,6 +61,7 @@ import { formatIncotermsLabel, resolveIncotermState } from '@/utils/incoterms'
 import { clientSearchColumns, productSearchColumns } from '@/utils/searchModalColumns'
 import { buildSelectOptionsFromRows } from '@/utils/selectOptions'
 import { formatCurrencyAmount } from '@/utils/currencyFormat'
+import { formatKstDateTime } from '@/utils/dateTime'
 
 const router = useRouter()
 const authStore = useAuthStore()
@@ -530,13 +531,7 @@ function isPendingApproval(row) {
 }
 
 function getRequestedAt() {
-  const now = new Date()
-  const year = now.getFullYear()
-  const month = String(now.getMonth() + 1).padStart(2, '0')
-  const day = String(now.getDate()).padStart(2, '0')
-  const hours = String(now.getHours()).padStart(2, '0')
-  const minutes = String(now.getMinutes()).padStart(2, '0')
-  return `${year}/${month}/${day} ${hours}:${minutes}`
+  return formatKstDateTime()
 }
 
 function buildNextPiId() {
@@ -698,7 +693,7 @@ const createApprovalItemRows = computed(() => {
   return (nextRow.items ?? []).map((item, index) => ({
     id: `${item.name || 'item'}-${index}`,
     name: item.name || '-',
-    qty: parseAmount(item.qty) > 0 ? parseAmount(item.qty).toLocaleString() : '-',
+    qty: parseAmount(item.quantity ?? item.qty) > 0 ? parseAmount(item.quantity ?? item.qty).toLocaleString() : '-',
     unit: item.unit || '-',
     unitPrice: formatAmount(currency, parseAmount(item.unitPrice)),
     amount: formatAmount(currency, parseAmount(item.amount)),

--- a/src/views/documents/PODetailPage.vue
+++ b/src/views/documents/PODetailPage.vue
@@ -57,6 +57,7 @@ import {
 import { canMutateDocument } from '@/utils/documentOwnership'
 import { formatReferenceDocumentStatus } from '@/utils/referenceDocumentStatus'
 import { clientSearchColumns } from '@/utils/searchModalColumns'
+import { formatKstDateTime, formatKstSlashDate } from '@/utils/dateTime'
 
 const route = useRoute()
 const router = useRouter()
@@ -187,13 +188,7 @@ function getCurrentRequesterName() {
 }
 
 function getRequestedAt() {
-  const now = new Date()
-  const year = now.getFullYear()
-  const month = String(now.getMonth() + 1).padStart(2, '0')
-  const day = String(now.getDate()).padStart(2, '0')
-  const hours = String(now.getHours()).padStart(2, '0')
-  const minutes = String(now.getMinutes()).padStart(2, '0')
-  return `${year}/${month}/${day} ${hours}:${minutes}`
+  return formatKstDateTime()
 }
 
 function getDefaultDeleteApprover(row) {
@@ -790,11 +785,7 @@ function closeProductionIssueConfirm() {
 }
 
 function formatTodaySlashDate() {
-  const now = new Date()
-  const year = now.getFullYear()
-  const month = String(now.getMonth() + 1).padStart(2, '0')
-  const day = String(now.getDate()).padStart(2, '0')
-  return `${year}/${month}/${day}`
+  return formatKstSlashDate()
 }
 
 function createNextProductionOrderId() {

--- a/src/views/documents/POPage.vue
+++ b/src/views/documents/POPage.vue
@@ -61,6 +61,7 @@ import { canMutateDocument } from '@/utils/documentOwnership'
 import { clientSearchColumns, productSearchColumns } from '@/utils/searchModalColumns'
 import { buildSelectOptionsFromRows } from '@/utils/selectOptions'
 import { formatCurrencyAmount } from '@/utils/currencyFormat'
+import { formatKstDateTime, formatKstSlashDate } from '@/utils/dateTime'
 
 const router = useRouter()
 const authStore = useAuthStore()
@@ -323,11 +324,7 @@ function openEditForm(row) {
 }
 
 function getTodaySlashDate() {
-  const today = new Date()
-  const year = today.getFullYear()
-  const month = String(today.getMonth() + 1).padStart(2, '0')
-  const day = String(today.getDate()).padStart(2, '0')
-  return `${year}/${month}/${day}`
+  return formatKstSlashDate()
 }
 
 function parseAmount(value) {
@@ -570,13 +567,7 @@ function isPendingApproval(row) {
 }
 
 function getRequestedAt() {
-  const now = new Date()
-  const year = now.getFullYear()
-  const month = String(now.getMonth() + 1).padStart(2, '0')
-  const day = String(now.getDate()).padStart(2, '0')
-  const hours = String(now.getHours()).padStart(2, '0')
-  const minutes = String(now.getMinutes()).padStart(2, '0')
-  return `${year}/${month}/${day} ${hours}:${minutes}`
+  return formatKstDateTime()
 }
 
 function buildNextPoId() {

--- a/src/views/master/ClientListPage.vue
+++ b/src/views/master/ClientListPage.vue
@@ -25,6 +25,7 @@ import { fetchDepartments, fetchTeams } from '@/api/auth'
 import { useMasterLookup } from '@/composables/useMasterLookup'
 import { useToast } from '@/composables/useToast'
 import { label, CLIENT_STATUS_LABEL } from '@/utils/enumLabels'
+import { formatKstDateInput } from '@/utils/dateTime'
 
 const router = useRouter()
 const authStore = useAuthStore()
@@ -247,7 +248,7 @@ async function handleSave(formData) {
   try {
     if (formMode.value === 'create') {
       const teamId = isAdmin.value ? formData.teamId : Number(currentUser.value?.teamId)
-      await createClient({ ...formData, clientRegDate: new Date().toISOString().slice(0, 10), ...(teamId && { teamId }) })
+      await createClient({ ...formData, clientRegDate: formatKstDateInput(), ...(teamId && { teamId }) })
       success('거래처가 등록되었습니다.')
     } else {
       await updateClient(selectedClient.value.clientId, formData)

--- a/src/views/master/ItemListPage.vue
+++ b/src/views/master/ItemListPage.vue
@@ -19,6 +19,7 @@ import { useToast } from '@/composables/useToast'
 import { useAuthStore } from '@/stores/auth'
 import { canManageItems } from '@/utils/roleAccess'
 import { label, ITEM_STATUS_LABEL } from '@/utils/enumLabels'
+import { formatKstDateInput } from '@/utils/dateTime'
 
 const router = useRouter()
 const { success, error } = useToast()
@@ -206,7 +207,7 @@ async function handleSave(formData) {
   saving.value = true
   try {
     if (formMode.value === 'create') {
-      await createItem({ ...formData, itemRegDate: new Date().toISOString().slice(0, 10) })
+      await createItem({ ...formData, itemRegDate: formatKstDateInput() })
       success('품목이 등록되었습니다.')
     } else {
       // 백엔드는 상태 변경을 PATCH /api/items/{id}/status 로 분리해 둠.


### PR DESCRIPTION
## 변경 요약
- src/utils/dateTime.js를 추가해 날짜 입력값, slash 날짜 표시, 날짜/시각 정렬을 Asia/Seoul 기준으로 통일했습니다.
- 발행일/납기일/등록일/요청시각 생성부에서 브라우저 UTC 변환 영향을 받는 toISOString/Date.parse 의존을 제거했습니다.
- 문서 store, 대시보드, BaseTable, 활동 등록, 거래처/품목 등록일을 KST 유틸로 정리했습니다.
- 이전 점검에서 남아 있던 API timeout 20초 보정과 PI 결재 검토 수량 fallback을 함께 포함했습니다.

## 검증
- npx vite build --outDir dist-check --emptyOutDir false --logLevel error 통과
- UTC 변환 위험 패턴(toISOString, Date.parse) 검색 결과 없음
- 참고: npm run build는 이전과 동일하게 명확한 오류 메시지 없이 transform 후 exit 1을 반환해, 위 Vite 직접 빌드로 검증했습니다.

Closes #494