### PR TITLE
fix: PI PO 수정 요청 및 환율 표시 보정

### DIFF
--- a/src/components/domain/document/PIFormModal.vue
+++ b/src/components/domain/document/PIFormModal.vue
@@ -153,8 +153,12 @@ const approverDirectory = ref([])
 const productCatalog = ref([...fallbackProductCatalog])
 const incotermCatalog = ref([...fallbackIncotermsCatalog])
 const exchangeRateHint = ref(createExchangeRateHint('USD', getTodayDateInput()))
-const { loaded: exchangeRatesLoaded } = useExchangeRates()
+const {
+  loaded: exchangeRatesLoaded,
+  loadExchangeRates: ensureExchangeRatesLoaded,
+} = useExchangeRates()
 const currentCurrency = computed(() => form.value.currency || 'USD')
+let currencyDateWatchReady = props.mode !== 'edit'
 
 const currentCurrencySymbol = computed(() => currencySymbolMap[currentCurrency.value] ?? currentCurrency.value)
 
@@ -680,6 +684,8 @@ async function initializeForm() {
   if (!props.open) return
 
   validationErrors.value = {}
+  currencyDateWatchReady = props.mode !== 'edit'
+  void ensureExchangeRatesLoaded()
 
   if (props.mode === 'edit' && props.document) {
     const normalizedIncoterms = resolveIncotermState(
@@ -769,8 +775,9 @@ function removeItem(index) {
 function handleSave() {
   if (!validateForm()) return
   // 외화 PI 인데 환율 미확보면 단가가 KRW 값 그대로 남아 서버 환산 시 금액이 비정상으로 저장된다.
-  if (form.value.currency && form.value.currency !== 'KRW' && !exchangeRatesLoaded.value) {
-    validationErrors.value.currency = '환율 로딩이 완료되지 않았습니다. 잠시 후 다시 시도해주세요.'
+  const currencyCode = form.value.currency || 'USD'
+  if (currencyCode !== 'KRW' && !getKrwRate(currencyCode)) {
+    validationErrors.value.currency = `${currencyCode} 환율 정보가 준비되지 않았습니다. 잠시 후 다시 시도해주세요.`
     // 인라인 메시지만으로는 사용자가 버튼 근처를 보고 있어 인지가 어렵다 — validateForm 과 동일하게 toast 도 발생.
     error(validationErrors.value.currency, '입력 확인')
     return
@@ -833,7 +840,6 @@ watch(
 // 일으켰다. 즉 PI260021 을 편집 모달로 열기만 해도 $999.99 가 (KRW_master × 현재_rate)
 // 로 재계산돼 폼에 찍히고, 저장 시 DB 가 덮어씀. edit 모드 초기 실행은 건너뛰고 이후
 // 사용자가 통화/발행일을 명시적으로 바꿀 때만 refresh.
-let currencyDateWatchReady = props.mode !== 'edit'
 watch(
   () => [form.value.currency, form.value.issueDate],
   ([currency, issueDate]) => {

--- a/src/views/documents/PIDetailPage.vue
+++ b/src/views/documents/PIDetailPage.vue
@@ -824,7 +824,8 @@ async function confirmEditApprovalRequest() {
       const payload = buildManagerUpdatePayload(pendingEditRequest.value.formValue)
       await updateProformaInvoiceDraft(pendingEditRequest.value.id, payload)
     } else {
-      await requestPiModification({ piId: pendingEditRequest.value.id, userId })
+      const revisedRequest = buildManagerUpdatePayload(pendingEditRequest.value.formValue)
+      await requestPiModification({ piId: pendingEditRequest.value.id, userId, revisedRequest })
     }
     await loadPiDocuments()
 

--- a/src/views/documents/PIDetailPage.vue
+++ b/src/views/documents/PIDetailPage.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
 import ApprovalRequestModal from '@/components/common/ApprovalRequestModal.vue'
@@ -53,6 +53,7 @@ import { formatIncotermsLabel, resolveIncotermState } from '@/utils/incoterms'
 import { clientSearchColumns } from '@/utils/searchModalColumns'
 import { label, PI_PO_STATUS_LABEL } from '@/utils/enumLabels'
 import { formatKstDateTime } from '@/utils/dateTime'
+import { clearExchangeRates, getKrwRate, loadExchangeRates } from '@/stores/exchangeRates'
 
 const route = useRoute()
 const router = useRouter()
@@ -93,6 +94,7 @@ const approvalChangeColumns = [
 ]
 
 const clientRowsSource = ref(createDocumentClientRows())
+const currencyCatalog = ref([])
 
 const clientRows = computed(() => {
   const keyword = clientSearchKeyword.value.trim().toLowerCase()
@@ -190,6 +192,12 @@ function formatCurrencyValue(currency, value) {
 
 function formatSlashDate(value) {
   return value ? value.replaceAll('-', '/') : '-'
+}
+
+function findCurrencyIdByCode(code) {
+  if (!code) return null
+  const match = currencyCatalog.value.find((currency) => (currency.currencyCode ?? currency.code) === code)
+  return match?.currencyId ?? match?.id ?? null
 }
 
 function buildLinkedDocuments(documentId) {
@@ -557,12 +565,19 @@ async function loadClientRows() {
       currenciesData,
       buyersData,
     })
+    currencyCatalog.value = currenciesData ?? []
   } catch {
     clientRowsSource.value = createDocumentClientRows()
+    currencyCatalog.value = []
   }
 }
 
-onMounted(loadClientRows)
+onMounted(() => {
+  loadClientRows()
+  loadExchangeRates()
+})
+
+onUnmounted(clearExchangeRates)
 
 function goBack() {
   router.push({ name: 'pi' })
@@ -711,13 +726,21 @@ function handleSave(formValue) {
 function buildManagerUpdatePayload(formValue) {
   const matchedClient = clientRowsSource.value.find((c) => c.name === formValue.clientName)
   const currencyCode = formValue.currency || sourceRow.value?.currency || 'USD'
+  const currencyId = findCurrencyIdByCode(currencyCode) ?? matchedClient?.currencyId ?? null
+  const krwRate = getKrwRate(currencyCode)
+  const toKrw = (amountInCurrency) => {
+    const value = Number(amountInCurrency) || 0
+    if (!currencyCode || currencyCode === 'KRW') return value
+    if (!krwRate) return value
+    return Math.round(value * krwRate)
+  }
   const items = (formValue.items ?? []).map((item) => ({
     itemId: null,
     itemName: item.name ?? '',
     quantity: Number(item.qty ?? item.quantity ?? 0) || 0,
     unit: item.unit ?? '',
-    unitPrice: Number(item.unitPrice ?? 0) || 0,
-    amount: Number(item.amount ?? 0) || 0,
+    unitPrice: toKrw(item.unitPrice),
+    amount: toKrw(item.amount),
     remark: item.remark ?? '',
   }))
   const totalAmount = items.reduce((sum, item) => sum + (Number(item.amount) || 0), 0)
@@ -725,7 +748,7 @@ function buildManagerUpdatePayload(formValue) {
     piId: null,
     issueDate: (formValue.issueDate ?? '').replaceAll('/', '-'),
     clientId: matchedClient?.clientId ?? null,
-    currencyId: null,
+    currencyId,
     managerId: sourceRow.value?.managerId ?? authStore.currentUser?.userId ?? null,
     deliveryDate: (formValue.deliveryDate ?? '').replaceAll('/', '-') || null,
     incotermsCode: formValue.incoterms || 'FOB',
@@ -735,7 +758,7 @@ function buildManagerUpdatePayload(formValue) {
     clientAddress: formValue.clientAddress || matchedClient?.address || sourceRow.value?.clientAddress || '',
     country: matchedClient?.country || sourceRow.value?.country || '',
     currencyCode,
-    exchangeRate: null,
+    exchangeRate: currencyCode === 'KRW' || !krwRate ? null : Number((1 / krwRate).toFixed(8)),
     managerName: sourceRow.value?.manager || authStore.currentUser?.userName || '',
     userId: authStore.currentUser?.userId ?? null,
     remarks: formValue.reason ?? sourceRow.value?.remarks ?? '',

--- a/src/views/documents/PIPage.vue
+++ b/src/views/documents/PIPage.vue
@@ -23,6 +23,7 @@ import {
   requestPiModification,
   validatePiDeletable,
   requestPiDeletion,
+  updateProformaInvoiceDraft,
 } from '@/api/documents'
 import { fetchBuyers, fetchClients, fetchCountries, fetchCurrencies, fetchItems } from '@/api/master'
 import { useDocumentFilter } from '@/composables/useDocumentFilter'
@@ -857,7 +858,8 @@ async function confirmEditApprovalRequest() {
   if (!pendingEditRequest.value) return
   try {
     const userId = authStore.currentUser?.userId
-    await requestPiModification({ piId: pendingEditRequest.value.id, userId })
+    const revisedRequest = buildCreatePayload(pendingEditRequest.value.formValue)
+    await requestPiModification({ piId: pendingEditRequest.value.id, userId, revisedRequest })
     await loadPiDocuments()
 
     editApprovalRequestOpen.value = false
@@ -917,18 +919,19 @@ async function handleSave(formValue) {
     return
   }
 
-  // TODO: PI 수정 결재 API (request-modification) 가 백엔드에 추가되면
-  //       PO 와 동일하게 requestPiModification 연동으로 교체한다.
-  //       현재는 로컬-only 로 스냅샷 비교만 수행.
   const { nextRow } = buildRowPayload(formValue)
 
   if (isTeamLeader.value) {
-    rowsData.value = rowsData.value.map((r) =>
-      r.id === selectedRow.value?.id ? { ...r, ...nextRow } : r
-    )
-    formOpen.value = false
-    selectedClient.value = null
-    success('PI가 수정되었습니다.')
+    try {
+      const payload = buildCreatePayload(formValue)
+      await updateProformaInvoiceDraft(selectedRow.value?.id, payload)
+      await loadPiDocuments()
+      formOpen.value = false
+      selectedClient.value = null
+      success('PI가 수정되었습니다.')
+    } catch (e) {
+      error(e.response?.data?.message || 'PI 수정 중 오류가 발생했습니다.')
+    }
     return
   }
 
@@ -948,6 +951,10 @@ async function handleSave(formValue) {
   pendingEditRequest.value = {
     id: selectedRow.value?.id,
     approver: formValue.approver || '',
+    formValue: {
+      ...formValue,
+      items: (formValue.items ?? []).map((item) => ({ ...item })),
+    },
     nextRow,
     revisedSnapshot,
     changeRows,

--- a/src/views/documents/PODetailPage.vue
+++ b/src/views/documents/PODetailPage.vue
@@ -337,7 +337,9 @@ const collectionLockInfo = computed(() => getPoCollectionLockInfo(detail.value?.
 const collectionLockMessage = computed(() => formatPoCollectionLockMessage(collectionLockInfo.value))
 const linkedPiDocument = computed(() => piDocuments.value.find((row) => row.id === (detail.value?.piId || detail.value?.linkedPiId)))
 const linkedProductionOrder = computed(() => productionOrderDocuments.value.find((row) => row.poId === detail.value?.id) ?? null)
-const canIssueProductionOrder = computed(() => Boolean(detail.value && !linkedProductionOrder.value && !shipmentLockInfo.value.locked))
+// 생산 경유 여부와 담당자는 PO 등록/등록요청 시점에 확정한다. 상세 화면에서는
+// 수동 생산지시서 발행 진입점을 제공하지 않는다.
+const canIssueProductionOrder = computed(() => false)
 const productionIssueConfirmRows = computed(() => {
   if (!detail.value) return []
 
@@ -864,7 +866,8 @@ async function confirmEditApprovalRequest() {
       const payload = buildManagerUpdatePoPayload(pendingEditRequest.value.formValue)
       await updatePurchaseOrderDraft(pendingEditRequest.value.id, payload)
     } else {
-      await requestPoModification({ poId: pendingEditRequest.value.id, userId })
+      const revisedRequest = buildManagerUpdatePoPayload(pendingEditRequest.value.formValue)
+      await requestPoModification({ poId: pendingEditRequest.value.id, userId, revisedRequest })
     }
     await loadPoDocuments()
 

--- a/src/views/documents/POPage.vue
+++ b/src/views/documents/POPage.vue
@@ -23,6 +23,7 @@ import {
   requestPoModification,
   validatePoDeletable,
   requestPoDeletion,
+  updatePurchaseOrderDraft,
 } from '@/api/documents'
 import { fetchCurrencies, fetchItems } from '@/api/master'
 import { useDocumentFilter } from '@/composables/useDocumentFilter'
@@ -497,7 +498,10 @@ function buildCreatePayload(formValue) {
   const currencyCode = linkedPi?.currency || formValue.currency || matchedClient?.currency || 'USD'
   const currencyId = findCurrencyIdByCode(currencyCode) ?? matchedClient?.currencyId ?? null
 
-  const items = (linkedPi?.items ?? []).map((item) => {
+  const sourceItems = Array.isArray(formValue.items) && formValue.items.length
+    ? formValue.items
+    : (linkedPi?.items ?? [])
+  const items = sourceItems.map((item) => {
     const quantity = Number(item.qty ?? item.quantity ?? 0) || 0
     const unitPrice = Number(item.unitPrice ?? 0) || 0
     const amount = Number(item.amount ?? 0) || quantity * unitPrice
@@ -523,7 +527,7 @@ function buildCreatePayload(formValue) {
   return {
     poId: null,
     piId: formValue.linkedPiId || null,
-    issueDate: toIsoDate(getTodaySlashDate()),
+    issueDate: toIsoDate(formValue.issueDate || selectedRow.value?.issueDate || getTodaySlashDate()),
     clientId: matchedClient?.clientId ?? null,
     currencyId,
     managerId: authStore.currentUser?.userId ?? null,
@@ -888,7 +892,8 @@ async function confirmEditApprovalRequest() {
 
   try {
     const userId = authStore.currentUser?.userId
-    await requestPoModification({ poId: pendingEditRequest.value.id, userId })
+    const revisedRequest = buildCreatePayload(pendingEditRequest.value.formValue)
+    await requestPoModification({ poId: pendingEditRequest.value.id, userId, revisedRequest })
     await loadPoDocuments()
 
     editApprovalRequestOpen.value = false
@@ -958,10 +963,9 @@ async function handleSave(formValue) {
   }
 
   if (isTeamLeader.value) {
-    // 팀장 셀프 수정: 백엔드에 수정 결재 요청을 보내고 즉시 반영을 기대한다.
     try {
-      const userId = authStore.currentUser?.userId
-      await requestPoModification({ poId: selectedRow.value?.id, userId })
+      const payload = buildCreatePayload(formValue)
+      await updatePurchaseOrderDraft(selectedRow.value?.id, payload)
       await loadPoDocuments()
       formOpen.value = false
       selectedPi.value = null
@@ -976,6 +980,10 @@ async function handleSave(formValue) {
   pendingEditRequest.value = {
     id: selectedRow.value?.id,
     approver: formValue.approver || '',
+    formValue: {
+      ...formValue,
+      items: (formValue.items ?? []).map((item) => ({ ...item })),
+    },
     nextRow,
     revisedSnapshot,
     changeRows,


### PR DESCRIPTION
## 📋 작업 내용

- PI 수정 모달 자체에서 환율 데이터를 로드하도록 보강하고, 외화별 환율 준비 여부를 저장 전에 검증했습니다.
- PI 상세 팀장 직접 수정 payload에 currencyId/exchangeRate/KRW 환산값을 채우도록 수정했습니다.
- PI/PO 목록 및 상세의 수정 요청 API 호출에 revisedRequest payload를 포함했습니다.
- PO 목록/상세의 팀장 직접 수정은 request-modification이 아니라 PUT 수정 API를 호출하도록 바꿨습니다.
- PO 상세의 생산지시서 수동 발행 진입점을 숨겼습니다.

## 🔗 관련 이슈

- closes #498

## 📸 스크린샷 (선택)

- 생략

## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

- npm run build 통과
- 수정 승인 payload 반영은 backend-documents main 커밋 04968f8과 함께 배포되어야 정상 동작합니다.