### PR TITLE
fix: 사용자 등록 권한 파생 및 오류 처리 보정

### DIFF
--- a/src/components/domain/auth/UserFormModal.vue
+++ b/src/components/domain/auth/UserFormModal.vue
@@ -9,6 +9,7 @@ import FileUploadField from '@/components/common/FileUploadField.vue'
 import FormField from '@/components/common/FormField.vue'
 import { useToast } from '@/composables/useToast'
 import { resetPassword } from '@/api/auth'
+import { inferRoleFromOrg } from '@/utils/userRole'
 import { isValidEmail } from '@/utils/validators'
 
 const props = defineProps({
@@ -29,18 +30,13 @@ const form = ref(getInitialForm())
 const errors = ref({})
 const showResetConfirm = ref(false)
 
-// 부서 → role 자동 매핑 (부서명 기준)
-const DEPT_ROLE_MAP = {
-  '영업부': 'sales',
-  '생산부': 'production',
-  '출하부': 'shipping',
-  '경영지원부': 'admin',
-}
-
 function derivedRole(deptId) {
-  const dept = props.departments.find((d) => String(d.departmentId ?? d.id) === String(deptId))
-  const name = dept?.departmentName ?? dept?.name ?? ''
-  return DEPT_ROLE_MAP[name] ?? 'sales'
+  return inferRoleFromOrg({
+    departmentId: deptId,
+    teamId: form.value.teamId,
+    departments: props.departments,
+    teams: props.teams,
+  })
 }
 
 const statusOptions = [
@@ -89,6 +85,9 @@ watch(
         transferReason: '',
         sealImage: null,
       }
+      if (!form.value.role) {
+        form.value.role = derivedRole(form.value.departmentId)
+      }
     } else if (isOpen && props.mode === 'create') {
       form.value = getInitialForm()
     }
@@ -97,12 +96,21 @@ watch(
 
 // 부서 변경 시 팀 초기화 + role 자동 파생
 watch(() => form.value.departmentId, (deptId) => {
-  const team = props.teams.find((t) => String(t.teamId) === String(form.value.teamId))
+  const team = props.teams.find((t) => String(t.teamId ?? t.id) === String(form.value.teamId))
   if (team && String(team.departmentId) !== String(deptId)) {
     form.value.teamId = ''
   }
   form.value.role = derivedRole(deptId)
 })
+
+watch(
+  () => [form.value.teamId, props.departments.length, props.teams.length],
+  () => {
+    if (props.mode === 'create' || !form.value.role) {
+      form.value.role = derivedRole(form.value.departmentId)
+    }
+  },
+)
 
 const teamOptions = computed(() => {
   const filtered = form.value.departmentId
@@ -121,9 +129,10 @@ function validate() {
   } else if (!isValidEmail(form.value.email)) {
     e.email = '올바른 이메일 형식을 입력해주세요.'
   } else {
+    const email = form.value.email.trim().toLowerCase()
     const duplicate = props.allUsers.find(
       (u) =>
-        (u.userEmail ?? u.email) === form.value.email.trim() &&
+        String(u.userEmail ?? u.email ?? '').trim().toLowerCase() === email &&
         (props.mode === 'create' || (u.userId ?? u.id) !== (props.user?.userId ?? props.user?.id)),
     )
     if (duplicate) e.email = '이미 사용 중인 이메일 주소입니다.'
@@ -132,6 +141,9 @@ function validate() {
   if (!form.value.positionId) e.positionId = '직급을 선택해주세요.'
   if (!form.value.departmentId) e.departmentId = '부서를 선택해주세요.'
   if (!form.value.teamId) e.teamId = '팀을 선택해주세요.'
+  if (form.value.departmentId && form.value.teamId && !derivedRole(form.value.departmentId)) {
+    e.departmentId = '부서 권한 매핑을 확인해주세요.'
+  }
 
   errors.value = e
   return Object.keys(e).length === 0

--- a/src/components/domain/auth/UserListTab.vue
+++ b/src/components/domain/auth/UserListTab.vue
@@ -19,6 +19,7 @@ import {
   updateUser,
 } from '@/api/auth'
 import { label, USER_STATUS_LABEL } from '@/utils/enumLabels'
+import { resolveUserRole, toBackendRole } from '@/utils/userRole'
 
 const { success, error } = useToast()
 
@@ -196,15 +197,30 @@ function openDeleteModal(user) {
   showDeleteModal.value = true
 }
 
+function getErrorMessage(e, fallback) {
+  return e?.response?.data?.message ?? e?.message ?? fallback
+}
+
 async function handleSave(formData) {
   saving.value = true
   try {
     if (formMode.value === 'create') {
+      const role = resolveUserRole({
+        role: formData.role,
+        departmentId: formData.departmentId,
+        teamId: formData.teamId,
+        departments: departments.value,
+        teams: teams.value,
+      })
+      if (!role) {
+        throw new Error('부서 권한 매핑을 확인해주세요.')
+      }
+
       const newUser = {
-        name: formData.name,
-        email: formData.email,
+        name: formData.name.trim(),
+        email: formData.email.trim(),
         password: 'password123',
-        role: String(formData.role).toUpperCase(),
+        role: toBackendRole(role),
         teamId: formData.teamId ? Number(formData.teamId) : undefined,
         positionId: formData.positionId ? Number(formData.positionId) : undefined,
       }
@@ -224,7 +240,7 @@ async function handleSave(formData) {
     await loadData()
     showFormModal.value = false
   } catch (e) {
-    error('저장 중 오류가 발생했습니다.')
+    error(getErrorMessage(e, '저장 중 오류가 발생했습니다.'))
   } finally {
     saving.value = false
   }

--- a/src/utils/userRole.js
+++ b/src/utils/userRole.js
@@ -1,0 +1,42 @@
+const VALID_ROLES = new Set(['admin', 'sales', 'production', 'shipping'])
+
+function normalizeOrgName(value) {
+  return String(value ?? '').trim().toLowerCase().replace(/\s+/g, '')
+}
+
+function sameId(a, b) {
+  return String(a ?? '') === String(b ?? '')
+}
+
+export function normalizeUserRole(role) {
+  const value = String(role ?? '').trim().toLowerCase()
+  return VALID_ROLES.has(value) ? value : ''
+}
+
+export function deriveRoleFromDepartmentName(name) {
+  const value = normalizeOrgName(name)
+  if (!value) return ''
+
+  if (value.includes('영업') || value.includes('sales')) return 'sales'
+  if (value.includes('생산') || value.includes('production')) return 'production'
+  if (value.includes('출하') || value.includes('shipping')) return 'shipping'
+  if (value.includes('경영지원') || value.includes('관리') || value.includes('admin')) return 'admin'
+
+  return ''
+}
+
+export function inferRoleFromOrg({ departmentId, teamId, departments = [], teams = [] } = {}) {
+  const team = teams.find((t) => sameId(t.teamId ?? t.id, teamId))
+  const resolvedDepartmentId = departmentId || team?.departmentId
+  const department = departments.find((d) => sameId(d.departmentId ?? d.id, resolvedDepartmentId))
+  const departmentName = department?.departmentName ?? department?.name ?? team?.departmentName ?? ''
+  return deriveRoleFromDepartmentName(departmentName)
+}
+
+export function resolveUserRole({ role, departmentId, teamId, departments = [], teams = [] } = {}) {
+  return normalizeUserRole(role) || inferRoleFromOrg({ departmentId, teamId, departments, teams })
+}
+
+export function toBackendRole(role) {
+  return normalizeUserRole(role).toUpperCase()
+}


### PR DESCRIPTION
## 📋 작업 내용\n\n- 사용자 등록 시 부서/팀 기준으로 role을 안전하게 파생하도록 공통 유틸을 추가했습니다.\n- 운영 DB의 관리부/경영지원부 명칭 차이를 모두 admin 권한으로 매핑했습니다.\n- 생성 payload의 이름/이메일을 trim하고, role이 비면 저장 전에 명확한 오류를 보여주도록 했습니다.\n- 저장 실패 토스트에 백엔드 응답 메시지가 표시되도록 보정했습니다.\n\n## 🔗 관련 이슈\n\n- closes #504\n\n## 📸 스크린샷 (선택)\n\n- UI 구조 변경 없음\n\n## ✅ 체크리스트\n\n- [x] 정상 동작 확인\n- [x] 불필요한 코드/주석 제거\n- [x] 충돌(conflict) 해결 완료\n\n## 💬 리뷰어에게\n\n- 
px -p node@20 npm run build 통과 확인했습니다.\n- 백엔드는 	eam2-backend-auth main에 별도 커밋으로 사용자 생성 검증과 오류 응답 코드를 함께 보정했습니다.