### PR TITLE
fix(frontend): 미리보기 기반 문서 메일 PDF 첨부

### DIFF
--- a/src/api/emails.js
+++ b/src/api/emails.js
@@ -52,6 +52,7 @@ export async function fetchActivityEmails() {
  * @param {string} [payload.emailRecipientName]
  * @param {string} payload.emailRecipientEmail
  * @param {string[]} payload.docTypes     ['CI'] | ['PL'] | ['PI'] 등
+ * @param {{filename:string, contentType:string, contentBase64:string}[]} [payload.attachments]
  * @returns {Promise<{status:'SENT'|'FAILED', message:string, attachmentFilenames:string[]}>}
  */
 export async function sendDocumentEmail(payload) {

--- a/src/components/domain/document/SendDocumentEmailModal.vue
+++ b/src/components/domain/document/SendDocumentEmailModal.vue
@@ -6,6 +6,7 @@ import BaseModal from '@/components/common/BaseModal.vue'
 import BaseTextField from '@/components/common/BaseTextField.vue'
 import { useToast } from '@/composables/useToast'
 import { sendDocumentEmail } from '@/api/emails'
+import { buildDocumentPdfAttachment } from '@/utils/documentOutput'
 
 const props = defineProps({
   open: { type: Boolean, default: false },
@@ -17,6 +18,8 @@ const props = defineProps({
   poId: { type: String, default: '' },
   // 모달 상단에 노출할 문서 식별자 (예: 'CI-2026-0001')
   documentLabel: { type: String, default: '' },
+  // 메일 첨부 PDF를 현재 미리보기와 같은 HTML 빌더로 렌더링하기 위한 문서 데이터
+  document: { type: Object, default: null },
   // 기본 수신자 정보 (거래처 담당자 등)
   defaultRecipientName: { type: String, default: '' },
   defaultRecipientEmail: { type: String, default: '' },
@@ -30,6 +33,7 @@ const recipientName = ref('')
 const recipientEmail = ref('')
 const subject = ref('')
 const submitting = ref(false)
+const submitStatus = ref('')
 
 // clientId 가 0/null 이라도 수신자 이메일·제목만 있으면 발송 허용한다.
 // (과거 빌드에서 생성된 PO/CI/PL 은 ClientResponse.id 필드 명명 버그로 clientId=0 로 저장됐는데,
@@ -63,6 +67,7 @@ watch(
         : `${englishLabel} — Document enclosed`
     } else {
       submitting.value = false
+      submitStatus.value = ''
     }
   },
 )
@@ -76,7 +81,16 @@ async function handleSubmit() {
   if (!canSubmit.value) return
 
   submitting.value = true
+  submitStatus.value = '첨부 PDF 생성 중...'
   try {
+    const attachments = []
+    if (props.document) {
+      attachments.push(await buildDocumentPdfAttachment(props.docType, props.document, {
+        filename: props.documentLabel || props.document?.id || props.docType,
+      }))
+    }
+
+    submitStatus.value = '메일 발송 중...'
     const payload = {
       // clientId 가 비어있는 과거 문서도 발송 가능하도록 0 으로 fallback.
       // 백엔드 EmailSendRequest 는 @NotNull 이라 0 은 통과(로그에 clientId=0 기록).
@@ -86,6 +100,7 @@ async function handleSubmit() {
       emailRecipientName: recipientName.value.trim() || undefined,
       emailRecipientEmail: recipientEmail.value.trim(),
       docTypes: [props.docType],
+      attachments,
     }
     const response = await sendDocumentEmail(payload)
     if (response?.status === 'SENT') {
@@ -96,10 +111,11 @@ async function handleSubmit() {
       toast.error(response?.message || '메일 발송에 실패했습니다.')
     }
   } catch (error) {
-    const message = error?.response?.data?.message ?? '메일 발송에 실패했습니다.'
+    const message = error?.response?.data?.message ?? error?.message ?? '메일 발송에 실패했습니다.'
     toast.error(message)
   } finally {
     submitting.value = false
+    submitStatus.value = ''
   }
 }
 </script>
@@ -145,7 +161,8 @@ async function handleSubmit() {
       </div>
 
       <div class="rounded-lg bg-slate-50 p-3 text-xs text-slate-500">
-        <p>첨부 파일은 서버에서 자동으로 생성되어 첨부됩니다 ({{ docType }} PDF).</p>
+        <p v-if="document">첨부 파일은 현재 미리보기 양식 그대로 PDF로 렌더링되어 첨부됩니다 ({{ docType }} PDF).</p>
+        <p v-else>첨부 파일은 서버에서 자동으로 생성되어 첨부됩니다 ({{ docType }} PDF).</p>
         <p v-if="!clientId" class="mt-1 text-amber-600">
           ⚠ 거래처 ID 가 문서에 기록되어 있지 않습니다. 메일은 발송되지만 이력에 거래처 연결이 누락될 수 있습니다.
         </p>
@@ -160,7 +177,7 @@ async function handleSubmit() {
         <template #leading>
           <i class="fas fa-paper-plane text-xs" aria-hidden="true"></i>
         </template>
-        {{ submitting ? '발송 중...' : '발송' }}
+        {{ submitting ? (submitStatus || '발송 중...') : '발송' }}
       </BaseButton>
     </template>
   </BaseModal>

--- a/src/utils/documentOutput.js
+++ b/src/utils/documentOutput.js
@@ -935,6 +935,13 @@ export function openTableOutput({ title, subtitle = '', columns = [], rows = [],
  * @param {boolean} autoPrint - true면 자동으로 인쇄 대화상자 표시
  */
 export function openDocumentOutputByType(type, doc, autoPrint = false) {
+  const html = buildDocumentOutputHtmlByType(type, doc)
+  if (!html) return false
+
+  return openPrintWindow(html, autoPrint)
+}
+
+export function buildDocumentOutputHtmlByType(type, doc) {
   const builders = {
     PI: buildPIOutputHtml,
     PO: buildPOOutputHtml,
@@ -947,11 +954,27 @@ export function openDocumentOutputByType(type, doc, autoPrint = false) {
   const builder = builders[type]
   if (!builder) {
     console.warn(`[documentOutput] 알 수 없는 문서 유형: ${type}`)
-    return false
+    return ''
   }
 
-  const html = builder(doc)
-  return openPrintWindow(html, autoPrint)
+  return builder(doc)
+}
+
+export async function buildDocumentPdfAttachment(type, doc, { filename } = {}) {
+  const html = buildDocumentOutputHtmlByType(type, doc)
+  if (!html) {
+    throw new Error(`지원하지 않는 문서 유형입니다: ${type}`)
+  }
+
+  const pdfBlob = await renderHtmlToPdfBlob(html)
+  const contentBase64 = await blobToBase64(pdfBlob)
+  const resolvedFilename = normalizePdfFilename(filename || doc?.id || type || 'document')
+
+  return {
+    filename: resolvedFilename,
+    contentType: 'application/pdf',
+    contentBase64,
+  }
 }
 
 /**
@@ -986,4 +1009,133 @@ function openPrintWindow(html, autoPrint) {
   setTimeout(revokePreviewUrl, 5000)
 
   return true
+}
+
+async function renderHtmlToPdfBlob(html) {
+  const iframe = await createHiddenDocumentFrame(markCanvasSafeImages(html))
+
+  try {
+    const frameDocument = iframe.contentDocument
+    const source = frameDocument?.body
+    if (!source) {
+      throw new Error('PDF 렌더링 대상 문서를 열 수 없습니다.')
+    }
+
+    await waitForFrameAssets(frameDocument)
+
+    const pageWidth = 595.28
+    const sourceWidth = Math.max(794, source.scrollWidth || source.offsetWidth || 794)
+    const { jsPDF } = await import('jspdf')
+    const pdf = new jsPDF({
+      orientation: 'portrait',
+      unit: 'pt',
+      format: 'a4',
+      compress: true,
+    })
+
+    return await new Promise((resolve, reject) => {
+      const htmlRenderResult = pdf.html(source, {
+        callback: (doc) => {
+          try {
+            resolve(doc.output('blob'))
+          } catch (error) {
+            reject(error)
+          }
+        },
+        margin: [0, 0, 0, 0],
+        width: pageWidth,
+        windowWidth: sourceWidth,
+        autoPaging: 'text',
+        html2canvas: {
+          backgroundColor: '#ffffff',
+          scale: 0.72,
+          useCORS: true,
+          allowTaint: false,
+        },
+      })
+      if (htmlRenderResult && typeof htmlRenderResult.catch === 'function') {
+        htmlRenderResult.catch(reject)
+      }
+    })
+  } finally {
+    iframe.remove()
+  }
+}
+
+function createHiddenDocumentFrame(html) {
+  return new Promise((resolve, reject) => {
+    const iframe = document.createElement('iframe')
+    iframe.setAttribute('aria-hidden', 'true')
+    iframe.style.position = 'fixed'
+    iframe.style.left = '-10000px'
+    iframe.style.top = '0'
+    iframe.style.width = '794px'
+    iframe.style.height = '1123px'
+    iframe.style.border = '0'
+    iframe.style.visibility = 'hidden'
+
+    const timeoutId = window.setTimeout(() => {
+      iframe.remove()
+      reject(new Error('PDF 렌더링 시간이 초과되었습니다.'))
+    }, 12000)
+
+    iframe.addEventListener(
+      'load',
+      () => {
+        window.clearTimeout(timeoutId)
+        resolve(iframe)
+      },
+      { once: true },
+    )
+
+    document.body.appendChild(iframe)
+    iframe.srcdoc = html
+  })
+}
+
+async function waitForFrameAssets(frameDocument) {
+  try {
+    await frameDocument.fonts?.ready
+  } catch (error) {
+    // Font loading failure should not block email sending.
+  }
+
+  const images = Array.from(frameDocument.images || [])
+  await Promise.all(images.map((image) => {
+    if (image.complete) return Promise.resolve()
+    return new Promise((resolve) => {
+      const finish = () => resolve()
+      image.addEventListener('load', finish, { once: true })
+      image.addEventListener('error', finish, { once: true })
+      window.setTimeout(finish, 3000)
+    })
+  }))
+
+  await new Promise((resolve) => window.requestAnimationFrame(() => {
+    window.requestAnimationFrame(resolve)
+  }))
+}
+
+function markCanvasSafeImages(html) {
+  return html.replaceAll('<img ', '<img crossorigin="anonymous" ')
+}
+
+function blobToBase64(blob) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.addEventListener('load', () => {
+      const result = String(reader.result || '')
+      const [, base64 = ''] = result.split(',')
+      resolve(base64)
+    })
+    reader.addEventListener('error', () => reject(reader.error))
+    reader.readAsDataURL(blob)
+  })
+}
+
+function normalizePdfFilename(filename) {
+  const base = String(filename || 'document')
+    .replace(/[\\/:*?"<>|]/g, '_')
+    .trim() || 'document'
+  return base.toLowerCase().endsWith('.pdf') ? base : `${base}.pdf`
 }

--- a/src/views/documents/CIDetailPage.vue
+++ b/src/views/documents/CIDetailPage.vue
@@ -305,6 +305,7 @@ function goToLinkedDocument(document) {
       :client-id="detail.clientId"
       :po-id="linkedPo?.id ?? detail.poId ?? ''"
       :document-label="detail.id"
+      :document="detail"
       :default-recipient-name="detail.buyer || detail.clientName"
       :default-recipient-email="detail.clientEmail || ''"
       @close="sendEmailOpen = false"

--- a/src/views/documents/PLDetailPage.vue
+++ b/src/views/documents/PLDetailPage.vue
@@ -306,6 +306,7 @@ function goToLinkedDocument(document) {
       :client-id="detail.clientId"
       :po-id="linkedPo?.id ?? detail.poId ?? ''"
       :document-label="detail.id"
+      :document="detail"
       :default-recipient-name="detail.buyer || detail.clientName"
       :default-recipient-email="detail.clientEmail || ''"
       @close="sendEmailOpen = false"


### PR DESCRIPTION
## 📋 작업 내용

- CI/PL 메일 발송 시 서버 PDF 생성 대신 현재 문서 미리보기 HTML을 브라우저에서 PDF로 렌더링해 첨부합니다.
- PDF 렌더링 진행 상태를 모달 버튼에 표시합니다.
- jspdf/html2canvas는 PDF 생성 시점에 동적 import 하도록 구성해 초기 번들 증가를 줄였습니다.
- 백엔드 #8dd82d0의 client-rendered attachments 지원과 함께 동작합니다.

## 🔗 관련 이슈

- closes #500

## 📸 스크린샷 (선택)

N/A

## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 불필요한 코드/주석 제거
- [x] 충돌(conflict) 해결 완료

## 💬 리뷰어에게

- 메일 발송 시 PDF 생성이 먼저 수행되므로 첫 발송 때 jspdf/html2canvas chunk가 로드됩니다.
- 서버 PDF fallback은 백엔드에 남아 있어 document prop이 없는 경로나 재전송 흐름은 기존 방식으로 동작합니다.
